### PR TITLE
Fix rendering on openhab docs site

### DIFF
--- a/addons/bindings/ipp/readme.md
+++ b/addons/bindings/ipp/readme.md
@@ -34,4 +34,5 @@ All devices support some of the following channels:
 | jobs | Number       | Total number of print jobs on the printer |
 | waitingJobs | Number       | Number of waiting print jobs on the printer |
 | doneJobs | Number       | Number of completed print jobs on the printer |
+
 ## Full Example


### PR DESCRIPTION
This table doesn't render correctly on the openhab docs site (http://docs.openhab.org/addons/bindings/ipp/readme.html), my best guess is because there is no newline after the table.