### PR TITLE
Fix scrollbar bug, Add responsive images

### DIFF
--- a/concepts/index.md
+++ b/concepts/index.md
@@ -22,7 +22,7 @@ Channels can be linked to multiple Items and Items can be linked to multiple Cha
 
 To illustrate these concepts, take a two-channel actuator that controls two lights:
 
-![](images/thing-devices-1.png){: .responsive-img}
+![](images/thing-devices-1.png)
 
 The actuator is the _Thing_. This might be installed in the electrical cabinet, it has a physical address and needs to be setup and configured in order to be used.
 The user is instead interested in the two lights, which are located at different locations in his home. These lights are the desired functionality, thus the _Items_ and they are linked to the _Channels_ of the actuator.

--- a/concepts/index.md
+++ b/concepts/index.md
@@ -22,13 +22,8 @@ Channels can be linked to multiple Items and Items can be linked to multiple Cha
 
 To illustrate these concepts, take a two-channel actuator that controls two lights:
 
-![](images/thing-devices-1.png)
+![](images/thing-devices-1.png){: .responsive-img}
 
 The actuator is the _Thing_. This might be installed in the electrical cabinet, it has a physical address and needs to be setup and configured in order to be used.
 The user is instead interested in the two lights, which are located at different locations in his home. These lights are the desired functionality, thus the _Items_ and they are linked to the _Channels_ of the actuator.
 A _Link_ can be regarded like a physical wire in this example.
-
-
-
-
-

--- a/css/styles.css
+++ b/css/styles.css
@@ -717,6 +717,10 @@ body.documentation .content-wrapper {
     }
 }
 
+body.documentation section#documentation .content img {
+	max-width: 100%;
+	height: auto;
+}
 body.documentation section#documentation .content > h1:first-child {
 	margin-top: 0px;
 }

--- a/css/styles.css
+++ b/css/styles.css
@@ -497,10 +497,6 @@ section#developers .section-header {
 
 /* Text Pages */
 
-section.text {
-    overflow-x: scroll;
-}
-
 section.text h1 {
 	font-size: 2.0rem;
 	line-height: 3.0rem;


### PR DESCRIPTION
Fixes https://community.openhab.org/t/documenting-openhab-2/10568/84
Fixes https://github.com/openhab/openhab-docs/issues/49

Sorry for piggybacking :o)

The "bug" behind Link 1 is actually a feature added by the original author of style.css to be able to look at big pictures.
I included the changes suggested by Link 2 to fix that in the right way.
However not as a class, I like this solution better after all.

Outlook: At some point in the future, if one image needs to be half size or with a pink frame, this would be possible by adding a class:

```
![title](image.png){: .half-pink-img}
```