### PR TITLE
Fix digitalSTROM Readme typo

### DIFF
--- a/addons/bindings/digitalstrom/readme.md
+++ b/addons/bindings/digitalstrom/readme.md
@@ -12,6 +12,7 @@ The integration happens through the digitalSTROM-Server, which acts as a gateway
 **Note:** All was tested with digitalSTROM-Server firmware version 1.9.3 to 1.10.3.
 
 ![various_digitalSTROM_clamps](doc/DS-Clamps.jpg)
+
 ## Supported Things
 
 ### digitalSTROM-Server


### PR DESCRIPTION
This PR just fixes a small formatting problem. Check http://docs.openhab.org/features/bindings/digitalstrom/readme.html to see that the headline "Supported Things" is not shown as such.

However I found a bigger problem that might need improvement in the transformation system!? The digitalSTROM image (`DS-Clamps.jpg`) is too wide for my (small) notebook screen. Something like this should fix that:
```css
img {
    max-width: 100%;
}
```
