### PR TITLE
Addons: Added bindings back to user menu

### DIFF
--- a/_bindings/folding/readme.md
+++ b/_bindings/folding/readme.md
@@ -1,0 +1,45 @@
+---
+id: folding
+label: Folding@home
+title: Folding@home - Bindings
+type: binding
+description: "Binding for the [Folding@home](https://folding.stanford.edu/) distributed computing"
+since: 2x
+install: auto
+---
+
+<!-- Attention authors: Do not edit directly. Please add your changes to the appropriate source repository -->
+
+{% include base.html %}
+
+# Folding@home Binding
+
+Binding for the [Folding@home](https://folding.stanford.edu/) distributed computing
+software.
+
+This binding can control multiple Folding@home clients and slots, using the TCP
+interface. Clients are modeled as bridges, and support adding any number of slots
+(though, usually CPU and GPU). The binding provides control over Run / Pause and
+Finish. It polls for the status of the client, updates the run / pause state, and
+provides a basic description of the slot. 
+
+The clients must be added manually in the Paper UI, but the slots for that 
+client will then appear using auto-discovery.
+
+## Requirements (network access to F@H)
+
+The Folding@home TCP interface is enabled only on localhost by default, without
+a password. In order to allow control of Folding on other machines than the one
+running openHAB, it is necessary to configure the Folding client to accept commands
+from a non-localhost address. Here is how to do it in the FAHControl application:
+
+  * Open FAHControl on the client to be added
+  * Click on Configure, then the Remote Access tab
+  * Enter a password twice (invent one)
+  * Locate the Allow box under IP Address Restrictions
+  * Append a space and the IP address of the machine running openHAB to the text
+    in that box, so it reads something like `127.0.0.1 192.168.1.2`
+
+You should now have access to the client, configure it using the password and
+IP address in the manual thing configuration interface.
+

--- a/_bindings/homematic/readme.md
+++ b/_bindings/homematic/readme.md
@@ -21,25 +21,25 @@ This binding allows you to integrate, view, control and configure all Homematic 
 ## Supported Bridges
 
 All gateways which provides the Homematic BIN- or XML-RPC API: 
-- CCU 1+2 
-- [Homegear](https://www.homegear.eu)
-- [YAHM](https://github.com/leonsio/YAHM)
-- [Windows BidCos service](http://www.eq-3.de/downloads.html?kat=download&id=125)
-- [OCCU](https://github.com/eq-3/occu)
+* CCU 1+2 
+* [Homegear](https://www.homegear.eu)
+* [YAHM](https://github.com/leonsio/YAHM)
+* [Windows BidCos service](http://www.eq-3.de/downloads.html?kat=download&id=125)
+* [OCCU](https://github.com/eq-3/occu)
 
 The Homematic IP Access Point does not support this API and can't be used with this binding. But you can control Homematic IP devices with a CCU2 with at least firmware 2.17.15.
 
 These ports are used by the binding by default to communicate **TO** the gateway:  
-- RF components: 2001
-- WIRED components: 2000
-- HMIP components: 2010 
-- CUxD: 8701
-- TclRegaScript: 8181
-- Groups: 9292
+* RF components: 2001
+* WIRED components: 2000
+* HMIP components: 2010 
+* CUxD: 8701
+* TclRegaScript: 8181
+* Groups: 9292
 
 And **FROM** the gateway to openHab:
-- XML-RPC: 9125
-- BIN-RPC: 9126
+* XML-RPC: 9125
+* BIN-RPC: 9126
 
 **Note:** The binding tries to identify the gateway with XML-RPC and uses henceforth:
 
@@ -118,8 +118,8 @@ The syntax for a bridge is:
 
 ```
 homematic:bridge:NAME
-
 ```
+
 - **homematic** the binding id, fixed
 - **bridge** the type, fixed
 - **name** the name of the bridge
@@ -155,18 +155,19 @@ Bridge homematic:bridge:ccu [ gatewayAddress="..." ]
   Thing HM-LC-Dim1T-Pl-2    JEQ0999999
 }
 ```
+
 The first parameter after Thing is the device type, the second the serial number. If you are using Homegear, you have to add the prefix ```HG-``` for each type.
 
 ```
   Thing HG-HM-LC-Dim1T-Pl-2     JEQ0999999
-
 ```
+
 This is necessary, because the Homegear devices supports more datapoints than Homematic devices.
 
 ```
   Thing HG-HM-LC-Dim1T-Pl-2     JEQ0999999  "Name"  @  "Location"
-
 ```
+
 As additional parameters you can define a name and a location for each thing. The Name will be used to identify the Thing in the Paper UI lists, the Location will be used in the Control section of PaperUI to sort the things.
 
 ### Items
@@ -174,8 +175,8 @@ In the items file, you can map the datapoints, the syntax is:
 
 ```
 homematic:TYPE:BRIDGE:SERIAL:CHANNELNUMBER#DATAPOINTNAME
-
 ```
+
 * **homematic:** the binding id, fixed  
 * **type:** the type of the Homematic device  
 * **bridge:** the name of the bridge  
@@ -187,6 +188,7 @@ homematic:TYPE:BRIDGE:SERIAL:CHANNELNUMBER#DATAPOINTNAME
 Switch  RC_1  "Remote Control Button 1" { channel="homematic:HM-RC-19-B:ccu:KEQ0099999:1#PRESS_SHORT" }
 Dimmer  Light "Light [%d %%]"           { channel="homematic:HM-LC-Dim1T-Pl-2:ccu:JEQ0555555:1#LEVEL" }
 ```
+
 **Note:** don't forget to add the ```HG-``` type prefix for Homegear devices
 
 
@@ -248,38 +250,35 @@ Assumed you mapped the virtual datapoint to a String item called Display_Options
 ```
 String Display_Options "Display_Options" { channel="homematic:HM-RC-19-B:ccu:KEQ0099999:18#DISPLAY_OPTIONS" }
 ```
+
 show message TEST:
 
 ```
 smarthome send Display_Options "TEST"
-
 ```
+
 show message TEXT, beep once and turn backlight on:
 
 ```
 smarthome send Display_Options "TEXT, TONE1, BACKLIGHT_ON"
-
 ```
  
 show message 15, beep once, turn backlight on and shows the celsius unit:
 
 ```
 smarthome send Display_Options "15, TONE1, BACKLIGHT_ON, CELSIUS"
-
 ```
- 
+
 show message ALARM, beep three times, let the backlight blink fast and shows a bell symbol:
 
 ```
 smarthome send Display_Options "ALARM, TONE3, BLINK_FAST, BELL"
-
 ```
- 
+
 Duplicate options: TONE3 is ignored, because TONE1 is specified previously.
 
 ```
 smarthome send Display_Options "TEXT, TONE1, BLINK_FAST, TONE3"
-
 ```
 
 ### Troubleshooting
@@ -303,7 +302,23 @@ The gateway autodetection of the binding can not clearly identify the gateway an
 
 **Variables out of sync**  
 
-The CCU only sends a event if a datapoint of a device has changed. There is (currently) no way to receive a event automatically when a variable has changed. To reload all variables, send a REFRESH command to any variable.
+The CCU only sends a event if a datapoint of a device has changed. There is (currently) no way to receive a event automatically when a variable has changed. To reload all variable values, send a REFRESH command to any variable.  
+e.g you have a item linked to a variable with the name Var_1  
+In the console:
+
+```
+smarthome send Var_1 REFRESH
+```
+
+In scripts:
+
+```
+import org.eclipse.smarthome.core.types.RefreshType
+...
+sendCommand(Var_1, RefreshType.REFRESH)
+```
+
+**Note:** adding new and removing deleted variables from the GATEWAY-EXTRAS Thing is currently not supported. You have to delete the Thing, start a scan and add it again. 
 
 ### Debugging and Tracing
 

--- a/_bindings/network/readme.md
+++ b/_bindings/network/readme.md
@@ -118,8 +118,8 @@ demo.sitemap:
 sitemap demo label="Main Menu"
 {
 	Frame {
-		Switch item=MyDevice
-		Number item=MyDeviceResponseTime
+		Text item=MyDevice label="Device [%s]"
+		Text item=MyDeviceResponseTime label="Device Response Time [%s]"
 	}
 }
 ```

--- a/_bindings/zwave/readme.md
+++ b/_bindings/zwave/readme.md
@@ -13,13 +13,8 @@ install: auto
 
 {% include base.html %}
 
----
-layout: documentation
----
-
-{% include base.html %}
-
 # ZWave Binding
+
 The ZWave binding supports an interface to a wireless Z-Wave home automation network. 
 
 ZWave is a wireless home automation protocol with reliable two way communications between nodes. It supports a mesh network where mains powered nodes can route messages between nodes that could otherwise not communicate with each other. The network supports hop distances of up to four hops.

--- a/_bindings/zway/readme.md
+++ b/_bindings/zway/readme.md
@@ -142,7 +142,7 @@ The following channels represent universial channels if no further device inform
 | sensorBinary      | Switch | Switch       | SensorBinary |
 | sensorMultilevel  | Number | -            | SensorMultilevel |
 | switchBinary      | Switch | Switch       | SwitchBinary |
-| switchMultilevel  | Number | -            | SwitchMultilevel |
+| switchMultilevel  | Dimmer | -            | SwitchMultilevel |
 | switchColor       | Color  | ColorLight   | SwitchRGBW |
 | switchControl     | Switch | Switch       | SwitchControl |
 | thermostat        | Number | Temperature  | Thermostat |

--- a/_includes/user-menu.html
+++ b/_includes/user-menu.html
@@ -60,6 +60,10 @@
       <li><a href="{{docu}}/addons/bindings.html">Bindings</a>
         <ul>
           <li><a href="{{docu}}/addons/bindings.html">Overview</a></li>
+          <hr />
+          {% for binding in site.bindings %}
+          <li><a href="{{ binding.url }}">{{ binding.label }}</a></li>
+          {% endfor %}
         </ul>
       </li>
       <li><a href="{{docu}}/addons/uis.html">User Interfaces</a>

--- a/_uis/habpanel/readme.md
+++ b/_uis/habpanel/readme.md
@@ -1,9 +1,9 @@
 ---
 id: habpanel
-label: Configuration
-title: Configuration - UI
+label: HABPanel
+title: HABPanel - UI
 type: ui
-description: "Unlike Basic UI and other interfaces, HABPanel doesn't use pre-configured sitemaps."
+description: "HABPanel is a lightweight dashboard interface for openHAB."
 since: 2x
 install: auto
 ---
@@ -12,8 +12,7 @@ install: auto
 
 {% include base.html %}
 
-HABPanel
-========
+# HABPanel
 
 HABPanel is a lightweight dashboard interface for openHAB.
 


### PR DESCRIPTION
This addresses https://github.com/openhab/openhab-docs/pull/355#issuecomment-283513476

Also updated a handful of binding docs resulting from `./update.sh`.

@ThomDietrich, the very long list of Bindings in the menu show their duplicate labels as expected, but one way to improve that is to create a new layout, based on the “documentation” layout, perhaps called “addon”, that shows the metadata on the page (like badges if `install` or `since` metadata given, logo if given, “improve this document” button if `source` given).  Then all you have to do to use the new layout is update `_config.yml` for those collections to which you wish to apply the new layout.

With such a layout, readers’ puzzlement over the duplicate labels would be quickly dispelled.  Would you consider adding a new custom “addon” layout?  Should I?

I don’t think adorning the binding menu items themselves with badges or parenthetical metadata would look good.

Signed-off-by: John Cocula <john@cocula.com>