### PR TITLE
Condense add-ons tables by reining in h4; top align cells

### DIFF
--- a/addons/actions.md
+++ b/addons/actions.md
@@ -38,7 +38,7 @@ They are automatically imported and can be used to execute openHAB-specific oper
 {% assign oh1addons = site.data.oh1addons %}
 {% assign legacyaddons = site.data.legacyaddons %}
 
-<table id="actions-overview" class="bordered">
+<table id="actions-overview" class="bordered addon-table">
   <thead>
     <tr>
       <th data-field="label" width="20%">Name</th>

--- a/addons/bindings.md
+++ b/addons/bindings.md
@@ -81,7 +81,7 @@ Bindings connect your smart home's devices and technologies to openHAB.
 {% assign oh1addons = site.data.oh1addons %}
 {% assign legacyaddons = site.data.legacyaddons %}
 
-<table id="bindings-overview" class="bordered">
+<table id="bindings-overview" class="bordered addon-table">
   <thead>
     <tr>
       <th data-field="label" width="20%">Name</th>

--- a/addons/persistence.md
+++ b/addons/persistence.md
@@ -37,7 +37,7 @@ Persistence services enable the storage of item states over time.
 {% assign oh1addons = site.data.oh1addons %}
 {% assign legacyaddons = site.data.legacyaddons %}
 
-<table id="persistence-overview" class="bordered">
+<table id="persistence-overview" class="bordered addon-table">
   <thead>
     <tr>
       <th data-field="label" width="20%">Name</th>

--- a/css/openhab.css
+++ b/css/openhab.css
@@ -31,6 +31,10 @@
   vertical-align: top;
 }
 
+.addon-table p {
+  margin: 0px 0px 0px !important;
+}
+
 /* add-on category initial visibility */
 
 .install-legacy {

--- a/css/openhab.css
+++ b/css/openhab.css
@@ -13,7 +13,25 @@
   color: #039BE5;
 }
 
-/* Binding category initial visibility */
+/* add-on tables */
+
+.addon-table h4 {
+  margin: 0px 0px 5px !important;
+}
+
+.addon-table h4:before {
+  content: none !important;
+}
+
+.addon-table h4:after {
+  content: none !important;
+}
+
+.addon-table td {
+  vertical-align: top;
+}
+
+/* add-on category initial visibility */
 
 .install-legacy {
   display: none;

--- a/css/styles.css
+++ b/css/styles.css
@@ -794,3 +794,11 @@ body.documentation section#documentation h2:after, body.documentation section#do
 body.documentation section#documentation h2:hover:after, body.documentation section#documentation h3:hover:after, body.documentation section#documentation h4:hover:after, body.documentation section#documentation h5:hover:after {
 	visibility: visible;
 }
+
+body.documentation section#documentation .addon-table h4 {
+	margin: -100px 0px 0px 0px;
+}
+
+body.documentation section#documentation .addon-table td {
+	vertical-align: top;
+}

--- a/css/styles.css
+++ b/css/styles.css
@@ -795,10 +795,3 @@ body.documentation section#documentation h2:hover:after, body.documentation sect
 	visibility: visible;
 }
 
-body.documentation section#documentation .addon-table h4 {
-	margin: -100px 0px 0px 0px;
-}
-
-body.documentation section#documentation .addon-table td {
-	vertical-align: top;
-}

--- a/css/styles.css
+++ b/css/styles.css
@@ -794,4 +794,3 @@ body.documentation section#documentation h2:after, body.documentation section#do
 body.documentation section#documentation h2:hover:after, body.documentation section#documentation h3:hover:after, body.documentation section#documentation h4:hover:after, body.documentation section#documentation h5:hover:after {
 	visibility: visible;
 }
-


### PR DESCRIPTION
![condensed](https://cloud.githubusercontent.com/assets/3008217/22626088/6f2e3912-eb9d-11e6-9e71-bc65c9bf7daa.png)

The only other opportunity to further condense the list vertically is to strip off the paragraph tag around the markdownify'd description.

Signed-off-by: John Cocula <john@cocula.com>