### PR TITLE
Actions/bindings/persistence docs track feature naming convention

### DIFF
--- a/addons/actions.md
+++ b/addons/actions.md
@@ -65,7 +65,7 @@ They are automatically imported and can be used to execute openHAB-specific oper
         {% endif %}
         <tr class="install-{{install}} source-{{action.source}}">
           <td>
-            <h4><a href="{{base}}/addons/actions/{{ action.source }}/{{ action.id }}/readme.html">{{ action.label }}</a></h4>
+            <h4><a href="{{base}}/addons/actions/{{action.id}}/readme.html">{{action.label}}</a></h4>
             <img src="{{base}}/images/tag-{{action.source}}.svg"> <img src="{{base}}/images/tag-install-{{install}}.svg">
           </td>
           <td>{{ action.description | markdownify }}</td>

--- a/addons/bindings.md
+++ b/addons/bindings.md
@@ -108,7 +108,7 @@ Bindings connect your smart home's devices and technologies to openHAB.
         {% endif %}
         <tr class="install-{{install}} source-{{binding.source}}">
           <td>
-            <h4><a href="{{base}}/addons/bindings/{{ binding.source }}/{{ binding.id }}/readme.html">{{ binding.label }}</a></h4>
+            <h4><a href="{{base}}/addons/bindings/{{binding.id}}{% if binding.source == 'oh1' %}1{% endif %}/readme.html">{{ binding.label }}</a></h4>
             <img src="{{base}}/images/tag-{{binding.source}}.svg"> <img src="{{base}}/images/tag-install-{{install}}.svg">
           </td>
           <td>{{ binding.description | markdownify }}</td>

--- a/addons/persistence.md
+++ b/addons/persistence.md
@@ -64,7 +64,7 @@ Persistence services enable the storage of item states over time.
         {% endif %}
         <tr class="install-{{install}} source-{{persist.source}}">
           <td>
-            <h4><a href="{{base}}/addons/persistence/{{ persist.source }}/{{ persist.id }}/readme.html">{{ persist.label }}</a></h4>
+            <h4><a href="{{base}}/addons/persistence/{{persist.id}}/readme.html">{{ persist.label }}</a></h4>
             <img src="{{base}}/images/tag-{{persist.source}}.svg"> <img src="{{base}}/images/tag-install-{{install}}.svg">
           </td>
           <td>{{ persist.description | markdownify }}</td>

--- a/pom.xml
+++ b/pom.xml
@@ -377,7 +377,8 @@
                 		def name = it.name
                 		if(name.contains('action')) {
                 			def actionId = it.name.replace('org.openhab.action.', '')
-                			def simpleActionNameDir = new File(actions.path, actionId)
+                			def target = new File(project.basedir, 'addons/actions')
+                			def simpleActionNameDir = new File(target.path, actionId)
                 			it.renameTo(simpleActionNameDir)
                 			def readme = new File(simpleActionNameDir.path, 'README.md')
                 			if(readme.exists()) {
@@ -429,7 +430,8 @@
                 		def name = it.name
                 		if(name.contains('persistence') &amp;&amp; !name.endsWith('.test')) {
                 			def persistenceId = it.name.replace('org.openhab.persistence.', '')
-                			def simplePersistenceNameDir = new File(persistence.path, persistenceId)
+                			def target = new File(project.basedir, 'addons/persistence')
+                			def simplePersistenceNameDir = new File(target.path, persistenceId)
                 			it.renameTo(simplePersistenceNameDir)
                 			def readme = new File(simplePersistenceNameDir.path, 'README.md')
                 			if(readme.exists()) {

--- a/pom.xml
+++ b/pom.xml
@@ -324,7 +324,8 @@
                 		def name = it.name
                 		if(name.contains('binding')) {
                 			def bindingId = it.name.replace('org.eclipse.smarthome.binding.', '').replace('org.openhab.binding.', '')
-                			def simpleBindingNameDir = new File(bindings.path, bindingId)
+                			def target = new File(project.basedir, 'addons/bindings')
+                			def simpleBindingNameDir = new File(target.path, (source == 'oh1') ? bindingId + '1' : bindingId)
                 			it.renameTo(simpleBindingNameDir)
                 			def readme = new File(simpleBindingNameDir.path, 'README.md')
                 			if(readme.exists()) {


### PR DESCRIPTION
To keep links to binding docs as they were and to track the feature name of bindings.  The bindings/oh1 and bindings/oh2 subdirectories are now gone.

Fixes #295. This PR supercedes #296.

Should persistence and actions be moved up a level from their current “oh1” directory, since they don’t use the “1” appended to the feature name?  If yes, what happens when new features for persistence or actions are added later in OH2?

Signed-off-by: John Cocula <john@cocula.com>