### PR TITLE
explain lowercase filenames for icons in migration tutorial

### DIFF
--- a/configuration/items.md
+++ b/configuration/items.md
@@ -245,7 +245,7 @@ FIRST_QUARTER=🌓 First Quarter
 OpenHAB provides you a set of [basic icons]({{base}}/addons/iconsets/classic/readme.html) by default.
 However if you wish to use custom icons you need to place them inside the `conf/icons/classic/` folder.
 These icons will be used in all of the openHAB frontends.
-The images must be in .png or .svg format, and have a filename with only lowercase characters and a hyphen or underscore (if required).
+The images must be in .png or .svg format, and have a name with only small letters and a hyphen or underscore (if required).
 The PaperUI interface (or via the classicui.cfg or basicui.cfg files) allows you to define whether you use Vector (.svg) or Bitmap (.png) icon files.
 
 As an example, to use a custom icon called `heatpump.svg` the correct syntax is `<heatpump>`.

--- a/configuration/items.md
+++ b/configuration/items.md
@@ -245,7 +245,7 @@ FIRST_QUARTER=🌓 First Quarter
 OpenHAB provides you a set of [basic icons]({{base}}/addons/iconsets/classic/readme.html) by default.
 However if you wish to use custom icons you need to place them inside the `conf/icons/classic/` folder.
 These icons will be used in all of the openHAB frontends.
-The images must be in .png or .svg format, and have a name with only small letters and a hyphen or underscore (if required).
+The images must be in .png or .svg format, and have a filename with only lowercase characters and a hyphen or underscore (if required).
 The PaperUI interface (or via the classicui.cfg or basicui.cfg files) allows you to define whether you use Vector (.svg) or Bitmap (.png) icon files.
 
 As an example, to use a custom icon called `heatpump.svg` the correct syntax is `<heatpump>`.

--- a/tutorials/migration.md
+++ b/tutorials/migration.md
@@ -503,9 +503,10 @@ common Sitemap issue will be missing icons. Browse through your sitemap
 methodically and identify those entries that have a missing or wrong
 icon. Select an alternative from the [defaults]({{base}}/addons/iconsets/classic/readme.html)
 or copy the ones you were using from openHAB 1.x to the conf/icons/classic folder. 
-Make sure that icon filenames are lowercase only.
-Both BasicUI and ClassicUI pull their icons from that folder. For a sitemap that
-most closely resembles your current sitemap I recommend using ClassicUI.
+Both BasicUI and ClassicUI pull their icons from that folder. For details on custom icons make
+sure to check the icons section in the [Items]({{base}}/configuration/items.html#icons) documentation.
+One important change since openHAB 1.x is that icon filenames need to be lowercase only in openHAB 2.
+For a sitemap that most closely resembles your current sitemap I recommend using ClassicUI.
 
 Once you are satisfied that your new openHAB system is up and running take a
 deep breath and take a break. Let it run for a few days or a week and verify

--- a/tutorials/migration.md
+++ b/tutorials/migration.md
@@ -502,7 +502,8 @@ there are no values in the database to restore the Items to when openHAB starts.
 common Sitemap issue will be missing icons. Browse through your sitemap
 methodically and identify those entries that have a missing or wrong
 icon. Select an alternative from the [defaults]({{base}}/addons/iconsets/classic/readme.html)
-or copy the one you were using from openHAB 1.x to the conf/icons/classic folder.
+or copy the ones you were using from openHAB 1.x to the conf/icons/classic folder. 
+Make sure that icon filenames are lowercase only.
 Both BasicUI and ClassicUI pull their icons from that folder. For a sitemap that
 most closely resembles your current sitemap I recommend using ClassicUI.
 

--- a/tutorials/migration.md
+++ b/tutorials/migration.md
@@ -506,7 +506,6 @@ or copy the ones you were using from openHAB 1.x to the conf/icons/classic folde
 Both BasicUI and ClassicUI pull their icons from that folder. For details on custom icons make
 sure to check the icons section in the [Items]({{base}}/configuration/items.html#icons) documentation.
 One important change since openHAB 1.x is that icon filenames need to be lowercase only in openHAB 2.
-For a sitemap that most closely resembles your current sitemap I recommend using ClassicUI.
 
 Once you are satisfied that your new openHAB system is up and running take a
 deep breath and take a break. Let it run for a few days or a week and verify


### PR DESCRIPTION
Pointing out that icons in conf/icons/classic need to be lowercase only. 
Also updated spelling in the icon section of configuration/items