### PR TITLE
Add redirects for old OH2 binding links

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -12,3 +12,5 @@ exclude: ["CNAME", "pom.xml", "README.md", "CONTRIBUTING.md"]
 gems:
   - jekyll-sitemap
   - jekyll-redirect-from
+whitelist:
+  - jekyll-redirect-from

--- a/_config.yml
+++ b/_config.yml
@@ -11,4 +11,4 @@ exclude: ["CNAME", "pom.xml", "README.md", "CONTRIBUTING.md"]
 # Additional gems for sitemap generation
 gems:
   - jekyll-sitemap
-  
+  - jekyll-redirect-from

--- a/pom.xml
+++ b/pom.xml
@@ -359,7 +359,6 @@
                 						frontMatter = frontMatter + "${key}: ${value}\n"
                 					}
                 					readme.write(frontMatter + "\n---\n&lt;!-- Attention authors: Do not edit directly. Please add your changes to the appropriate source repository --&gt;\n\n{% include base.html %}\n\n" + readme.text)
-                					// readme.write("---\nlayout: documentation\ntitle: ${label} - Bindings\nsource: external\n---\n&lt;!-- Attention authors: Do not edit directly. Please add your changes to the appropriate source repository --&gt;\n\n{% include base.html %}\n\n" + readme.text)
                 				}
                 				bindingList.append(source + ',' + bindingId + ',' + label + ',"' + description + '"\n')
                 			}

--- a/pom.xml
+++ b/pom.xml
@@ -346,7 +346,20 @@
                 			 		}
                 				}
                 				if(!readme.text.startsWith('---')) {
-                					readme.write("---\nlayout: documentation\ntitle: ${label} - Bindings\nsource: external\n---\n&lt;!-- Attention authors: Do not edit directly. Please add your changes to the appropriate source repository --&gt;\n\n{% include base.html %}\n\n" + readme.text)
+                					def front = [
+                						layout: "documentation",
+                						title: "${label} - Bindings",
+                						source: "external",
+                					]
+                					if(source == 'oh2') {
+                						front['redirect_from'] = "\n  - /addons/bindings/${bindingId}/readme.html"
+                					}
+                					def frontMatter = '---\n'
+                					front.each { key, value ->
+                						frontMatter = frontMatter + "${key}: ${value}\n"
+                					}
+                					readme.write(frontMatter + "\n---\n&lt;!-- Attention authors: Do not edit directly. Please add your changes to the appropriate source repository --&gt;\n\n{% include base.html %}\n\n" + readme.text)
+                					// readme.write("---\nlayout: documentation\ntitle: ${label} - Bindings\nsource: external\n---\n&lt;!-- Attention authors: Do not edit directly. Please add your changes to the appropriate source repository --&gt;\n\n{% include base.html %}\n\n" + readme.text)
                 				}
                 				bindingList.append(source + ',' + bindingId + ',' + label + ',"' + description + '"\n')
                 			}


### PR DESCRIPTION
Fixes #295.

Requires installation of [jekyll-redirect-from](https://github.com/jekyll/jekyll-redirect-from) plugin.

Signed-off-by: John Cocula <john@cocula.com>