### PR TITLE
Identify source file in front matter for all OH1 add-ons

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -347,8 +347,13 @@
 		        						}
                 			 		}
                 				}
+                				def toYaml = { '---\n' + it.collect{ /$it.key: $it.value/ }.join('\n') + '\n---\n' }
+                				def front = ['layout': 'documentation', 'title': "${label} - Bindings", 'source': 'external']
+                				if(source == 'oh1') {
+                					front['source'] = "https://github.com/openhab/openhab1-addons/blob/master/bundles/binding/org.openhab.binding.${bindingId}/README.md"
+                				}
                 				if(!readme.text.startsWith('---')) {
-                					readme.write("---\nlayout: documentation\ntitle: ${label} - Bindings\nsource: external\n---\n&lt;!-- Attention authors: Do not edit directly. Please add your changes to the appropriate source repository --&gt;\n\n{% include base.html %}\n\n" + readme.text)
+                					readme.write(toYaml(front) + "&lt;!-- Attention authors: Do not edit directly. Please add your changes to the appropriate source repository --&gt;\n\n{% include base.html %}\n\n" + readme.text)
                 				}
                 				bindingList.append(source + ',' + bindingId + ',' + icon + ',' + label + ',"' + description + '"\n')
                 			}
@@ -401,8 +406,13 @@
 		        						}
                 			 		}
                 				}
+                				def toYaml = { '---\n' + it.collect{ /$it.key: $it.value/ }.join('\n') + '\n---\n' }
+                				def front = ['layout': 'documentation', 'title': "${label} - Actions", 'source': 'external']
+                				if(source == 'oh1') {
+                					front['source'] = "https://github.com/openhab/openhab1-addons/blob/master/bundles/action/org.openhab.action.${actionId}/README.md"
+                				}
                 				if(!readme.text.startsWith('---')) {
-                					readme.write("---\nlayout: documentation\ntitle: ${label} - Actions\nsource: external\n---\n&lt;!-- Attention authors: Do not edit directly. Please add your changes to the appropriate source repository --&gt;\n\n{% include base.html %}\n\n" + readme.text)
+                					readme.write(toYaml(front) + "&lt;!-- Attention authors: Do not edit directly. Please add your changes to the appropriate source repository --&gt;\n\n{% include base.html %}\n\n" + readme.text)
                 				}
                 				actionList.append(source + ',' + actionId + ',' + icon + ',' + label + ',"' + description + '"\n')
                 			}
@@ -455,8 +465,13 @@
 		        						}
                 			 		}
                 				}
+                				def toYaml = { '---\n' + it.collect{ /$it.key: $it.value/ }.join('\n') + '\n---\n' }
+                				def front = ['layout': 'documentation', 'title': "${label} - Persistence", 'source': 'external']
+                				if(source == 'oh1') {
+                					front['source'] = "https://github.com/openhab/openhab1-addons/blob/master/bundles/persistence/org.openhab.persistence.${persistenceId}/README.md"
+                				}
                 				if(!readme.text.startsWith('---')) {
-                					readme.write("---\nlayout: documentation\ntitle: ${label} - Persistence\nsource: external\n---\n&lt;!-- Attention authors: Do not edit directly. Please add your changes to the appropriate source repository --&gt;\n\n{% include base.html %}\n\n" + readme.text)
+                					readme.write(toYaml(front) + "&lt;!-- Attention authors: Do not edit directly. Please add your changes to the appropriate source repository --&gt;\n\n{% include base.html %}\n\n" + readme.text)
                 				}
                 				persistenceList.append(source + ',' + persistenceId + ',' + icon + ',' + label + ',"' + description + '"\n')
                 			}


### PR DESCRIPTION
Attempting to minimize situations like [this](https://github.com/openhab/openhab-docs/pull/327#issuecomment-280059224) by implementing some of what @ThomDietrich requested [here](https://github.com/openhab/openhab-docs/pull/284#issuecomment-276951514):

> (If possible) please add an additional front matter (e.g. "source") directly pointing to the repository file as a full URL. This will be helpful in the above case and for an "Improve this article" button I was thinking about adding.

Same cannot be done for OH2 addons due to multiple repositories, but there may be a solution.

Signed-off-by: John Cocula <john@cocula.com>