### PR TITLE
Changed openhab.list to openhab2.list

### DIFF
--- a/installation/docker.md
+++ b/installation/docker.md
@@ -6,6 +6,26 @@ layout: documentation
 
 # Installation through Docker
 
+## Image Variants
+There are Docker images for three architectures and there is an online and offline version for each architecture.
+- amd64 : online, offline
+- armhf : online, offline
+- arm64 : online, offline
+
+To obtain the official Docker image from [Docker Hub](https://hub.docker.com/r/openhab/openhab/) use:
+
+```
+docker pull openhab/openhab:<architecture>-<[on|off]line>
+```
+
+For example, to pull the amd64 offline image use:
+
+```
+docker pull openhab/openhab:amd64-offline
+```
+
+If you are unsure about what architecture and version to choose use `openhab/openhab:amd64-online`.
+
 ## Usage
 
 **Important** To be able to use UPnP for discovery the container needs to be started with ``--net=host``.

--- a/installation/docker.md
+++ b/installation/docker.md
@@ -6,26 +6,6 @@ layout: documentation
 
 # Installation through Docker
 
-## Image Variants
-There are Docker images for three architectures and there is an online and offline version for each architecture.
-- amd64 : online, offline
-- armhf : online, offline
-- arm64 : online, offline
-
-To obtain the official Docker image from [Docker Hub](https://hub.docker.com/r/openhab/openhab/) use:
-
-```
-docker pull openhab/openhab:<architecture>-<[on|off]line>
-```
-
-For example, to pull the amd64 offline image use:
-
-```
-docker pull openhab/openhab:amd64-offline
-```
-
-If you are unsure about what architecture and version to choose use `openhab/openhab:amd64-online`.
-
 ## Usage
 
 **Important** To be able to use UPnP for discovery the container needs to be started with ``--net=host``.

--- a/installation/linux.md
+++ b/installation/linux.md
@@ -48,17 +48,17 @@ Alternatively resort to the [manual installation approach](linux.html#manual-ins
 Choose between the latest Beta release or a Snapshot with all incoming contributions, rebuild on [every change](https://oss.jfrog.org/webapp/#/builds/openHAB-Distribution).
 As openHAB 2 is still in an evolving state, the snapshot may be the **preferred choice**.
 
-The repository URLs will be stored in the file `/etc/apt/sources.list.d/openhab.list`.
+The repository URLs will be stored in the file `/etc/apt/sources.list.d/openhab2.list`.
 Be careful to not have conflicting repositories in your sources list.
 
 Decide between two options:
 
 * **Beta Release**
 
-  Add the **openHAB 2 Beta repository** to your systems apt sources list (will overwrite your existing `openhab.list`):
+  Add the **openHAB 2 Beta repository** to your systems apt sources list (will overwrite your existing `openhab2.list`):
 
   ```shell
-  echo 'deb http://dl.bintray.com/openhab/apt-repo2 testing main' | sudo tee /etc/apt/sources.list.d/openhab.list
+  echo 'deb http://dl.bintray.com/openhab/apt-repo2 testing main' | sudo tee /etc/apt/sources.list.d/openhab2.list
   ```
 
   Additionally, you need to add the openHAB 2 Bintray repositories key to your package manager by using either `wget` or `curl`:
@@ -71,11 +71,11 @@ Decide between two options:
 
 * **Snapshot Release**
 
-  Add the **openHAB 2 Snapshot repositories** to your systems apt sources list (will overwrite your existing `openhab.list`):
+  Add the **openHAB 2 Snapshot repositories** to your systems apt sources list (will overwrite your existing `openhab2.list`):
 
   ```shell
-  echo 'deb https://openhab.ci.cloudbees.com/job/openHAB-Distribution/ws/distributions/openhab-offline/target/apt-repo/ /' | sudo tee /etc/apt/sources.list.d/openhab.list
-  echo 'deb https://openhab.ci.cloudbees.com/job/openHAB-Distribution/ws/distributions/openhab-online/target/apt-repo/ /' | sudo tee --append /etc/apt/sources.list.d/openhab.list
+  echo 'deb https://openhab.ci.cloudbees.com/job/openHAB-Distribution/ws/distributions/openhab-offline/target/apt-repo/ /' | sudo tee /etc/apt/sources.list.d/openhab2.list
+  echo 'deb https://openhab.ci.cloudbees.com/job/openHAB-Distribution/ws/distributions/openhab-online/target/apt-repo/ /' | sudo tee --append /etc/apt/sources.list.d/openhab2.list
   ```
 
   Note: CloudBees provides the openHAB 2 repositories through HTTPS.
@@ -195,7 +195,7 @@ sudo apt-get purge openhab2-offline
 # respectively
 sudo apt-get purge openhab2-online
 
-sudo rm /etc/apt/sources.list.d/openhab.list
+sudo rm /etc/apt/sources.list.d/openhab2.list
 ```
 
 ### Manual Installation


### PR DESCRIPTION
As part of my efforts to run through a migration from OH 1 to OH 2 I hit a snag with the snapshot apt repos. While debugging this problem I noticed that the instructions have the user overwire openhab.list. But if they had already installed OH 1 through apt-get this file already exists, along with some others (openhab.list.DistUpgrade, openhab.list.save). 

To avoid intermingling the OH 1 and OH 2 repos in this way I propose moving to use openhab2.list.

If this is undesirable I can make a note in the migration docs instead.