### PR TITLE
Add note on 'System started' trigger

### DIFF
--- a/configuration/rules-dsl.md
+++ b/configuration/rules-dsl.md
@@ -149,7 +149,7 @@ Two system-based triggers are provided as described in the table below:
 
 Trigger  |  Description
 ---------|-------------
-System started | Rules using the 'System started' trigger exeucte when openHAB starts and when changes or additions to *any* rule are recognized by openHab.  This is normal behaivor and should be anticipated when writing rules using this trigger.
+System started | Rules using the 'System started' trigger exeucte when openHAB starts and when changes or additions to *any* rule are recognized by openHAB.  This is normal behaivor and should be anticipated when writing rules using this trigger.
 System shuts down| Rules using the 'System shuts down' trigger execute when openHAB shuts down.
 
 ## Scripts

--- a/configuration/rules-dsl.md
+++ b/configuration/rules-dsl.md
@@ -151,6 +151,7 @@ Currently, you schedule rules to be executed either at system startup or shutdow
 System started
 System shuts down
 ```
+These system-based triggers work as expected.  Rules using the 'System started' trigger execute when openHAB starts.  Rules using the 'System shuts down' trigger execute as openHAB shuts down.  Additionally, rules using the 'System Started' trigger will execute when changes or additions to rules files are recognized by openHAB.  This is normal behavior and should be anticipated when writing rules using these triggers.
 
 ## Scripts
 

--- a/configuration/rules-dsl.md
+++ b/configuration/rules-dsl.md
@@ -145,13 +145,12 @@ You may also use [CronMaker](http://www.cronmaker.com/) or the generator at [Fre
 
 ### System-based Triggers
 
-Currently, you schedule rules to be executed either at system startup or shutdown. Note that newly added or modified startup rules are executed once, even if openHAB is already up and running. They are simply executed once as soon as the system is aware of them. Here's the syntax for system triggers:
+Two system-based triggers are provided as described in the table below:
 
-```java
-System started
-System shuts down
-```
-These system-based triggers work as expected.  Rules using the 'System started' trigger execute when openHAB starts.  Rules using the 'System shuts down' trigger execute as openHAB shuts down.  Additionally, rules using the 'System Started' trigger will execute when changes or additions to rules files are recognized by openHAB.  This is normal behavior and should be anticipated when writing rules using these triggers.
+Trigger  |  Description
+---------|-------------
+System started | Rules using the 'System started' trigger exeucte when openHAB starts and when changes or additions to *any* rule are recognized by openHab.  This is normal behaivor and should be anticipated when writing rules using this trigger.
+System shuts down| Rules using the 'System shuts down' trigger execute when openHAB shuts down.
 
 ## Scripts
 

--- a/configuration/rules-dsl.md
+++ b/configuration/rules-dsl.md
@@ -149,8 +149,23 @@ Two system-based triggers are provided as described in the table below:
 
 Trigger  |  Description
 ---------|-------------
-System started | Rules using the 'System started' trigger exeucte when openHAB starts and when changes or additions to *any* rule are recognized by openHAB.  This is normal behaivor and should be anticipated when writing rules using this trigger.
+System started | System started is triggered upon openHAB startup, after the rule file containing the System started trigger is modified, or after item(s) related to that rule file are modified in a .items file.
 System shuts down| Rules using the 'System shuts down' trigger execute when openHAB shuts down.
+
+You may wish to use the 'System started' trigger to initialize values at startup if they are not already set.
+
+Example: 
+
+```java
+rule "Speedtest init"
+when
+    System started
+then
+    createTimer(now.plusSeconds(30)) [|
+        if (Speedtest_Summary.state == NULL || Speedtest_Summary.state == "") Speedtest_Summary.postUpdate("unknown")
+    ]
+end
+```
 
 ## Scripts
 


### PR DESCRIPTION
The 'System started' trigger causes actions to execute when the system is started (i.e. a reboot).  But the trigger also fires when alterations are made to any rules files.  This could lead to unanticipated system behavior, since users may expect that the only time the trigger would fire is when the system initializes for the first time.

Sign-off: Signed-off-by: Brad Gilmer brad@gilmer.tv (github: bgilmer77)