### PR TITLE
Correct to set the IP address of the Hue Bridge in Things?

### DIFF
--- a/addons/bindings/hue/readme.md
+++ b/addons/bindings/hue/readme.md
@@ -92,7 +92,7 @@ In this example **Bulb1** is a standard Philips HUE bulb (LCT001) which supports
 ### demo.things:
 
 ```
-Bridge hue:bridge:1 [ ipAddress="192.168.0.64" ] {
+Bridge hue:bridge:1 [ ipAddress="192.168.0.64" ] {  // ???
 	0210 bulb1 [ lightId="1" ]
 	0220 bulb2 [ lightId="2" ]
 }


### PR DESCRIPTION
Is it correct to place the IP address here? If I do so, Paper UI shows me two Bridges even though I uesed the correct IP address of the bridge in my environment. The one I added in the Things shows up as "Hue Bridge UNINITIALIZED" and the original discovered in the Paper UI is still called "Philips hue (192.168.178.18) ONLINE".