### PR TITLE
Replace and fix invalid links

### DIFF
--- a/_includes/base.html
+++ b/_includes/base.html
@@ -1,5 +1,4 @@
 {% assign base = '' %}
-{% assign base = '' %}
 {% comment %} <!--Disabled since the base in docs.openhab.org can only be '/'-->
 {% assign depth = page.url | split: '/' | size | minus: 1 %}
 {% if    depth == 0 %}{% assign base = '.' %}

--- a/_includes/base.html
+++ b/_includes/base.html
@@ -1,4 +1,6 @@
 {% assign base = '' %}
+{% assign base = '' %}
+{% comment %} <!--Disabled since the base in docs.openhab.org can only be '/'-->
 {% assign depth = page.url | split: '/' | size | minus: 1 %}
 {% if    depth == 0 %}{% assign base = '.' %}
 {% elsif depth == 1 %}{% assign base = '..' %}
@@ -6,3 +8,4 @@
 {% elsif depth == 3 %}{% assign base = '../../..' %}
 {% elsif depth == 4 %}{% assign base = '../../../..' %}
 {% elsif depth == 5 %}{% assign base = '../../../../..' %}{% endif %}
+{% endcomment %}

--- a/_includes/nav-main-bar.html
+++ b/_includes/nav-main-bar.html
@@ -1,7 +1,7 @@
 {% include base.html %}
 <div class="row center targets">
 	<div class="col s12 m4 l4">
-		<a href="/tutorials/">
+		<a href="{{base}}/tutorials/">
 			<div class="target target-beginner card">
 				<i class="mdi-action-explore icon-large"></i>
 				<div class="footer">
@@ -13,7 +13,7 @@
 		</a>
 	</div>
 	<div class="col s12 m4 l4">
-		<a href="/overview.html">
+		<a href="{{base}}/overview.html">
 			<div class="target target-advanced card">
 			<i class="mdi-file-folder-shared icon-large"></i>
 			<div class="footer">
@@ -24,7 +24,7 @@
 		</a>
 	</div>
 	<div class="col s12 m4 l4">
-		<a href="/developers/">
+		<a href="{{base}}/developers/">
 			<div class="target target-migration card">
 			<i class="mdi-device-developer-mode icon-large"></i>
 			<div class="footer">

--- a/configuration/nginx.md
+++ b/configuration/nginx.md
@@ -134,7 +134,7 @@ To generate a trusted certificate, you need to own a domain. To acquire your own
 |:-|:-:|:-|
 |Purchasing a domain name|[GoDaddy](http://www.godaddy.com), [Namecheap](http://www.namecheap.com), [Enom](http://www.enom.com), [Register](http://www.register.com)|You should have an IP adress that doesn't change (i.e. fixed), or changes rarely, and then update the DNS *A record* so that your domain/subdomain to point towards your IP.|
 |Obtaining a free domain|[FreeNom](http://www.freenom.com)|Setup is the same as above.|
-|Using a "Dynamic DNS" sevice|[No-IP](http://www.noip.com), [Dyn](http://www.www.dyn.com/dns)|Uses a client to automatically update your IP to a domain of you choice, some Dynamic DNS services offer a free domain too.|
+|Using a "Dynamic DNS" sevice|[No-IP](http://www.noip.com), [Dyn](http://www.dyn.com/dns)|Uses a client to automatically update your IP to a domain of you choice, some Dynamic DNS services offer a free domain too.|
 
 
 ## Enabling HTTPS

--- a/developers/prerequisites/osgi.md
+++ b/developers/prerequisites/osgi.md
@@ -36,7 +36,7 @@ The OSGi framework consist of several layers build on top of each other (See Fig
   - **Security Layer** - optional layer, based on the Java 2 security architecture, that manages permissions for different modules.
 
 ![OSGi Layers][fig1]  
-Fig.1 OSGi Layering (Source:<https://www.osgi.org/wp-content/uploads/layeringosgi.png>)
+Fig.1 OSGi Layering (Source:<https://www.osgi.org/wp-content/uploads/layering-osgi.png>)
 
 More details about the OSGi architecture can be found at <https://www.osgi.org/developer/architecture/>
 

--- a/features/automation/ruledsl.md
+++ b/features/automation/ruledsl.md
@@ -12,21 +12,10 @@ title: Rules
 openHAB has a highly integrated, lightweight but yet powerful rule engine included.
 On this page you will learn how to leverage its functionality to do *real* home automation.
 
-* [Defining Rules](#defining-rules)
-  * [File Location](#file-location)
-  * [IDE Support](#ide-support)
-  * [The Syntax](#the-syntax)
-  * Triggers
-    * [Rule Triggers](#rule-triggers)
-    * [Event-based Triggers](#event-based-triggers)
-    * [Time-based Triggers](#time-based-triggers)
-    * [System-based Triggers](#system-based-triggers)
-  * [Scripts](#scripts)
-    * [Implicit Variables inside the Execution Block](#implicit-variables-inside-the-execution-block)
-    * [Concurrency Guard](#concurrency-guard)
-    * [Logging](#logging)
-  * [Example](#example)
-  * [Differences to openHAB 1](#diff)
+{::options toc_levels="2..4"/}
+
+* TOC
+{:toc}
 
 ## Defining Rules
 
@@ -38,7 +27,7 @@ A rule file can contain multiple rules. All rules of a file share a common execu
 
 ### IDE Support
 
-The [Eclipse SmartHome Designer](../installation/designer.html) offers support for rules, which includes syntax checks and coloring, validation with error markers, content assist (Ctrl+Space) incl. templates etc. This makes the creation of rules very easy!
+The [Eclipse SmartHome Designer]({{base}}/installation/designer.html) offers support for rules, which includes syntax checks and coloring, validation with error markers, content assist (Ctrl+Space) incl. templates etc. This makes the creation of rules very easy!
 
 > Bug: Please note that there are a couple of [open bugs](https://github.com/eclipse/smarthome/issues?q=is%3Aopen+is%3Aissue+label%3ADesigner+label%3Abug), which result in error markers in the Designer, while the rules are executed nicely by the runtime.
 

--- a/features/sitemap.md
+++ b/features/sitemap.md
@@ -7,14 +7,14 @@ title: Sitemaps
 
 # Sitemaps
 
-In openHAB a collection of [Things](http://docs.openhab.org/concepts/things.html) and [Items](http://docs.openhab.org/concepts/items.html) represent physical or logical objects of the users home automation setup.
+In openHAB a collection of [Things]({{base}}/concepts/things.html) and [Items]({{base}}/concepts/items.html) represent physical or logical objects of the users home automation setup.
 Sitemaps are used to select and prepare these elements in order to compose a user-oriented presentation of this setup for various frontends,
-including [BasicUI](http://docs.openhab.org/addons/uis/basic/readme.html),
+including [BasicUI]({{base}}/addons/uis/basic/readme.html),
 the [Android openHAB app](https://play.google.com/store/apps/details?id=org.openhab.habdroid) and others.
 
 The definition of sitemaps happens declarative in a file with a clear syntax, described below.
 A sitemap definition file is stored in the folder `<openhab_config>/sitemaps` and has to have the `.sitemap` filename extension.
-For easy editing, the [openHAB Designer](http://docs.openhab.org/installation/designer.html) brings full IDE support for these files.
+For easy editing, the [openHAB Designer]({{base}}/installation/designer.html) brings full IDE support for these files.
 
 The openHAB runtime comes with a demo configuration package containing a [`demo.sitemap`](https://github.com/openhab/openhab-distro/blob/master/features/openhab-demo-resources/src/main/resources/sitemaps/demo.sitemap), which should let you easily understand possible elements and structures.
 It is recommended to use the `demo.sitemap` or another example sitemap as a starting point towards a customized sitemap fitting your personal home setup.
@@ -136,10 +136,10 @@ This provides the flexibility to present items in the way desired in your home a
 **General remarks on parameters:**
 
 * In the following definitions, parameters in `[square brackets]` are optional, parameters in front are considered more relevant.
-* Common parameters, also known from [items definition](http://docs.openhab.org/configuration/items.html):
-  * `item` defines the name of the item you want to present (e.g. `Temperature`), [more details](http://docs.openhab.org/configuration/items.html).
-  * `label` sets the textual description besides the preprocessed item data (e.g. "`Now [%s °C]`"), [more details](http://docs.openhab.org/configuration/items.html).
-  * `icon` is the name of the icon file to show next to the element, [more details](http://docs.openhab.org/configuration/items.html).
+* Common parameters, also known from [items definition](items.html):
+  * `item` defines the name of the item you want to present (e.g. `Temperature`), [more details](items.html).
+  * `label` sets the textual description besides the preprocessed item data (e.g. "`Now [%s °C]`"), [more details](items.html).
+  * `icon` is the name of the icon file to show next to the element, [more details](items.html).
 * Additional parameters like `mappings` or `valuecolor` are described below.
 
 <!-- TODO: turn links to article subheaders -->
@@ -166,7 +166,7 @@ Text [item=<itemname>] [label="<labelname>"] [icon="<iconname>"]
 
 Presents data as normal text.
 Most item types can be used, the values can be prepared and reformatted by using string formatters and transformations.
-Please check with the documentation on the [item label](http://docs.openhab.org/configuration/items.html) for details.
+Please check with the documentation on the [item label](items.html) for details.
 
 <!--TODO: Link to items-labels -->
 
@@ -180,7 +180,7 @@ Group [item=<itemname>] [label="<labelname>"] [icon="<iconname>"]
 
 The element will be clickable, revealing a new view showing all group items.
 In addition, item groups may be configured to hold a value, just like with normal items.
-Please refer to the documentation on [items](http://docs.openhab.org/configuration/items.html) for details.
+Please refer to the documentation on [items](items.html) for details.
 
 <!--TODO: Link to items-groups -->
 
@@ -499,7 +499,7 @@ The given color names are agreed on between all openHAB UIs and are therefor you
 ### Icons
 
 openHAB allows a set of icons to be assigned to the different states of an item and therefor to be presented in a sitemap.
-Please refer to the documentation on [item configuration](http://docs.openhab.org/configuration/items.html) for details.
+Please refer to the documentation on [item configuration](items.html) for details.
 
 ![battery-0](iconsets/classic/icons/battery-0.png "battery-0")
 ![battery-30](iconsets/classic/icons/battery-30.png "battery-30")

--- a/installation/index.md
+++ b/installation/index.md
@@ -83,8 +83,8 @@ After you got openHAB 2 set up and running, there are a few additional setup ste
 ## Getting started
 
 With the openHAB 2 distribution up and running, you should now continue with
-the [Demo Tutorial](http://docs.openhab.org/tutorials/demo.html),
-the [Beginner Tutorial](http://docs.openhab.org/tutorials/beginner)
+the [Demo Tutorial]({{base}}/tutorials/demo.html),
+the [Beginner Tutorial]({{base}}/tutorials/beginner)
 or by working on your own configuration.
 
 ## Help

--- a/installation/linux.md
+++ b/installation/linux.md
@@ -43,7 +43,7 @@ The manual installation through a platform independent archive file is suited fo
 ### Package Repository Installation
 
 Installation through a package repository is the recommended choice on Debian/Ubuntu derivatives.
-Alternatively resort to the [manual installation approach](linux.html#manual-installation).
+Alternatively resort to the [manual installation approach](#manual-installation).
 
 Choose between the latest Beta release or a Snapshot with all incoming contributions, rebuild on [every change](https://oss.jfrog.org/webapp/#/builds/openHAB-Distribution).
 As openHAB 2 is still in an evolving state, the snapshot may be the **preferred choice**.
@@ -366,10 +366,10 @@ sudo rm /lib/systemd/system/openhab2.service
 
 ## Network Sharing
 
-openHAB depends on configuration files and folders with custom content (details in [Configuration](http://docs.openhab.org/configuration/index.html) articles).
+openHAB depends on configuration files and folders with custom content (details in [Configuration]({{base}}/features/index.html) articles).
 Because your openHAB installation most probably is stored on a remote device, being able to easily access and modify these files from your local PC or Mac is important, therefore setting up a Samba network share is **highly recommended**.
 
-The [Eclipse SmartHome Designer](http://docs.openhab.org/installation/designer.html) software does also depend on a mounted share to access the openHAB configuration files.
+The [Eclipse SmartHome Designer]({{base}}/installation/designer.html) software does also depend on a mounted share to access the openHAB configuration files.
 
 We will now guide you through the Samba network shares setup process.
 Start by installing Samba. Afterwards open it's configuration file in your favorite editor:
@@ -471,7 +471,7 @@ Be sure to use the actual host name instead of `openhab-device`.
 When asked, authenticate with the username "openhab" and the chosen password.
 If you are not able to connect, try with the IP of your device (e.g. `smb://openhab@192.168.0.2` or `\\192.168.0.2`).
 
-If everything went well, you are set and ready to start [configuring](http://docs.openhab.org/configuration/index.html) your openHAB system.
+If everything went well, you are set and ready to start [configuring]({{base}}/features/index.html) your openHAB system.
 
 ## Viewing Log Messages
 
@@ -491,7 +491,7 @@ In order to get more insight on what your openHAB system is doing and to see occ
 
 You could even set up an SSH configuration (in Putty or similar) to automatically connect and execute the commands every time you start working on your setup.
 
-With openHAB 2 you can also [use the Karaf console](http://docs.openhab.org/administration/logging.html#karaf-console) to have a colored glance at the logging information.
+With openHAB 2 you can also [use the Karaf console]({{base}}/administration/logging.html#karaf-console) to have a colored glance at the logging information.
 
 Note: When starting openHAB 2 for the first time, you may see the following error in `openhab.log`, which is okay to occur once at first boot:
 ```text

--- a/tutorials/beginner/logs.md
+++ b/tutorials/beginner/logs.md
@@ -17,11 +17,11 @@ To find them:
 * navigate inside the userdata folder,
 * navigate inside the logs folder
 
-![](images/log-folders.png)
+<!-- ![](images/log-folders.png) -->
 
 * Inside the logs folder, double-click on the `openhab.log` file. The file will be displayed inside the console application.
 
-![](images/log-screen.png)
+<!-- ![](images/log-screen.png) -->
 
 
 > The console will display the messages as soon as they will be logged. Keep this window somewhere in order to take a look inside when it is needed.

--- a/tutorials/demo.md
+++ b/tutorials/demo.md
@@ -10,7 +10,7 @@ The 'Demo' is a quick and easy way to see the user interface for a virtual home 
 
 ## Prerequisites
 
-Make sure that you have a [JDK 8](/installation/index.html#prerequisites) installed.
+Make sure that you have a [JDK 8]({{base}}/installation/index.html#prerequisites) installed.
 
 ## Installation
 


### PR DESCRIPTION
Fixes #117 (and the change here is discussed in the comments) and addresses all of the current broken links to openHAB pages at the time of the PR.

Signed-off-by: Ben Clark <ben@benjyc.uk>