### PR TITLE
Update Amazon dash button Addon  readme.md

### DIFF
--- a/addons/bindings/amazondashbutton/readme.md
+++ b/addons/bindings/amazondashbutton/readme.md
@@ -86,6 +86,7 @@ Background discovery is supported. Just press the button in order to put it into
 ## Example Use
 
 The binding uses a trigger channel which doesn't have to be linked to an item. You can easily use it in your rules like this:
+
 ```
 rule "Dash button pressed"
     when

--- a/addons/bindings/amazondashbutton/readme.md
+++ b/addons/bindings/amazondashbutton/readme.md
@@ -82,3 +82,15 @@ Background discovery is supported. Just press the button in order to put it into
 ## Channels
 
 * Press: Channel for recognizing presses on the Amazon Dash Button
+
+## Example Use
+
+The binding uses a trigger channel which doesn't have to be linked to an item. You can easily use it in your rules like this:
+```
+rule "Dash button pressed"
+    when
+        Channel "amazondashbutton:dashbutton:ac-63-be-xx-xx-xx:press" triggered
+    then
+        println("The Dash button has been pressed")
+end
+```


### PR DESCRIPTION
Updated amazon dash button addon readme with example, to highlight how to trigger rules using Channel events, as opposed to the more common Item events