### PR TITLE
Add Synology DS413j to the list of tested devices

### DIFF
--- a/installation/synology.md
+++ b/installation/synology.md
@@ -47,6 +47,7 @@ The configuration files are located at:
 | DS216+II    | [2.0.0-beta3](https://github.com/openhab/openhab-syno-spk/releases/tag/2.0.0-beta3) |
 | DS216+II    | [2.0.0.009-SNAPSHOT-DSM6](https://github.com/openhab/openhab-syno-spk/releases/tag/2.0.0.009-SNAPSHOT-DSM6) |
 | DS216play   | [2.0.0.001-DSM6](https://github.com/openhab/openhab-syno-spk/releases/tag/2.0.0.001-DSM6) |
+| DS413j      | [2.0.0.001-DSM6](https://github.com/openhab/openhab-syno-spk/releases/tag/2.0.0.001-DSM6) |
 | DS916+      | [2.0.0.001-DSM6](https://github.com/openhab/openhab-syno-spk/releases/tag/2.0.0.001-DSM6) |
 
 > Please complete the list accordingly, thank you!


### PR DESCRIPTION
I have installed openhab on a Synology DS413j using the instructions in this documentation using 2.0.0.001-DSM6 with no problems.