### PR TITLE
also correctly sort bindings in the menu

### DIFF
--- a/_includes/user-menu.html
+++ b/_includes/user-menu.html
@@ -60,7 +60,10 @@
         <ul>
           <li><a href="{{docu}}/addons/bindings.html">Overview</a></li>
           <hr />
-          {% for binding in site.data.bindings %}
+          {% assign bindings = "" | split: "|" %}
+          {% for binding in site.data.bindings %}{% assign bindings = bindings | push: binding %}{% endfor %}
+          {% assign sorted_bindings = bindings | sort: "id" %}
+          {% for binding in sorted_bindings %}
           <li><a href="{{docu}}/addons/bindings/{{ binding.id }}/readme.html">{{ binding.label }}</a></li>
           {% endfor %}
         </ul>


### PR DESCRIPTION
The order is already correct on the overview page, but the menu still lists the ESH bindings first and then the OH2 bindings.

Signed-off-by: Kai Kreuzer <kai@openhab.org>