### PR TITLE
Fix nginx code closures in tabbed section

### DIFF
--- a/_includes/user-menu.html
+++ b/_includes/user-menu.html
@@ -28,7 +28,7 @@
       <li><a href="{{docu}}/installation/qnap.html">QNAP NAS</a></li>
       <hr />
       <li><a href="{{docu}}/installation/designer.html">SmartHome Designer</a></li>
-      <li><a href="{{docu}}/installation/security.html">Authentication &amp; HTTPS</a></li>
+      <li><a href="{{docu}}/installation/security.html">Security &amp; Remote Access</a></li>
       <li><a href="http://www.myopenhab.org">myopenHAB</a></li>
     </ul>
   </li>

--- a/installation/security.md
+++ b/installation/security.md
@@ -78,6 +78,30 @@ It also provides you a simple way of **protecting your server** with authenticat
 
 The good news is that [openHABian](openhabian) already offers the possibility to activate a preconfigured NGINX reverse proxy, which includes setting up authentication and a valid [Let's Encrypt](https://letsencrypt.org) certificate.
 
+**Table of Content:**
+
+* [Setting up NGINX](#nginx-setup)
+  * [Installation](#nginx-setup-install)
+  * [Basic Configuration](#nginx-setup-config)
+* [Authentication with NGINX](#nginx-auth)
+  * [Creating the First User](#nginx-auth-user)
+  * [Referencing the File in the NGINX Configuration](#nginx-auth-file)
+  * [Adding or Removing users](#nginx-auth-users)
+* [Making Exceptions for Specific IP addresses](#nginx-satisfy)
+* [Setting up a Domain](#nginx-domain)
+* [Enabling HTTPS](#nginx-https)
+* [Using OpenSSL to Generate Self-Signed Certificates](#nginx-openssl)
+  * [Adding the Certificates to Your Proxy Server](#nginx-openssl-add)
+* [Using Let's Encrypt to Generate Trusted Certificates](#nginx-letsencrypt)
+  * [Setting up the NGINX Proxy Server to Handle the Certificate Generation Procedure](#nginx-letsencrypt-generation)
+  * [Using Certbot](#nginx-letsencrypt-certbot)
+  * [Adding the Certificates to Your Proxy Server](#nginx-letsencrypt-add)
+* [Setting Your NGINX Server to Listen to the HTTPS Port](#nginx-https-listen)
+* [Redirecting HTTP Traffic to HTTPS](#nginx-httpredirect)
+* [Putting it All Together](#nginx-summary)
+* [Additional HTTPS Security](#nginx-https-security)
+* [Further Reading](#nginx-further-reading)
+
 {: #nginx-setup}
 #### Setting up NGINX
 
@@ -320,7 +344,7 @@ In the NGINX configuration, place the following underneath your server_name vari
     add_header                      Strict-Transport-Security "max-age=31536000";
 ```
 
-{: #nginx-https}
+{: #nginx-https-listen}
 #### Setting Your NGINX Server to Listen to the HTTPS Port
 
 Regardless of the option you choose, make sure you change the port to listen in on HTTPS traffic.

--- a/installation/security.md
+++ b/installation/security.md
@@ -249,7 +249,7 @@ If you need to use an internal or external IP to connect to openHAB, follow the 
   You will be prompted for some information which you will need to fill out for the certificate, when it asks for a **Common Name**, you may enter your IP Address:
   Common Name (e.g. server FQDN or YOUR name) []: xx.xx.xx.xx
 
-  **Adding the Certificates to Your Proxy Server**
+##### Adding the Certificates to Your Proxy Server
 
   The certificate and key should have been placed in `/etc/ssl/`. NGINX needs to be told where these files are and then enable the reverse proxy to direct HTTPS traffic. In the NGINX configuration, place the following underneath your server_name variable:
 
@@ -260,52 +260,52 @@ If you need to use an internal or external IP to connect to openHAB, follow the 
 
 #### Using Let's Encrypt to Generate Trusted Certificates
 
-  **Skip this step if you have no domain name or have already followed the instructions for OpenSSL**
+**Skip this step if you have no domain name or have already followed the instructions for OpenSSL**
 
-  Let's Encrypt is a service that allows anyone with a valid domain to automatically generate a trusted certificate, these certificates are usually accepted by a browser without any warnings.
+Let's Encrypt is a service that allows anyone with a valid domain to automatically generate a trusted certificate, these certificates are usually accepted by a browser without any warnings.
 
-  **Setting up the NGINX Proxy Server to Handle the Certificate Generation Procedure**
+**Setting up the NGINX Proxy Server to Handle the Certificate Generation Procedure**
 
-  Let's Encrypt needs to validate that the server has control of the domain, the most simple way of doing this is using a **webroot plugin** to place a file on the server, and then access it using a specific url: */.well-known/acme-challenge*.
-  Since the proxy only forwards traffic to the openHAB server, the server needs to be told to handle requests at this address differently.
+Let's Encrypt needs to validate that the server has control of the domain, the most simple way of doing this is using a **webroot plugin** to place a file on the server, and then access it using a specific url: */.well-known/acme-challenge*.
+Since the proxy only forwards traffic to the openHAB server, the server needs to be told to handle requests at this address differently.
 
-  First, **create a directory** that Certbot can be given access to:
+First, **create a directory** that Certbot can be given access to:
 
-  ```shell
-  sudo mkdir -p /var/www/mydomain
-  ```
+```shell
+sudo mkdir -p /var/www/mydomain
+```
 
-  Next add the new location parameter to your NGINX config, this should be **placed above the last brace** in the server setting:
+Next add the new location parameter to your NGINX config, this should be **placed above the last brace** in the server setting:
 
-  ```nginx
-  	location /.well-known/acme-challenge/ {
-  		root                            /var/www/mydomain;
-  	}
-  ```
+```nginx
+  location /.well-known/acme-challenge/ {
+    root                            /var/www/mydomain;
+  }
+```
 
-  **Using Certbot**
+##### Using Certbot
 
-  Certbot is a tool which simplifies the process of obtaining secure certificates.
-  The tool may not be packaged for some Linux distributions so installation instructions may vary, check out [their website](https://certbot.eff.org/) and follow the instructions **using the webroot mode**.
-  Don't forget to change the example domain to your own! An example of a valid certbot command (in this case for Debian Jessie) would be:
+Certbot is a tool which simplifies the process of obtaining secure certificates.
+The tool may not be packaged for some Linux distributions so installation instructions may vary, check out [their website](https://certbot.eff.org/) and follow the instructions **using the webroot mode**.
+Don't forget to change the example domain to your own! An example of a valid certbot command (in this case for Debian Jessie) would be:
 
-  ```shell
-  sudo certbot certonly --webroot -w /var/www/mydomain -d mydomain
-  ```
+```shell
+sudo certbot certonly --webroot -w /var/www/mydomain -d mydomain
+```
 
-  **Adding the Certificates to Your Proxy Server**
+##### Adding the Certificates to Your Proxy Server
 
-  The certificate and key should have been placed in `/etc/letsencrypt/live/mydomain_or_myip`.
-  NGINX needs to be told where these files are and then enable the reverse proxy to direct HTTPS traffic, using Strict Transport Security to prevent man-in-the-middle attacks.
-  In the NGINX configuration, place the following underneath your server_name variable:
+The certificate and key should have been placed in `/etc/letsencrypt/live/mydomain_or_myip`.
+NGINX needs to be told where these files are and then enable the reverse proxy to direct HTTPS traffic, using Strict Transport Security to prevent man-in-the-middle attacks.
+In the NGINX configuration, place the following underneath your server_name variable:
 
-  ```nginx
-  		ssl_certificate                 /etc/letsencrypt/live/mydomain_or_myip/fullchain.pem;
-  		ssl_certificate_key             /etc/letsencrypt/live/mydomain_or_myip/privkey.pem;
-  		add_header                      Strict-Transport-Security "max-age=31536000";
-  ```
+```nginx
+    ssl_certificate                 /etc/letsencrypt/live/mydomain_or_myip/fullchain.pem;
+    ssl_certificate_key             /etc/letsencrypt/live/mydomain_or_myip/privkey.pem;
+    add_header                      Strict-Transport-Security "max-age=31536000";
+```
 
-##### Setting Your NGINX Server to Listen to the HTTPS Port
+#### Setting Your NGINX Server to Listen to the HTTPS Port
 
 Regardless of the option you choose, make sure you change the port to listen in on HTTPS traffic.
 
@@ -318,7 +318,7 @@ You can check by going to https://mydomain_or_myip and confirming with your brow
 **These certificates expire within a few months** so it is important to run the updater in a cron expression (and also restart NGINX) as explained in the Certbot setup instructions.
 If you want to keep hold of a HTTP server for some reason, just add `listen 80;` and remove the Strict-Transport-Security line.
 
-##### Redirecting HTTP Traffic to HTTPS
+#### Redirecting HTTP Traffic to HTTPS
 
 You may want to redirect all HTTP traffic to HTTPS, you can do this by adding the following to the NGINX configuration.
 This will essentially replace the HTTP url with the HTTPS version!

--- a/installation/security.md
+++ b/installation/security.md
@@ -264,7 +264,7 @@ If you need to use an internal or external IP to connect to openHAB, follow the 
 
 Let's Encrypt is a service that allows anyone with a valid domain to automatically generate a trusted certificate, these certificates are usually accepted by a browser without any warnings.
 
-**Setting up the NGINX Proxy Server to Handle the Certificate Generation Procedure**
+##### Setting up the NGINX Proxy Server to Handle the Certificate Generation Procedure
 
 Let's Encrypt needs to validate that the server has control of the domain, the most simple way of doing this is using a **webroot plugin** to place a file on the server, and then access it using a specific url: */.well-known/acme-challenge*.
 Since the proxy only forwards traffic to the openHAB server, the server needs to be told to handle requests at this address differently.

--- a/installation/security.md
+++ b/installation/security.md
@@ -78,10 +78,12 @@ It also provides you a simple way of **protecting your server** with authenticat
 
 The good news is that [openHABian](openhabian) already offers the possibility to activate a preconfigured NGINX reverse proxy, which includes setting up authentication and a valid [Let's Encrypt](https://letsencrypt.org) certificate.
 
+{: #nginx-setup}
 #### Setting up NGINX
 
 These are the steps required to use [**NGINX**](https://nginx.org), a lightweight HTTP server, although you can use **Apache HTTP** server or any other HTTP server which supports reverse proxying.
 
+{: #nginx-setup-install}
 ##### Installation
 
 NGINX runs as a service in most Linux distributions, installation should be as simple as:
@@ -93,6 +95,7 @@ sudo apt-get update && sudo apt-get install nginx
 Once installed, you can test to see if the service is running correctly by going to *http://mydomain_or_myip*, you should see the default "Welcome to nginx" page.
 If you don't, you may need to check your firewall or ports and check if port 80 (and 443 for HTTPS later) is not blocked and that services can use it.
 
+{: #nginx-setup-config}
 ##### Basic Configuration
 
 NGINX configures the server when it starts up based on configuration files.
@@ -138,6 +141,7 @@ sudo service nginx restart
 
 ...and then go to *http://mydomain_or_myip* to see your openHAB server.
 
+{: #nginx-auth}
 #### Authentication with NGINX
 
 For further security, you may wish to ask for a **username and password** before users have access to openHAB.
@@ -146,6 +150,7 @@ This is fairly simple in NGINX once you have the reverse proxy setup, you just n
 **Note:** There is currently an issue with Proxy Authentication and HABmin when using some browsers.
 If you require HABmin, consider connecting locally or using Safari for now.
 
+{: #nginx-auth-user}
 ##### Creating the First User
 
 You will be using *htpasswd* to generate a username/password file, this utility can be found in the apache2-utils package:
@@ -163,6 +168,7 @@ sudo htpasswd -c /etc/nginx/.htpasswd username
 You will receive a prompt to create a password for this username, once finished the file will be created.
 You're then free to reference the file to NGINX.
 
+{: #nginx-auth-file}
 ##### Referencing the File in the NGINX Configuration
 
 Now the configuration file (`/etc/nginx/sites-enabled/openhab`) needs to be edited to use this password.
@@ -175,6 +181,7 @@ Open the configuration file and **add** the following lines underneath the proxy
 
 Once done, **test and restart your NGINX service** and authentication should now be enabled on your server!
 
+{: #nginx-auth-users}
 ##### Adding or Removing users
 
 To add new users to your site, you must use following command, **do not** use the `-c` modifier again as this will remove all previously created users:
@@ -191,6 +198,7 @@ sudo htpasswd -D /etc/nginx/.htpasswd username
 
 Once again, any changes you make to these files **must be followed with restarting the NGINX service** otherwise no changes will be made.
 
+{: #nginx-satisfy}
 #### Making Exceptions for Specific IP addresses
 
 It is often desirable to allow specific IPs (e.g. the local network) to access openHAB without needing to prompt for a password or to block everyone else entirely.
@@ -207,6 +215,7 @@ These lines are placed in the `location{}` block. For example, by adding the lin
 NGINX will allow anyone within the 192.168.0.1/24 range **and** the localhost to connect without a password.
 If you have setup a password following the previous section, then the rest will be prompted for a password for access.
 
+{: #nginx-domain}
 #### Setting up a Domain
 
 To generate a trusted certificate, you need to own a domain. To acquire your own domain, you can use one of the following methods:
@@ -217,7 +226,7 @@ To generate a trusted certificate, you need to own a domain. To acquire your own
 | Obtaining a free domain | [FreeNom](http://www.freenom.com) | Setup is the same as above. |
 | Using a "Dynamic DNS" sevice | [No-IP](http://www.noip.com), [Dyn](http://www.dyn.com/dns) | Uses a client to automatically update your IP to a domain of you choice, some Dynamic DNS services offer a free domain too. |
 
-
+{: #nginx-https}
 #### Enabling HTTPS
 
 Encrypting the communication between client and the server is important because it protects against eavesdropping and possible forgery.
@@ -226,6 +235,7 @@ The following options are available depending if you have a valid domain:
 If you have a **valid domain and can change the DNS** to point towards your IP, follow the [instructions for Let's Encrypt](#using-lets-encrypt-to-generate-trusted-certificates)
 If you need to use an internal or external IP to connect to openHAB, follow the [instructions for OpenSSL](#using-openssl-to-generate-self-signed-certificates)
 
+{: #nginx-openssl}
 #### Using OpenSSL to Generate Self-Signed Certificates
 
 OpenSSL is also packaged for most Linux distributions, installing it should be as simple as:
@@ -249,6 +259,7 @@ sudo openssl req -x509 -nodes -days 365 -newkey rsa:2048 -keyout /etc/ssl/openha
 You will be prompted for some information which you will need to fill out for the certificate, when it asks for a **Common Name**, you may enter your IP Address:
 Common Name (e.g. server FQDN or YOUR name) []: xx.xx.xx.xx
 
+{: #nginx-openssl-add}
 ##### Adding the Certificates to Your Proxy Server
 
 The certificate and key should have been placed in `/etc/ssl/`. NGINX needs to be told where these files are and then enable the reverse proxy to direct HTTPS traffic. In the NGINX configuration, place the following underneath your server_name variable:
@@ -258,12 +269,14 @@ The certificate and key should have been placed in `/etc/ssl/`. NGINX needs to b
   ssl_certificate_key             /etc/ssl/openhab.key;
 ```
 
+{: #nginx-letsencrypt}
 #### Using Let's Encrypt to Generate Trusted Certificates
 
 **Skip this step if you have no domain name or have already followed the instructions for OpenSSL**
 
 Let's Encrypt is a service that allows anyone with a valid domain to automatically generate a trusted certificate, these certificates are usually accepted by a browser without any warnings.
 
+{: #nginx-letsencrypt-generation}
 ##### Setting up the NGINX Proxy Server to Handle the Certificate Generation Procedure
 
 Let's Encrypt needs to validate that the server has control of the domain, the most simple way of doing this is using a **webroot plugin** to place a file on the server, and then access it using a specific url: */.well-known/acme-challenge*.
@@ -283,6 +296,7 @@ Next add the new location parameter to your NGINX config, this should be **place
   }
 ```
 
+{: #nginx-letsencrypt-certbot}
 ##### Using Certbot
 
 Certbot is a tool which simplifies the process of obtaining secure certificates.
@@ -293,6 +307,7 @@ Don't forget to change the example domain to your own! An example of a valid cer
 sudo certbot certonly --webroot -w /var/www/mydomain -d mydomain
 ```
 
+{: #nginx-letsencrypt-add}
 ##### Adding the Certificates to Your Proxy Server
 
 The certificate and key should have been placed in `/etc/letsencrypt/live/mydomain_or_myip`.
@@ -305,6 +320,7 @@ In the NGINX configuration, place the following underneath your server_name vari
     add_header                      Strict-Transport-Security "max-age=31536000";
 ```
 
+{: #nginx-https}
 #### Setting Your NGINX Server to Listen to the HTTPS Port
 
 Regardless of the option you choose, make sure you change the port to listen in on HTTPS traffic.
@@ -318,6 +334,7 @@ You can check by going to https://mydomain_or_myip and confirming with your brow
 **These certificates expire within a few months** so it is important to run the updater in a cron expression (and also restart NGINX) as explained in the Certbot setup instructions.
 If you want to keep hold of a HTTP server for some reason, just add `listen 80;` and remove the Strict-Transport-Security line.
 
+{: #nginx-httpredirect}
 #### Redirecting HTTP Traffic to HTTPS
 
 You may want to redirect all HTTP traffic to HTTPS, you can do this by adding the following to the NGINX configuration.
@@ -331,6 +348,7 @@ server {
 }
 ```
 
+{: #nginx-summary}
 #### Putting it All Together
 
 After following all the steps on this page, you *should* have a NGINX server configuration (`/etc/nginx/sites-enabled/openhab`) that looks like this:
@@ -370,6 +388,7 @@ server {
 }
 ```
 
+{: #nginx-https-security}
 #### Additional HTTPS Security
 
 To test your security settings [SSL Labs](https://www.ssllabs.com/ssltest/) provides a tool for testing your domain against ideal settings (Make sure you check "Do not show the results on the boards" if you dont want your domain seen).
@@ -399,6 +418,7 @@ All of these settings are customisable, but make sure you [read up on](http://ng
 Feel free to test the new configuration again on [SSL Labs](https://www.ssllabs.com/ssltest/).
 If you're achieving A or A+ here, then your client-openHAB communication is very secure.
 
+{: #nginx-further-reading}
 #### Further Reading
 
 The setup above is a suggestion for high compatibility with an A+ rating at the time of writing, however flaws in these settings (particularly the cyphers) may become known overtime.

--- a/installation/security.md
+++ b/installation/security.md
@@ -228,35 +228,35 @@ If you need to use an internal or external IP to connect to openHAB, follow the 
 
 #### Using OpenSSL to Generate Self-Signed Certificates
 
-  OpenSSL is also packaged for most Linux distributions, installing it should be as simple as:
+OpenSSL is also packaged for most Linux distributions, installing it should be as simple as:
 
-  ```shell
-  sudo apt-get install openssl
-  ```
+```shell
+sudo apt-get install openssl
+```
 
-  Once complete, you need to create a directory where our certificates can be placed:
+Once complete, you need to create a directory where our certificates can be placed:
 
-  ```shell
-  sudo mkdir -p /etc/ssl/certs
-  ```
+```shell
+sudo mkdir -p /etc/ssl/certs
+```
 
-  Now OpenSSL can be told to generate a 2048 bit long RSA key and a certificate that is valid for a year:
+Now OpenSSL can be told to generate a 2048 bit long RSA key and a certificate that is valid for a year:
 
-  ```shell
-  sudo openssl req -x509 -nodes -days 365 -newkey rsa:2048 -keyout /etc/ssl/openhab.key -out /etc/ssl/openhab.crt
-  ```
+```shell
+sudo openssl req -x509 -nodes -days 365 -newkey rsa:2048 -keyout /etc/ssl/openhab.key -out /etc/ssl/openhab.crt
+```
 
-  You will be prompted for some information which you will need to fill out for the certificate, when it asks for a **Common Name**, you may enter your IP Address:
-  Common Name (e.g. server FQDN or YOUR name) []: xx.xx.xx.xx
+You will be prompted for some information which you will need to fill out for the certificate, when it asks for a **Common Name**, you may enter your IP Address:
+Common Name (e.g. server FQDN or YOUR name) []: xx.xx.xx.xx
 
 ##### Adding the Certificates to Your Proxy Server
 
-  The certificate and key should have been placed in `/etc/ssl/`. NGINX needs to be told where these files are and then enable the reverse proxy to direct HTTPS traffic. In the NGINX configuration, place the following underneath your server_name variable:
+The certificate and key should have been placed in `/etc/ssl/`. NGINX needs to be told where these files are and then enable the reverse proxy to direct HTTPS traffic. In the NGINX configuration, place the following underneath your server_name variable:
 
-  ```nginx
-  	ssl_certificate                 /etc/ssl/openhab.crt;
-  	ssl_certificate_key             /etc/ssl/openhab.key;
-  ```
+```nginx
+  ssl_certificate                 /etc/ssl/openhab.crt;
+  ssl_certificate_key             /etc/ssl/openhab.key;
+```
 
 #### Using Let's Encrypt to Generate Trusted Certificates
 


### PR DESCRIPTION
Made them into own categories instead of bolding statements (which was a workaround for when he had <4 headings).

Fixes #259 

Signed-off-by: Ben Clark <ben@benjyc.uk>