### PR TITLE
Fix tabs and indention in _includes and _layouts

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,20 @@
+; This file is for unifying the coding style for different editors and IDEs.
+; More information at http://EditorConfig.org
+
+root = true
+
+[*]
+indent_style = space
+indent_size = 2
+end_of_line = crlf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+max_line_length = 160
+
+[*.html]
+indent_style = space
+indent_size = 2
+
+[*.md]
+max_line_length = null

--- a/_includes/dev-menu.html
+++ b/_includes/dev-menu.html
@@ -1,30 +1,34 @@
 {% include base.html %} {% assign docu = base %}
 
 <ul class="nav">
-	<li><a href="{{docu}}/developers">Overview</a></li>
-	<li><a href="{{docu}}/developers/contributing/contributing">Contributing</a></li>
-	<li><a href="{{docu}}/developers/prerequisites/osgi.html">Prerequisites</a>
-		<ul>
-			<li><a href="{{docu}}/developers/prerequisites/osgi.html">OSGi</a>
-				<ul>
-					<li><a href="{{docu}}/developers/prerequisites/osgi.html">Overview</a></li>
-					<li><a href="{{docu}}/developers/prerequisites/osgids.html">Declarative Services</a></li>
-					<li><a href="{{docu}}/developers/prerequisites/osgitasks.html">Coding tasks</a></li>
-			</ul></li>     
-			<li><a href="{{docu}}/developers/prerequisites/tycho.html">Tycho</a></li>
-			<li><a href="{{docu}}/developers/prerequisites/equinox.html">Equinox</a></li>
-			<li><a href="{{docu}}/developers/prerequisites/targetplatform.html">Target Platform</a></li>
-		</ul></li>
-	<li><a href="{{docu}}/developers/development/ide.html">Basics</a>
-		<ul>
-			<li><a href="{{docu}}/developers/development/ide.html">IDE Setup</a></li>
-			<li><a href="{{docu}}/developers/development/guidelines.html">Code Guidelines</a></li>
-			<li><a href="{{docu}}/developers/development/bindings.html">Developing Bindings</a></li>
-			<li><a href="{{docu}}/developers/development/logging.html">Logging</a></li>
-		</ul></li>
-	<li><a href="{{docu}}/developers/development/evolution.html">Migration from 1.x</a>
-		<ul>
-			<li><a href="{{docu}}/developers/development/evolution.html">Technical Differences</a></li>
-			<li><a href="{{docu}}/developers/development/compatibilitylayer.html">Compatibility Layer</a></li>
-		</ul></li>
+  <li><a href="{{docu}}/developers">Overview</a></li>
+  <li><a href="{{docu}}/developers/contributing/contributing">Contributing</a></li>
+  <li><a href="{{docu}}/developers/prerequisites/osgi.html">Prerequisites</a>
+    <ul>
+      <li><a href="{{docu}}/developers/prerequisites/osgi.html">OSGi</a>
+        <ul>
+          <li><a href="{{docu}}/developers/prerequisites/osgi.html">Overview</a></li>
+          <li><a href="{{docu}}/developers/prerequisites/osgids.html">Declarative Services</a></li>
+          <li><a href="{{docu}}/developers/prerequisites/osgitasks.html">Coding tasks</a></li>
+        </ul>
+      </li>
+      <li><a href="{{docu}}/developers/prerequisites/tycho.html">Tycho</a></li>
+      <li><a href="{{docu}}/developers/prerequisites/equinox.html">Equinox</a></li>
+      <li><a href="{{docu}}/developers/prerequisites/targetplatform.html">Target Platform</a></li>
+    </ul>
+  </li>
+  <li><a href="{{docu}}/developers/development/ide.html">Basics</a>
+    <ul>
+      <li><a href="{{docu}}/developers/development/ide.html">IDE Setup</a></li>
+      <li><a href="{{docu}}/developers/development/guidelines.html">Code Guidelines</a></li>
+      <li><a href="{{docu}}/developers/development/bindings.html">Developing Bindings</a></li>
+      <li><a href="{{docu}}/developers/development/logging.html">Logging</a></li>
+    </ul>
+  </li>
+  <li><a href="{{docu}}/developers/development/evolution.html">Migration from 1.x</a>
+    <ul>
+      <li><a href="{{docu}}/developers/development/evolution.html">Technical Differences</a></li>
+      <li><a href="{{docu}}/developers/development/compatibilitylayer.html">Compatibility Layer</a></li>
+    </ul>
+  </li>
 </ul>

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -1,47 +1,48 @@
-    {% include base.html %}
-	     
-<!--    <footer class="page-footer">
-		<div class="footer-copyright">
-			<div class="container center">
-				Copyright 2016 by the openHAB community
-			</div>
-		</div>
-	</footer>
--->    
-	<script src="{{base}}/js/jquery.min.js"></script>
-	<script src="{{base}}/js/jquery.scrollme.min.js"></script>
-    <script src="{{base}}/js/jquery.sticky.js"></script>
-	<script src="{{base}}/js/materialize.js"></script>
-    <script src="{{base}}/js/highlight.pack.js"></script>
-	<script src="{{base}}/js/init.js"></script>
-	<script>
-        window.twttr = (function(d, s, id) {
-            var js, fjs = d.getElementsByTagName(s)[0], t = window.twttr || {};
-            if (d.getElementById(id))
-                return t;
-            js = d.createElement(s);
-            js.id = id;
-            js.src = "https://platform.twitter.com/widgets.js";
-            fjs.parentNode.insertBefore(js, fjs);
+{% include base.html %}
 
-            t._e = [];
-            t.ready = function(f) {
-                t._e.push(f);
-            };
+<!--
+<footer class="page-footer">
+  <div class="footer-copyright">
+    <div class="container center">
+      Copyright 2016 by the openHAB community
+    </div>
+  </div>
+</footer>
+-->
 
-            return t;
-        }(document, "script", "twitter-wjs"));
-    </script>
+<script src="{{base}}/js/jquery.min.js"></script>
+<script src="{{base}}/js/jquery.scrollme.min.js"></script>
+<script src="{{base}}/js/jquery.sticky.js"></script>
+<script src="{{base}}/js/materialize.js"></script>
+<script src="{{base}}/js/highlight.pack.js"></script>
+<script src="{{base}}/js/init.js"></script>
+<script>
+  window.twttr = (function(d, s, id) {
+    var js, fjs = d.getElementsByTagName(s)[0], t = window.twttr || {};
+    if (d.getElementById(id))
+    return t;
+    js = d.createElement(s);
+    js.id = id;
+    js.src = "https://platform.twitter.com/widgets.js";
+    fjs.parentNode.insertBefore(js, fjs);
+
+    t._e = [];
+    t.ready = function(f) {
+      t._e.push(f);
+    };
+
+    return t;
+  }(document, "script", "twitter-wjs"));
+</script>
 
 <script>
   (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-  (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-  m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
   })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
 
   ga('create', 'UA-47717934-3', 'auto');
   ga('send', 'pageview');
-
-</script>
+  </script>
 </body>
 </html>

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -1,48 +1,46 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-<meta charset="utf-8">
-<meta http-equiv="X-UA-Compatible" content="IE=edge">
-<meta name="viewport" content="width=device-width, initial-scale=1">
- {% include base.html %}
-<!--<link rel="shortcut icon" href="https://www.openhab.org/favicon.png"></link>-->
-<title>{% if page.title != nil %}{{ page.title }} - {% endif %}openHAB - Empowering the Smart Home</title>
- 
-<!-- CSS -->
-<link href="{{base}}/css/materialize.css" type="text/css" rel="stylesheet"
-	media="screen,projection" />
-<link href="{{base}}/css/highlight.github.css" type="text/css" rel="stylesheet"
-    	media="screen,projection" />
-<link href="{{base}}/css/styles.css" rel="stylesheet" />
+  <meta charset="utf-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  {% include base.html %}
+  <!--<link rel="shortcut icon" href="https://www.openhab.org/favicon.png"></link>-->
+  <title>{% if page.title != nil %}{{ page.title }} - {% endif %}openHAB - Empowering the Smart Home</title>
 
-<!-- Font -->
-<link href='https://fonts.googleapis.com/css?family=Lato:300,400,700'
-	rel='stylesheet' type='text/css' />
-    
+  <!-- CSS -->
+  <link href="{{base}}/css/materialize.css" type="text/css" rel="stylesheet"
+  media="screen,projection" />
+  <link href="{{base}}/css/highlight.github.css" type="text/css" rel="stylesheet"
+  media="screen,projection" />
+  <link href="{{base}}/css/styles.css" rel="stylesheet" />
+
+  <!-- Font -->
+  <link href='https://fonts.googleapis.com/css?family=Lato:300,400,700'
+  rel='stylesheet' type='text/css' />
 </head>
-<body class="{{ include.bodyClass }}">
-	<div id="header" class="navbar-fixed">
-		<nav role="navigation">
-			<div class="container">
-				<div class="nav-wrapper">
-					<a href="{{base}}/index.html"><img id="logo" src="/images/logo.png" /></a>
-					<a href="#" data-activates="nav-mobile" class="button-collapse"><i
-						class="mdi-navigation-menu"></i></a>
-					<ul class="right hide-on-med-and-down">
 
-                    <li><a href="{{base}}/tutorials">Tutorials</a></li>
-                    <li><a href="{{base}}/overview.html">User Manual</a></li>
-                    <li><a href="{{docu}}/developers">Developer Guide</a></li>
-					<li><a href="https://github.com/openhab/openhab-distro">GitHub</a></li>
-					</ul>
-					<ul id="nav-mobile" class="side-nav">
-                        <li><a href="{{base}}/index.html">Home</a></li>
-	                    <li><a href="{{base}}/tutorials">Tutorials</a></li>
-                        <li><a href="{{base}}/overview.html">User Manual</a></li>
-                        <li><a href="{{docu}}/developers">Developer Guide</a></li>
-						<li><a href="https://github.com/openhab/openhab-distro">GitHub</a></li>
-					</ul>
-				</div>
-			</div>
-		</nav>
-	</div>
+<body class="{{ include.bodyClass }}">
+  <div id="header" class="navbar-fixed">
+    <nav role="navigation">
+      <div class="container">
+        <div class="nav-wrapper">
+          <a href="{{base}}/index.html"><img id="logo" src="/images/logo.png" /></a>
+          <a href="#" data-activates="nav-mobile" class="button-collapse"><i class="mdi-navigation-menu"></i></a>
+            <ul class="right hide-on-med-and-down">
+              <li><a href="{{base}}/tutorials">Tutorials</a></li>
+              <li><a href="{{base}}/overview.html">User Manual</a></li>
+              <li><a href="{{docu}}/developers">Developer Guide</a></li>
+              <li><a href="https://github.com/openhab/openhab-distro">GitHub</a></li>
+            </ul>
+            <ul id="nav-mobile" class="side-nav">
+              <li><a href="{{base}}/index.html">Home</a></li>
+              <li><a href="{{base}}/tutorials">Tutorials</a></li>
+              <li><a href="{{base}}/overview.html">User Manual</a></li>
+              <li><a href="{{docu}}/developers">Developer Guide</a></li>
+              <li><a href="https://github.com/openhab/openhab-distro">GitHub</a></li>
+            </ul>
+          </div>
+        </div>
+      </nav>
+    </div>

--- a/_includes/nav-main-bar.html
+++ b/_includes/nav-main-bar.html
@@ -1,37 +1,39 @@
 {% include base.html %}
 <div class="row center targets">
-	<div class="col s12 m4 l4">
-		<a href="{{base}}/tutorials/">
-			<div class="target target-beginner card">
-				<i class="mdi-action-explore icon-large"></i>
-				<div class="footer">
-					<div class="valign-wrapper">
-						<h2 class="valign">Tutorials</h2>
-					</div>
-				</div>
-			</div>
-		</a>
-	</div>
-	<div class="col s12 m4 l4">
-		<a href="{{base}}/overview.html">
-			<div class="target target-advanced card">
-			<i class="mdi-file-folder-shared icon-large"></i>
-			<div class="footer">
-				<div class="valign-wrapper">
-					<h2 class="valign">User Manual</h2></div>
-				</div>
-			</div>
-		</a>
-	</div>
-	<div class="col s12 m4 l4">
-		<a href="{{base}}/developers/">
-			<div class="target target-migration card">
-			<i class="mdi-device-developer-mode icon-large"></i>
-			<div class="footer">
-				<div class="valign-wrapper">
-					<h2 class="valign">Developer Guide</h2></div>
-				</div>
-			</div>
-		</a>
-	</div>
+  <div class="col s12 m4 l4">
+    <a href="{{base}}/tutorials/">
+      <div class="target target-beginner card">
+        <i class="mdi-action-explore icon-large"></i>
+        <div class="footer">
+          <div class="valign-wrapper">
+            <h2 class="valign">Tutorials</h2>
+          </div>
+        </div>
+      </div>
+    </a>
+  </div>
+  <div class="col s12 m4 l4">
+    <a href="{{base}}/overview.html">
+      <div class="target target-advanced card">
+        <i class="mdi-file-folder-shared icon-large"></i>
+        <div class="footer">
+          <div class="valign-wrapper">
+            <h2 class="valign">User Manual</h2>
+          </div>
+        </div>
+      </div>
+    </a>
+  </div>
+  <div class="col s12 m4 l4">
+    <a href="{{base}}/developers/">
+      <div class="target target-migration card">
+        <i class="mdi-device-developer-mode icon-large"></i>
+        <div class="footer">
+          <div class="valign-wrapper">
+            <h2 class="valign">Developer Guide</h2>
+          </div>
+        </div>
+      </div>
+    </a>
+  </div>
 </div>

--- a/_includes/tutorial-advanced-menu.html
+++ b/_includes/tutorial-advanced-menu.html
@@ -1,14 +1,13 @@
 {% include base.html %} {% assign docu = base | append: "/tutorials/advanced" %}
 
 <ul class="nav">
-    <li>Tutorial (Advanced)</li>
-        <ul>
-            <li><a href="{{docu}}/index.html">Overview</a></li>
-            <li><a href="{{docu}}/installing.html">Installing the extension</a></li>
-            <li><a href="{{docu}}/connecting.html">Connecting to the Z-Wave controller</a></li>
-            <li><a href="{{docu}}/adding.html">Adding a new thing</a></li>
-            <li><a href="{{docu}}/configuring.html">Configuring a thing</a></li>
-            <li><a href="{{docu}}/tools.html">Other tools of HABmin</a></li>
-        </ul>
-    </li>
+  <li>Tutorial (Advanced)</li>
+  <ul>
+    <li><a href="{{docu}}/index.html">Overview</a></li>
+    <li><a href="{{docu}}/installing.html">Installing the extension</a></li>
+    <li><a href="{{docu}}/connecting.html">Connecting to the Z-Wave controller</a></li>
+    <li><a href="{{docu}}/adding.html">Adding a new thing</a></li>
+    <li><a href="{{docu}}/configuring.html">Configuring a thing</a></li>
+    <li><a href="{{docu}}/tools.html">Other tools of HABmin</a></li>
+  </ul>
 </ul>

--- a/_includes/tutorial-beginner-menu.html
+++ b/_includes/tutorial-beginner-menu.html
@@ -1,14 +1,13 @@
 {% include base.html %} {% assign docu = base | append: "/tutorials/beginner" %}
 
 <ul class="nav">
-    <li>Tutorial (Beginner)</li>
-        <ul>
-            <li><a href="{{docu}}/index.html">Overview</a></li>
-            <li><a href="{{docu}}/uis.html">User Interfaces</a></li>
-            <li><a href="{{docu}}/installing.html">Installing an extension</a></li>
-            <li><a href="{{docu}}/persistence.html">Working with persistence</a></li>
-            <li><a href="{{docu}}/rulesscripts.html">Working with rules and script</a></li>
-            <li><a href="{{docu}}/logs.html">Looking to the logs</a></li>
-        </ul>
-    </li>
+  <li>Tutorial (Beginner)</li>
+  <ul>
+    <li><a href="{{docu}}/index.html">Overview</a></li>
+    <li><a href="{{docu}}/uis.html">User Interfaces</a></li>
+    <li><a href="{{docu}}/installing.html">Installing an extension</a></li>
+    <li><a href="{{docu}}/persistence.html">Working with persistence</a></li>
+    <li><a href="{{docu}}/rulesscripts.html">Working with rules and script</a></li>
+    <li><a href="{{docu}}/logs.html">Looking to the logs</a></li>
+  </ul>
 </ul>

--- a/_includes/user-menu.html
+++ b/_includes/user-menu.html
@@ -1,101 +1,102 @@
 {% include base.html %} {% assign docu = base %}
 
 <ul class="nav">
-	<li><a href="{{docu}}/overview.html">Overview</a></li>
-	<li><a href="{{docu}}/concepts/index.html">Concepts</a>
-		<ul>
-			<li><a href="{{docu}}/concepts/index.html">Overview</a>
-				<li><a href="{{docu}}/concepts/items.html">Items</a></li>
-				<li><a href="{{docu}}/concepts/things.html">Things</a></li>
-				<li><a href="{{docu}}/concepts/discovery.html">Inbox &amp; Discovery</a></li>
-				<li><a href="{{docu}}/concepts/audio.html">Audio &amp; Voice</a></li>
-			</ul>
-		</li>
-		<li><a href="{{docu}}/installation/index.html">Installation</a>
-			<ul>
-				<li><a href="{{docu}}/installation/index.html">Overview</a></li>
-				<li><a href="{{docu}}/installation/linux.html">Linux</a></li>
-				<li><a href="{{docu}}/installation/macosx.html">Mac OS X</a></li>
-				<li><a href="{{docu}}/installation/windows.html">Windows</a></li>
-				<li><a href="{{docu}}/installation/docker.html">Docker</a></li>
-				<li><a href="{{docu}}/installation/rasppi.html">Raspberry Pi</a></li>
-				<li><a href="{{docu}}/installation/pine.html">PINE64</a></li>
-				<li><a href="{{docu}}/installation/synology.html">Synology</a></li>
-				<li><a href="{{docu}}/installation/designer.html">openHAB Designer</a></li>
-			</ul>
-		</li>
-		<li><a href="{{docu}}/configuration/nginx.html">Configuration</a>
-			<ul>
-				<li><a href="{{docu}}/configuration/nginx.html">Reverse Proxy</a></li>
-			</ul>
-		</li>
-		<li><a href="{{docu}}/administration/index.html">Administration</a>
-			<ul>
-				<li><a href="{{docu}}/administration/index.html">Overview</a></li>
-				<li><a href="{{docu}}/administration/console.html">Console</a></li>
-				<li><a href="{{docu}}/administration/logging.html">Logging</a></li>
-				<li><a href="{{docu}}/administration/bundles.html">Bundle Management</a></li>
-				<li><a href="{{docu}}/administration/runtime.html">Runtime Commands</a></li>
-			</ul>
-		</li>
-		<li><a href="{{docu}}/features/index.html">Features</a>
-			<ul>
-				<li><a href="{{docu}}/features/index.html">Overview</a></li>
-				<li><a href="{{docu}}/features/items.html">Items</a></li>
-				<li><a href="{{docu}}/features/sitemap.html">Sitemaps</a></li>
-				<li><a href="{{docu}}/features/persistence.html">Persistence</a></li>
-				<li><a href="{{docu}}/features/multimedia.html">Multimedia</a></li>
-				<li><a href="{{docu}}/features/automation/ruledsl.html">Automation</a>
-					<ul>
-						<li><a href="{{docu}}/features/automation/ruledsl.html">Textual Rules</a></li>
-						<li><a href="{{docu}}/features/automation/ngrules.html">Next-Gen Rules</a></li>
-					</ul>
-				</li>
-			</ul>
-		</li>
-		<li><a href="{{docu}}/addons/index.html">Add-ons</a></li>
-		<ul>
-			<li><a href="{{docu}}/addons/index.html">Overview</a></li>
-			<li><a href="{{docu}}/addons/bindings.html">Bindings</a>
-				<ul>
-					{% for binding in site.data.bindings %}
-					<li><a href="{{docu}}/addons/bindings/{{ binding.id }}/readme.html">{{ binding.label }}</a></li>
-					{% endfor %}
-				</ul>
-			</li>
-			<li><a href="{{docu}}/addons/voice.html">Voice Services</a>
-				<ul>
-					{% for voice in site.data.voice %}
-					<li><a href="{{docu}}/addons/voice/{{ voice.id }}/readme.html">{{ voice.label }}</a></li>
-					{% endfor %}
-				</ul>
-			</li>
-			<li><a href="{{docu}}/addons/io.html">System Integrations</a>
-				<ul>
-					<li><a href="{{docu}}/addons/io/homekit/readme.html">HomeKit</a></li>
-					<li><a href="{{docu}}/addons/io/hueemulation/readme.html">Amazon Echo</a></li>
-					<li><a href="{{docu}}/addons/io/imperihome/readme.html">ImperiHome</a></li>
-				</ul>
-			</li>
-			<li><a href="{{docu}}/addons/uis.html">User Interfaces</a>
-				<ul>
-					<li><a href="{{docu}}/addons/uis.html">Overview</a></li>
-					<li><a href="{{docu}}/addons/uis/basic/readme.html">Basic UI</a></li>
-					<li><a href="{{docu}}/addons/uis/classic/readme.html">Classic UI</a></li>
-					<li><a href="{{docu}}/addons/uis/paper/readme.html">Paper UI</a></li>
-					<li><a href="{{docu}}/addons/uis/habmin/readme.html">HABmin</a></li>
-					<li><a href="{{docu}}/addons/uis/habpanel/readme.html">HABPanel</a></li>
-					<li><a href="{{docu}}/addons/iconsets/classic/readme.html">Classic Iconset</a></li>
-				</ul>
-			</li>
-			<li><a href="{{docu}}/addons/1xaddons.html">1.x Add-ons</a></li>
-		</ul>
-	</li>
-	<li><a href="{{docu}}/appendix/contributing.html">Appendix</a></li>
-	<ul>
-		<li><a href="{{docu}}/appendix/downloads.html">Downloads</a></li>
-		<li><a href="{{docu}}/appendix/examples/index.html">Examples</a></li>
-		<li><a href="{{docu}}/appendix/troubleshooting.html">Troubleshooting</a></li>
-		<li><a href="{{docu}}/appendix/contributing.html">Contributing</a></li>
-	</ul>
+  <li><a href="{{docu}}/overview.html">Overview</a></li>
+  <li><a href="{{docu}}/concepts/index.html">Concepts</a>
+    <ul>
+      <li><a href="{{docu}}/concepts/index.html">Overview</a></li>
+      <li><a href="{{docu}}/concepts/items.html">Items</a></li>
+      <li><a href="{{docu}}/concepts/things.html">Things</a></li>
+      <li><a href="{{docu}}/concepts/discovery.html">Inbox &amp; Discovery</a></li>
+      <li><a href="{{docu}}/concepts/audio.html">Audio &amp; Voice</a></li>
+    </ul>
+  </li>
+  <li><a href="{{docu}}/installation/index.html">Installation</a>
+    <ul>
+      <li><a href="{{docu}}/installation/index.html">Overview</a></li>
+      <li><a href="{{docu}}/installation/linux.html">Linux</a></li>
+      <li><a href="{{docu}}/installation/macosx.html">Mac OS X</a></li>
+      <li><a href="{{docu}}/installation/windows.html">Windows</a></li>
+      <li><a href="{{docu}}/installation/docker.html">Docker</a></li>
+      <li><a href="{{docu}}/installation/rasppi.html">Raspberry Pi</a></li>
+      <li><a href="{{docu}}/installation/pine.html">PINE64</a></li>
+      <li><a href="{{docu}}/installation/synology.html">Synology</a></li>
+      <li><a href="{{docu}}/installation/designer.html">openHAB Designer</a></li>
+    </ul>
+  </li>
+  <li><a href="{{docu}}/configuration/nginx.html">Configuration</a>
+    <ul>
+      <li><a href="{{docu}}/configuration/nginx.html">Reverse Proxy</a></li>
+    </ul>
+  </li>
+  <li><a href="{{docu}}/administration/index.html">Administration</a>
+    <ul>
+      <li><a href="{{docu}}/administration/index.html">Overview</a></li>
+      <li><a href="{{docu}}/administration/console.html">Console</a></li>
+      <li><a href="{{docu}}/administration/logging.html">Logging</a></li>
+      <li><a href="{{docu}}/administration/bundles.html">Bundle Management</a></li>
+      <li><a href="{{docu}}/administration/runtime.html">Runtime Commands</a></li>
+    </ul>
+  </li>
+  <li><a href="{{docu}}/features/index.html">Features</a>
+    <ul>
+      <li><a href="{{docu}}/features/index.html">Overview</a></li>
+      <li><a href="{{docu}}/features/items.html">Items</a></li>
+      <li><a href="{{docu}}/features/sitemap.html">Sitemaps</a></li>
+      <li><a href="{{docu}}/features/persistence.html">Persistence</a></li>
+      <li><a href="{{docu}}/features/multimedia.html">Multimedia</a></li>
+      <li><a href="{{docu}}/features/automation/ruledsl.html">Automation</a>
+        <ul>
+          <li><a href="{{docu}}/features/automation/ruledsl.html">Textual Rules</a></li>
+          <li><a href="{{docu}}/features/automation/ngrules.html">Next-Gen Rules</a></li>
+        </ul>
+      </li>
+    </ul>
+  </li>
+  <li><a href="{{docu}}/addons/index.html">Add-ons</a>
+    <ul>
+      <li><a href="{{docu}}/addons/index.html">Overview</a></li>
+      <li><a href="{{docu}}/addons/bindings.html">Bindings</a>
+        <ul>
+          {% for binding in site.data.bindings %}
+          <li><a href="{{docu}}/addons/bindings/{{ binding.id }}/readme.html">{{ binding.label }}</a></li>
+          {% endfor %}
+        </ul>
+      </li>
+      <li><a href="{{docu}}/addons/voice.html">Voice Services</a>
+        <ul>
+          {% for voice in site.data.voice %}
+          <li><a href="{{docu}}/addons/voice/{{ voice.id }}/readme.html">{{ voice.label }}</a></li>
+          {% endfor %}
+        </ul>
+      </li>
+      <li><a href="{{docu}}/addons/io.html">System Integrations</a>
+        <ul>
+          <li><a href="{{docu}}/addons/io/homekit/readme.html">HomeKit</a></li>
+          <li><a href="{{docu}}/addons/io/hueemulation/readme.html">Amazon Echo</a></li>
+          <li><a href="{{docu}}/addons/io/imperihome/readme.html">ImperiHome</a></li>
+        </ul>
+      </li>
+      <li><a href="{{docu}}/addons/uis.html">User Interfaces</a>
+        <ul>
+          <li><a href="{{docu}}/addons/uis.html">Overview</a></li>
+          <li><a href="{{docu}}/addons/uis/basic/readme.html">Basic UI</a></li>
+          <li><a href="{{docu}}/addons/uis/classic/readme.html">Classic UI</a></li>
+          <li><a href="{{docu}}/addons/uis/paper/readme.html">Paper UI</a></li>
+          <li><a href="{{docu}}/addons/uis/habmin/readme.html">HABmin</a></li>
+          <li><a href="{{docu}}/addons/uis/habpanel/readme.html">HABPanel</a></li>
+          <li><a href="{{docu}}/addons/iconsets/classic/readme.html">Classic Iconset</a></li>
+        </ul>
+      </li>
+      <li><a href="{{docu}}/addons/1xaddons.html">1.x Add-ons</a></li>
+    </ul>
+  </li>
+  <li><a href="{{docu}}/appendix/contributing.html">Appendix</a>
+    <ul>
+      <li><a href="{{docu}}/appendix/downloads.html">Downloads</a></li>
+      <li><a href="{{docu}}/appendix/examples/index.html">Examples</a></li>
+      <li><a href="{{docu}}/appendix/troubleshooting.html">Troubleshooting</a></li>
+      <li><a href="{{docu}}/appendix/contributing.html">Contributing</a></li>
+    </ul>
+  </li>
 </ul>

--- a/_layouts/developersguide.html
+++ b/_layouts/developersguide.html
@@ -1,14 +1,14 @@
-    {% include header.html bodyClass="documentation"%}
+{% include header.html bodyClass="documentation"%}
 
-    <section id="documentation" class="text content-wrapper">
-        <div class="container">
-            <div class="side-nav-wrapper">
-                {% include dev-menu.html %}
-            </div>
-            <div class="content">
-	            {{ content }}
-            </div>
-        </div>
-    </section>
+<section id="documentation" class="text content-wrapper">
+  <div class="container">
+    <div class="side-nav-wrapper">
+      {% include dev-menu.html %}
+    </div>
+    <div class="content">
+      {{ content }}
+    </div>
+  </div>
+</section>
 
-    {% include footer.html %}
+{% include footer.html %}

--- a/_layouts/documentation.html
+++ b/_layouts/documentation.html
@@ -1,14 +1,14 @@
-    {% include header.html bodyClass="documentation"%}
-    
-    <section id="documentation" class="text content-wrapper">
-        <div class="container">
-            <div class="side-nav-wrapper">
-                {% include user-menu.html %}
-            </div>    
-            <div class="content">  
-	            {{ content }}
-            </div>
-        </div>
-    </section>
+{% include header.html bodyClass="documentation"%}
 
-    {% include footer.html %}
+<section id="documentation" class="text content-wrapper">
+  <div class="container">
+    <div class="side-nav-wrapper">
+      {% include user-menu.html %}
+    </div>
+    <div class="content">
+      {{ content }}
+    </div>
+  </div>
+</section>
+
+{% include footer.html %}

--- a/_layouts/gettingstarted.html
+++ b/_layouts/gettingstarted.html
@@ -1,14 +1,14 @@
-    {% include header.html bodyClass="documentation"%}
-    
-    <section id="documentation" class="text content-wrapper">
-        <div class="container">
-            <div class="side-nav-wrapper">
-                {% include gettingstarted-menu.html %}
-            </div>    
-            <div class="content">  
-	            {{ content }}
-            </div>
-        </div>
-    </section>
+{% include header.html bodyClass="documentation"%}
 
-    {% include footer.html %}
+<section id="documentation" class="text content-wrapper">
+  <div class="container">
+    <div class="side-nav-wrapper">
+      {% include gettingstarted-menu.html %}
+    </div>
+    <div class="content">
+      {{ content }}
+    </div>
+  </div>
+</section>
+
+{% include footer.html %}

--- a/_layouts/intro.html
+++ b/_layouts/intro.html
@@ -1,9 +1,9 @@
-    {% include header.html bodyClass="documentation"%}
-    
-    <section id="documentation" class="text content-wrapper">
-        <div class="container">
-	            {{ content }}
-        </div>
-    </section>
+{% include header.html bodyClass="documentation"%}
 
-    {% include footer.html %}
+<section id="documentation" class="text content-wrapper">
+  <div class="container">
+    {{ content }}
+  </div>
+</section>
+
+{% include footer.html %}

--- a/_layouts/raw.html
+++ b/_layouts/raw.html
@@ -1,8 +1,7 @@
-    {% include header.html bodyClass="documentation" %}
-    
-    <section id="documentation" class="text content-wrapper">
-	            {{ content }}
-    </section>
+{% include header.html bodyClass="documentation" %}
 
-    {% include footer.html %}
- 
+<section id="documentation" class="text content-wrapper">
+  {{ content }}
+</section>
+
+{% include footer.html %}

--- a/_layouts/redirected.html
+++ b/_layouts/redirected.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="canonical" href="{{ page.redirect_to }}"/>
+<meta http-equiv="content-type" content="text/html; charset=utf-8" />
+<meta http-equiv="refresh" content="0;url={{ page.redirect_to }}" />
+</head>
+<body>
+  <h1>Page has been moved. Redirecting...</h1>
+    <a href="{{ page.redirect_to }}">Click here if you are not redirected.<a>
+    <script>location='{{ page.redirect_to }}'</script>
+</body>
+</html>

--- a/_layouts/tutorial-advanced.html
+++ b/_layouts/tutorial-advanced.html
@@ -1,14 +1,14 @@
-    {% include header.html bodyClass="documentation"%}
-    
-    <section id="documentation" class="text content-wrapper">
-        <div class="container">
-            <div class="side-nav-wrapper">
-                {% include tutorial-advanced-menu.html %}
-            </div>    
-            <div class="content">  
-	            {{ content }}
-            </div>
-        </div>
-    </section>
+{% include header.html bodyClass="documentation"%}
 
-    {% include footer.html %}
+<section id="documentation" class="text content-wrapper">
+  <div class="container">
+    <div class="side-nav-wrapper">
+      {% include tutorial-advanced-menu.html %}
+    </div>
+    <div class="content">
+      {{ content }}
+    </div>
+  </div>
+</section>
+
+{% include footer.html %}

--- a/_layouts/tutorial-beginner.html
+++ b/_layouts/tutorial-beginner.html
@@ -1,14 +1,14 @@
-    {% include header.html bodyClass="documentation"%}
-    
-    <section id="documentation" class="text content-wrapper">
-        <div class="container">
-            <div class="side-nav-wrapper">
-                {% include tutorial-beginner-menu.html %}
-            </div>    
-            <div class="content">  
-	            {{ content }}
-            </div>
-        </div>
-    </section>
+{% include header.html bodyClass="documentation"%}
 
-    {% include footer.html %}
+<section id="documentation" class="text content-wrapper">
+  <div class="container">
+    <div class="side-nav-wrapper">
+      {% include tutorial-beginner-menu.html %}
+    </div>
+    <div class="content">
+      {{ content }}
+    </div>
+  </div>
+</section>
+
+{% include footer.html %}

--- a/redirect-test.md
+++ b/redirect-test.md
@@ -1,0 +1,7 @@
+---
+layout: redirected
+sitemap: false
+redirect_to: /installation/linux.html
+---
+
+<!-- Note to authors: This file was created in December 2016. Feel free to remove it after a few months... -->


### PR DESCRIPTION
Code style fixes convenient before I start to work on the new docs structure. Formatting was fixed in the Atom editor with default settings.

Compare ``diff`` with and without whitespaces:
https://github.com/openhab/openhab-docs/pull/147/files
https://github.com/openhab/openhab-docs/pull/147/files?w=0

Additionally: Some HTML fixes, a testing file for redirection I'll need for the next step.

@kaikreuzer a quick "okay with me" would be nice ;)

Signed-off-by: Thomas Dietrich <thomas.dietrich@tu-ilmenau.de> (github: ThomDietrich)