### PR TITLE
Issue 298

### DIFF
--- a/administration/console.md
+++ b/administration/console.md
@@ -32,12 +32,13 @@ ssh -p 8101 openhab@localhost
 Password authentication
 Password:
 
-                          __  _____    ____
-  ____  ____  ___  ____  / / / /   |  / __ )
- / __ \/ __ \/ _ \/ __ \/ /_/ / /| | / __  |
-/ /_/ / /_/ /  __/ / / / __  / ___ |/ /_/ /
-\____/ .___/\___/_/ /_/_/ /_/_/  |_/_____/
-    /_/                        2.0.0-SNAPSHOT
+                          __  _____    ____      
+  ____  ____  ___  ____  / / / /   |  / __ )     
+ / __ \/ __ \/ _ \/ __ \/ /_/ / /| | / __  | 
+/ /_/ / /_/ /  __/ / / / __  / ___ |/ /_/ /      
+\____/ .___/\___/_/ /_/_/ /_/_/  |_/_____/     
+    /_/                        2.0.0
+                               Release Build   
 
 Hit '<tab>' for a list of available commands
 and '[cmd] --help' for help on a specific command.

--- a/administration/console.md
+++ b/administration/console.md
@@ -16,14 +16,19 @@ The console offers the option to:
 ## Accessing the Console
 
 Accessing the console depends on the start mode of openHAB.
+
+### Started with Script
 The manually start using shell/batch script ends directly in the console.
 
-If openHAB runs a service, the console can be accessed using ssh to the openHAB host on port 8101.
+### Running as Service
+If openHAB runs a service, the console can be accessed using ssh from the openHAB host on localhost:8101. It is intentionally not available from remote hosts due to security concerns.
+
 The default username/password is **openhab/habopen**.
-Be aware, that the first connection attempt may take a few seconds longer.
+
+Be aware that the first connection attempt may take a few seconds longer. It may timeout waiting for authentication the first time.
 
 ```
-ssh openhab@localhost -p 8101
+ssh -p 8101 openhab@localhost
 Password authentication
 Password:
 


### PR DESCRIPTION
Addresses primary usability concern about localhost outlined in #298 
- Clarified in Accessing the Console that Karaf console only binds to localhost
- Moved -p 8101 to more conventional location in ssh command
- Updated console splash screen to 2.0.0 Release version

Formatting checked in MacDown, but not in context of site itself.

Does not address the "suggested additions" outlined in #298 