### PR TITLE
Improve binding sorting (not 100%)

### DIFF
--- a/addons/bindings.md
+++ b/addons/bindings.md
@@ -6,9 +6,11 @@ layout: documentation
 
 # List of Available Bindings
 
-{% assign bindings = site.data.bindings | sort: 'label.toLowerCase()' %}
+{% assign bindings = "" | split: "|" %}
+{% for binding in site.data.bindings %}{% assign bindings = bindings | push: binding %}{% endfor %}
+{% assign sorted_bindings = bindings | sort: "id" %}
 
 | Binding | Description |
 |-------|----------------------|
-{% for binding in bindings %}| [{{ binding.label }}]({{docu}}/addons/bindings/{{ binding.id }}/readme.html) | {{ binding.description }} |
+{% for binding in sorted_bindings %}| [{{ binding.label }}]({{docu}}/addons/bindings/{{ binding.id }}/readme.html) | {{ binding.description }} |
 {% endfor %}					


### PR DESCRIPTION
Workaround inability to [sort arrays from CSV files](https://github.com/jekyll/jekyll-help/issues/157) by pushing a new array and sorting that.  Also, sort by id because sorting by `field.toLowerCase()` does not work.  It's still not a perfect sort, but it's close.