### PR TITLE
Adding example about.html files to the guidelines

### DIFF
--- a/developers/development/guidelines.md
+++ b/developers/development/guidelines.md
@@ -28,7 +28,7 @@ Note that this list also serves as a checklist for code reviews on pull requests
 ## B. OSGi Bundles
 
 7. Every bundle must contain a Maven pom.xml with a version and artifact name that is in sync with the manifest entry. The pom.xml must reference the correct parent pom (which is usually in the parent folder).
-1. Every bundle must contain an [about.html](https://eclipse.org/legal/epl/about.php) file, providing license information.
+1. Every bundle must contain an [about.html](https://eclipse.org/legal/epl/about.php) file, providing license information. If there is a third-party software in the bundle, its licence information must be added to the bundle's about.html file. You can look at and use these two examples: [about.html without 3rd party licence information](https://github.com/openhab/openhab2-addons/blob/master/addons/ui/org.openhab.ui.cometvisu.php/about.html) and [about.html with 3rd party licence information](https://github.com/openhab/openhab2-addons/blob/master/addons/binding/org.openhab.binding.avmfritz/about.html). The date in the about.html files must be changed to the current.
 1. Every bundle must contain a build.properties file, which lists all resources that should end up in the binary under `bin.includes`.
 1. The manifest must not contain any "Require-Bundle" entries. Instead, "Import-Package" must be used.
 1. The manifest must not export any internal package.


### PR DESCRIPTION
In the Code Guidelines section, when mentioning the about.html file there could be two examples:
 - about.html file without 3rd party licence information
 - about.html file with 3rd party licence information

It will be easy for the contributers - they will spend less time figuring how the file should look and make fewer mistakes.

There could be a check when a bundle is commited, not only if it contains an about.html file, but also if the about.html file contains one of the dates in the example about.html files. This will help if a contributer has forgotten to change the date in the file.

The example files could be choosen from: https://github.com/openhab/openhab2-addons/pull/1263/files

Signed-off-by: Kiril Atanasov <kiril.atanasov@musala.com>