### PR TITLE
Add directory /opt/openhab to chown command

### DIFF
--- a/installation/docker.md
+++ b/installation/docker.md
@@ -73,7 +73,7 @@ mkdir /opt/openhab
 mkdir /opt/openhab/conf
 mkdir /opt/openhab/userdata
 mkdir /opt/openhab/addons
-chown -R openhab:openhab
+chown -R openhab:openhab /opt/openhab
 ```
 
 ## Running the Container as a Service Managed by Docker


### PR DESCRIPTION
Hi,

I've just added the missing directory for openhab files within the chown command.

Cheers,
Dennis