### PR TITLE
Use adduser rather than useradd for adding groups to user

### DIFF
--- a/installation/linux.md
+++ b/installation/linux.md
@@ -398,8 +398,8 @@ The following example shows how to add Linux user `openhab` to the often needed 
 Additional groups may be needed, depending on your hardware and software setup.
 
 ```shell
-sudo useradd openhab dialout
-sudo useradd openhab tty
+sudo adduser openhab dialout
+sudo adduser openhab tty
 ```
 
 Additionally it's needed to allow the java environment to access the serial port of the connected peripheral.


### PR DESCRIPTION
`useradd` will only work if user is new, and apt-get install process creates the user already, so changed to use usermod instead.

`adduser` would be viable for most systems and is simpler, but usermod is probably more widely available, so a bit of a toss up between the two. Happy to change it if it's preferred to use `adduser user group` instead.

Signed-off-by: Toby Shepheard <shepheardt@yahoo.com> (github: toby200)