### PR TITLE
Add missing openHAB 1.x binding information

### DIFF
--- a/_data/oh1addons_infos.yml
+++ b/_data/oh1addons_infos.yml
@@ -53,6 +53,18 @@
   description: Monitor and control Anel NET-PwrCtrl power sockets and relays
   wiki_url: https://github.com/openhab/openhab/wiki/Anel-Binding
 
+- label: Bticino Binding
+  description: Connects to Bticino My Home Automation installations by OpenWebNet protocol
+  wiki_url: https://github.com/openhab/openhab/wiki/Bticino-Binding
+
+- label: CalDAV Binding (command)
+  description: Execute CalDAV commands through an event, triggered at the start or the end of an event
+  wiki_url: https://github.com/openhab/openhab/wiki/CalDAV
+
+- label: CalDAV Binding (personal)
+  description: Detect presence through calendar events or show upcoming/active calendar events
+  wiki_url: https://github.com/openhab/openhab/wiki/CalDAV
+
 - label: ComfoAir Binding
   description: Monitor and control Zehnder ComfoAir ventilation systems
   wiki_url: https://github.com/openhab/openhab/wiki/Comfo-Air-Binding
@@ -61,6 +73,14 @@
   description: This binding supports Denon AV receivers
   wiki_url: https://github.com/openhab/openhab/wiki/Denon-Binding
 
+- label: DMX OLA Binding
+  description: Control DMX devices like RGB led strips, dimmers and more
+  wiki_url: https://github.com/openhab/openhab/wiki/DMX-Binding
+
+- label: DSMR Binding
+  description: Obtains data from a Dutch smart meter ("Slimme meter" in Dutch) via the P1-port
+  wiki_url: https://github.com/openhab/openhab/wiki/DSMR-binding
+
 - label: eBUS Binding
   description: The eBUS protocol is used by heating system vendors like Wolf, Vaillant, Kromschröder etc.
   wiki_url: https://github.com/openhab/openhab/wiki/eBUS-Binding
@@ -68,6 +88,10 @@
 - label: Ecobee Binding
   description: Monitor and control Ecobee thermostats
   wiki_url: https://github.com/openhab/openhab/wiki/Ecobee-Binding
+
+- label: Waterkotte Ecotouch Binding
+  description: Connects to Waterkotte EcoTouch heat pumps via network
+  wiki_url: https://github.com/openhab/openhab/wiki/Waterkotte-EcoTouch-Heat-Pump-Binding
 
 - label: Energenie Binding
   description: Send commands to multiple Gembird energenie PMS-LAN power extenders.
@@ -85,6 +109,10 @@
   description: Compatible with Epson projectors which support ESC/VP21 protocol over serial port
   wiki_url: https://github.com/openhab/openhab/wiki/Epson-Projector-Binding
 
+- label: Expire Binding
+  description: This binding will post an update or command that you specify (the "expire" update/command) to items it is bound to after a period of time has passed
+  wiki_url: https://github.com/openhab/openhab/wiki/Expire-Binding
+
 - label: Exec Binding
   description: Enhance openHAB with a "swiss-army-knife-binding" which executes given commands on the commandline
   wiki_url: https://github.com/openhab/openhab/wiki/Exec-Binding
@@ -96,6 +124,14 @@
 - label: Freeswitch Binding
   description: It connects to a freeswitch instance and can report on current active calls as well as show unread voicemails and if a MWI is on
   wiki_url: https://github.com/openhab/openhab/wiki/Freeswitch-Binding
+
+- label: Fritzbox Binding
+  description: Connects to a AVM FritzBox on the monitor port 1012 and listens to event notifications from this box. There are events for incoming and outgoing calls, as well as for connections and disconnections.
+  wiki_url: https://github.com/openhab/openhab/wiki/Fritz-Box-Binding
+
+- label: Fritzbox TR064 Binding
+  description: Communicates with AVM Fritz!Box using SOAP requests (TR064 protocol)
+  wiki_url: https://github.com/openhab/openhab/wiki/FritzBox-TR064-Binding
 
 - label: FS20 Binding
   description: Enables support of sending and receiving FS20 messages via the CUL transport
@@ -117,6 +153,10 @@
   description: Allows you to control Heatmiser RS-422 network thermostats
   wiki_url: https://github.com/openhab/openhab/wiki/Heatmiser-Binding
 
+- label: Horizon Binding
+  description: This binding supports the horizon mediabox used by cable companies in the Netherlands and some other countries
+  wiki_url: https://github.com/openhab/openhab/wiki/Horizon-mediabox-binding
+
 - label: HTTP Binding
   description: If you want to let openHAB request an URL when special events occur or let it poll a given URL frequently
   wiki_url: https://github.com/openhab/openhab/wiki/Http-Binding
@@ -128,6 +168,14 @@
 - label: InsteonPLM Binding
   description: Insteon is a home area networking technology developed primarily for connecting light switches and loads
   wiki_url: https://github.com/openhab/openhab/wiki/Insteon-PLM-Binding
+
+- label: Intertechno Binding
+  description: Allows to integrate Intertechno CUL devices into openHAB
+  wiki_url: https://github.com/openhab/openhab/wiki/CUL-Intertechno
+
+- label: IPX800 Binding
+  description: Connects to a GCE Electronics IPX800 relay webserver
+  wiki_url: https://github.com/openhab/openhab/wiki/IPX800-Binding
 
 - label: IRTrans Binding
   description: Allows openHAB to communicate with the infrared emitter/transceiver of IrTrans
@@ -153,6 +201,10 @@
   description: Every LG TV Model with Netcast 3.0 and Netcast 4.0 (Model years 2012 & 2013)
   wiki_url: https://github.com/openhab/openhab/wiki/Lg-TV
 
+- label: MochadX10 Binding
+  description: This binding makes it possible to control X10 devices via a server running the Mochad X10 daemon
+  wiki_url: https://github.com/openhab/openhab/wiki/Mochad-X10-Binding
+
 - label: Milight Binding
   description: Allows to send commands to multiple Milight bridges
   wiki_url: https://github.com/openhab/openhab/wiki/Milight-Binding
@@ -169,7 +221,7 @@
   description: This binding allows openHAB to act as an MQTT client, so that openHAB items can send and receive MQTT messages to/from an MQTT broker
   wiki_url: https://github.com/openhab/openhab/wiki/MQTT-Binding
 
-- label: Owntracks Binding
+- label: OwnTracks (formerly MQTTitude) Binding
   description: Owntracks (formerly known as MQTTitude) provides device location data via an MQTT bridge to openHAB
   wiki_url: https://github.com/openhab/openhab/wiki/Mqttitude-Binding
 
@@ -212,6 +264,22 @@
 - label: OneWire Binding
   description: OneWire bus system is a lightweight and cheap bus system mostly used for sensors like, temperature, humidity, counters and presence
   wiki_url: https://github.com/openhab/openhab/wiki/One-Wire-Binding
+
+- label: OWServer Binding
+  description: This binding reads values from 1-wire devices connected to an OW-SERVER (both Rev. 1 and 2)
+  wiki_url: https://github.com/openhab/openhab/wiki/EDS-OWServer-Binding
+
+- label: Panasonic TV Binding
+  description: This binding supports Panasonic TVs. It should be compatible with most up-to-date Panasonic Smart-TVs.
+  wiki_url: https://github.com/openhab/openhab/wiki/Panasonic-TV-Binding
+
+- label: Plex Binding
+  description: This binding supports multiple clients connected to a Plex Media Server
+  wiki_url: https://github.com/openhab/openhab/wiki/Plex-Binding
+
+- label: Plugwise Binding
+  description: Adds support to openHAB for Plugwise ZigBee devices using the Stick
+  wiki_url: https://github.com/openhab/openhab/wiki/Plugwise-Binding
 
 - label: Visonic PowerMax Binding
   description: Powermax alarm panel series and the Powermaster alarm series
@@ -261,12 +329,16 @@
   description: TinkerForge is a system of open source hardware building blocks that allows you to combine sensor and actuator blocks by plug and play.
   wiki_url: https://github.com/openhab/openhab/wiki/Tinkerforge-Binding
 
+- label: Universal Powerline Bus Binding
+  description: The Universal Powerline Bus (UPB) binding reads and writes messages to and from a UPB modem
+  wiki_url: https://github.com/openhab/openhab/wiki/UPB-Binding
+
 - label: Weather Binding
   description: Collects current and forecast weather data from different providers with a free weather API
   wiki_url: https://github.com/openhab/openhab/wiki/Weather-Binding
 
 - label: WOL (Wake-on-LAN) Binding
-  description:
+  description: Send Wake-on-LAN magic packets to specific hosts in the network
   wiki_url: https://github.com/openhab/openhab/wiki/Wake-on-LAN-Binding-%28WoL%29
 
 - label: InfluxDB (v 1.0) Persistence


### PR DESCRIPTION
This PR should add the missing binding information in the table on: http://docs.openhab.org/addons/bindings.html#compatible-1x-bindings 