### PR TITLE
Removed disabling buffering in NGINX examples

### DIFF
--- a/configuration/nginx.md
+++ b/configuration/nginx.md
@@ -44,7 +44,6 @@ server {
 
 	location / {
 		proxy_pass                            http://localhost:8080/;
-		proxy_buffering                       off;
 		proxy_set_header Host                 $http_host;
 		proxy_set_header X-Real-IP            $remote_addr;
 		proxy_set_header X-Forwarded-For      $proxy_add_x_forwarded_for;
@@ -260,7 +259,6 @@ server {
 
 	location / {
 		proxy_pass                              http://localhost:8080/;
-		proxy_buffering                         off;
 		proxy_set_header Host                   $http_host;
 		proxy_set_header X-Real-IP              $remote_addr;
 		proxy_set_header X-Forwarded-For        $proxy_add_x_forwarded_for;


### PR DESCRIPTION
SSEs are now supported through a proxy using buffering. IMHO we should recommend the defaults (proxy_buffering=on), especially for slower machines.

Resolves #115 

Signed-off-by: Ben Clark <ben@benjyc.uk>