### PR TITLE
The Parameter needs to be a number.

### DIFF
--- a/addons/bindings/oh2/pioneeravr/readme.md
+++ b/addons/bindings/oh2/pioneeravr/readme.md
@@ -39,7 +39,7 @@ Configuration of serialAvr:
 Example:
 
 ```
-pioneeravr:ipAvr:vsx921IP [ address="192.168.1.25", tcpPort="23" ]
+pioneeravr:ipAvr:vsx921IP [ address="192.168.1.25", tcpPort=23 ]
 pioneeravr:serialAvr:vsx921Serial [ serialPort="COM9" ]
 ```
 


### PR DESCRIPTION
If using a String the following happens:

2017-02-05 14:36:26.513 [ERROR] [ome.core.thing.internal.ThingManager] - Exception occured while calling thing handler factory 'org.openhab.binding.pioneeravr.internal.handler.AvrHandlerFactory@5ef15132': java.lang.String cannot be cast to java.lang.Number
java.lang.ClassCastException: java.lang.String cannot be cast to java.lang.Number
	at org.openhab.binding.pioneeravr.internal.handler.IpAvrHandler.createConnection(IpAvrHandler.java:31)[210:org.openhab.binding.pioneeravr:2.0.0]

... and it does not work. A number works and this is a fix for the documentation.

Signed-off-by: Oliver Wehrens <oliver@wehrens.de> (github: oliverwehrens)