### PR TITLE
Fix invalid links to IDE and apps docs (#278)

### DIFF
--- a/addons/uis.md
+++ b/addons/uis.md
@@ -16,9 +16,9 @@ layout: documentation
 
 | App | Description          |
 |---------|----------------------|
-| [Android openHAB App]({{docu}}/addons/apps/android.html) | The native Android app to access openHAB on the go. |
-| [iOS openHAB App]({{docu}}/addons/apps/ios.html) | The native iOS app to access openHAB on the go. |
-| [Windows 10 openHAB App]({{docu}}/addons/apps/windows.html) | The native Windows 10 app to access openHAB on the go. |
+| [Android openHAB App]({{docu}}/addons/uis/apps/android.html) | The native Android app to access openHAB on the go. |
+| [iOS openHAB App]({{docu}}/addons/uis/apps/ios.html) | The native iOS app to access openHAB on the go. |
+| [Windows 10 openHAB App]({{docu}}/addons/uis/apps/windows.html) | The native Windows 10 app to access openHAB on the go. |
 
 
 | Iconset | Description          |

--- a/concepts/guidelines.md
+++ b/concepts/guidelines.md
@@ -18,7 +18,7 @@ Note that this list also serves as a checklist for code reviews on pull requests
 1. Every class, interface and enumeration should have JavaDoc describing its purpose and usage.
 1. Every class, interface and enumeration must have an @author tag in its JavaDoc for every author that wrote a substantial part of the file.
 1. Every constant, field and method with default, protected or public visibility should have JavaDoc (optional, but encouraged for private visibility as well).
-1. Code must be formatted using the provided code formatter and clean up settings. They are set up automatically by the official [IDE setup](ide.html).
+1. Code must be formatted using the provided code formatter and clean up settings. They are set up automatically by the official [IDE setup]({{base}}/developers/development/ide.html).
 1. Generics must be used where applicable.
 1. Code should not show any warnings. Warnings that cannot be circumvented should be suppressed by using the @SuppressWarnings annotation. 
 1. For dependency injection, OSGi Declarative Services should be used.


### PR DESCRIPTION
Does not fix the part of #278 affecting http://www.openhab.org/technologies.html as I think that might belong to another repository and I wouldn't know how to fix it.

Please review the way the relative links were done as I'm new to this mechanism.