### PR TITLE
Disable proxy_buffering in nginx example

### DIFF
--- a/configuration/jetty.md
+++ b/configuration/jetty.md
@@ -25,10 +25,11 @@ server {
 
 	location / {
 		proxy_pass                            http://localhost:8080/;
+		proxy_buffering                       off;
 		proxy_set_header Host                 $http_host;
 		proxy_set_header X-Real-IP            $remote_addr;
 		proxy_set_header X-Forwarded-For      $proxy_add_x_forwarded_for;
-		proxy_set_header X-Forwarded-Scheme   $scheme;		
+		proxy_set_header X-Forwarded-Scheme   $scheme;
 	}
 }
 ```
@@ -54,10 +55,11 @@ server {
 
 	location / {
 		proxy_pass                            http://localhost:8080/;
+		proxy_buffering                       off;
 		proxy_set_header Host                 $http_host;
 		proxy_set_header X-Real-IP            $remote_addr;
 		proxy_set_header X-Forwarded-For      $proxy_add_x_forwarded_for;
-		proxy_set_header X-Forwarded-Scheme   $scheme;		
+		proxy_set_header X-Forwarded-Scheme   $scheme;
 	}
 }
 ```


### PR DESCRIPTION
Using the default, proxy buffering causes very slow synchronisation issues with states because it waits for eventsource types (such as http://openhab.domain.tld/rest/events?topics=smarthome/items/*/state) to complete.