### PR TITLE
Changed Yahoo binding example to match README

### DIFF
--- a/tutorials/migration.md
+++ b/tutorials/migration.md
@@ -599,7 +599,7 @@ a .things file (located in conf/things) with the line:
 
 
 ```java
-Thing yahooweather:weather:berlin [ location="638242", unit="c" ]
+Thing yahooweather:weather:berlin [ location=638242 ]
 ```
 
 As described in the Binding's readme, three Channels are supported: temperature,
@@ -616,8 +616,8 @@ the Channels.
 
 ```java
 // openHAB 2 Syntax
-Number Temperature   { channel="yahooweather:weather:berlin#temperature" }
-Number Humidity      { channel="yahooweather:weather:berlin#humidity" }
+Number Temperature   { channel="yahooweather:weather:berlin:temperature" }
+Number Humidity      { channel="yahooweather:weather:berlin:humidity" }
 ```
 
 As you can see, the Channel ID consists of the Thing's name, a "#" and the


### PR DESCRIPTION
Updated the Yahoo Weather Binding example to match the one in the README. In particular removing the reference to "unit" (is that supported any longer?), removing the quotes around the woeid in the thing config, and replacing the "#" with ":" in the Item definition.

Corrects #233 

Signed-off-by: Richard Koshak rlkoshak@gmail.com (github: rkoshak)