### PR TITLE
Add Vagrant machine

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 _site
 .sass-cache
 .jekyll-metadata
+.vagrant
 project.pbxproj
 *.xcworkspacedata
 *.xcscmblueprint

--- a/README.md
+++ b/README.md
@@ -17,6 +17,8 @@ Our documentation is built with Jekyll and served through Github Pages.
 In order to run Jekyll locally, you also need Ruby being installed.
 Please see the [Jekyll installation instructions](https://jekyllrb.com/docs/installation/) for details.
 
+An alternative for a local setup is a virtual machine provided by Vagrant.
+
 ## Serving the Documentation locally
 
 Once you have Jekyll installed and the repository checked out, simply run
@@ -28,6 +30,19 @@ jekyll serve
 from within the repository root folder and point your browser to [`http://localhost:4000`](http://localhost:4000).
 This will give you a preview of the documentation in the same way as it will appear on docs.openhab.org once your PR is merged.
 Changes to the markdown files will automatically be taken into account as Jekyll re-generates the pages on the fly.
+
+### Alternative: Vagrant VM
+
+You can also have a virtual machine serving a Jekyll and webserver instance for you, without changing your base system or being limited by it.
+The virtual machine will run in the background, process your changes to the source and presenting the results on your hosts [`http://localhost:4000`](http://localhost:4000).
+A [Vagrant](https://www.vagrantup.com) machine configured by a [`Vagrantfile`](Vagrantfile) file is provided for that purpose.
+
+You need to have [VirtualBox](https://www.virtualbox.org) and [Vagrant](https://www.vagrantup.com/downloads.html) installed.
+After that, it's as easy as:
+
+```shell
+/path-to/openhab-docs$ vagrant up
+```
 
 ## Automatically Generated Parts
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,0 +1,19 @@
+
+$script = <<SCRIPT
+sudo apt-get update
+sudo apt-get install -y build-essential git nodejs python-software-properties
+sudo apt-add-repository -y ppa:brightbox/ruby-ng
+sudo apt-get update
+sudo apt-get install -y ruby2.2 ruby2.2-dev
+sudo gem install github-pages -V --no-ri --no-rdoc
+SCRIPT
+
+Vagrant.configure("2") do |config|
+
+  config.vm.box = "JekyllVM"
+  config.vm.box_url = "http://files.vagrantup.com/precise32.box"
+  config.vm.network "forwarded_port", guest: 4000, host: 4000
+  config.vm.synced_folder ".", "/srv/website", create: true
+  config.vm.provision "shell", inline: $script
+  config.vm.provision "shell", inline: "cd /srv/website && jekyll serve --watch --incremental --host 0.0.0.0", run: "always"
+end


### PR DESCRIPTION
Build this before testing of https://github.com/openhab/openhab-docs/pull/56. Vagrant is quite helpful while tinkering. Having the extra `Vagrantfile` in the folder will not harm anybody but help whoever might be interested.