### PR TITLE
Search input hotfix

### DIFF
--- a/css/openhab.css
+++ b/css/openhab.css
@@ -24,13 +24,19 @@ li.search:hover {
   border: none !important; 
   transition: 0.2s ease-in;
   display: block;
-  margin: 17px 0 0 0;
+  margin: 17px 0 0 0 !important;
 }
 
-.search-form ::-webkit-input-placeholder,
-.search-form ::-moz-placeholder,
-.search-form ::-ms-input-placeholder {
-    color: #fff;
+::-webkit-input-placeholder {
+  color: #fff;
+}
+
+::-moz-placeholder {
+  color: #fff;
+}
+
+::-ms-input-placeholder{
+  color: #fff;
 }
 
 #searchform .search-form-input:focus {
@@ -56,4 +62,12 @@ li.search:hover {
 
 #searchresults input {
    box-sizing: content-box;
+}
+
+input.gsc-input {
+  box-shadow: none !important;
+}
+
+#querymob {
+  color: #000;
 }

--- a/css/openhab.css
+++ b/css/openhab.css
@@ -20,7 +20,6 @@ li.search:hover {
 .search-form-input  {
   padding-left: 5px !important;
   width: 100px;
-  width: 100px;
   border: none !important; 
   transition: 0.2s ease-in;
   display: block;
@@ -31,15 +30,15 @@ li.search:hover {
   margin: 9px 0 0 0 !important;
 }
 
-::-webkit-input-placeholder {
+.search-form ::-webkit-input-placeholder {
   color: #fff;
 }
 
-::-moz-placeholder {
+.search-form ::-moz-placeholder {
   color: #fff;
 }
 
-::-ms-input-placeholder{
+.search-form ::-ms-input-placeholder{
   color: #fff;
 }
 

--- a/css/openhab.css
+++ b/css/openhab.css
@@ -27,6 +27,10 @@ li.search:hover {
   margin: 17px 0 0 0 !important;
 }
 
+.sticky .search-form-input {
+  margin: 9px 0 0 0 !important;
+}
+
 ::-webkit-input-placeholder {
   color: #fff;
 }


### PR DESCRIPTION
Apparently [placeholder property](https://css-tricks.com/almanac/selectors/p/placeholder/) is not very well standardized.
Fixed the margin overwriting materialize.css rule (thus the infamous `!important` ;-))

Signed-off-by: Kuba Wolanin <hi@kubawolanin.com>