### PR TITLE
Add headline to page title

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -6,7 +6,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1">
  {% include base.html %}
 <!--<link rel="shortcut icon" href="https://www.openhab.org/favicon.png"></link>-->
-<title>openHAB - Empowering the Smart Home</title>
+<title>{% if page.title != nil %}{{ page.title }} - {% endif %}openHAB - Empowering the Smart Home</title>
  
 <!-- CSS -->
 <link href="{{base}}/css/materialize.css" type="text/css" rel="stylesheet"

--- a/features/sitemap.md
+++ b/features/sitemap.md
@@ -1,5 +1,6 @@
 ---
 layout: documentation
+title: Sitemaps
 ---
 
 {% include base.html %}


### PR DESCRIPTION
If available, add `title` to pagetitle.
Example provided.

In your browser, this "openHAB - Empowering the Smart Home"
becomes this: "Sitemap - openHAB - Empowering the Smart Home"