### PR TITLE
Adding description on using sendCommand/postUpdate fixes #185

### DIFF
--- a/configuration/rules-dsl.md
+++ b/configuration/rules-dsl.md
@@ -179,7 +179,30 @@ end
 ```
 
 
-## Manipulating Item States
+## Scripts
+
+The expression language used within scripts is the same that is used in the Xtend language - see the [documentation of expressions](http://www.eclipse.org/xtend/documentation/203_xtend_expressions.html) on the Xtend homepage.
+
+The syntax is very similar to Java, but has many nice features that allows writing concise code.
+It is especially powerful in handling collections.
+What makes it a good match for openHAB from a technical perspective is the fact that there is no need to compile the scripts as they can be interpreted at runtime.
+
+To be able to do something useful with the scripts, openHAB provides access to
+
+- all defined items, so that you can easily access them by their name
+- all enumerated states/commands, e.g. `ON, OFF, DOWN, INCREASE` etc.
+- all [standard actions](https://github.com/openhab/openhab/wiki/Actions) to make something happen
+
+Combining these features, you can easily write code like:
+
+```java
+if (Temperature.state < 20) {
+    Heating.sendCommand(ON)
+}
+```
+
+{: #manipulating-item-states}
+### Manipulating Item States
 
 Rules are often used to manipulate the state of an Item, for example switching lights on and off under certain conditions.
 Two commands can change the value or state of an Item within rules:
@@ -200,7 +223,7 @@ The following table summarizes the impact of the two manipulator commands on the
 Besides the specific manipulator command methods `MyItem.sendCommand(<new_state>)` and `MyItem.postUpdate(<new_state>)`, generic manipulators in the form of `sendCommand(MyItem, <new_state>)` and `postUpdate(MyItem, <new_state>)` are available. The specific versions is normally recommended.
 
 {: #sendcommand-method-vs-action}
-### MyItem.sendCommand("new state") versus sendCommand(MyItem, "new state")
+#### MyItem.sendCommand("new state") versus sendCommand(MyItem, "new state")
 
 Using the methods `MyItem.sendCommand(<new_state>)` and `MyItem.postUpdate(<new_state>)` is often preferable.
 These are methods of Objects that can accept a variety of types.
@@ -232,63 +255,6 @@ For example, if the name of the Item to receive an update or command was calcula
 ```java
 val int index = 5
 sendCommand("My_Lamp_" + index, ON)
-```
-
-#### Details:
-
-As all object-oriented computer languages, Java and the Rules DSL have implemented the concept of inheritance. 
-However, inheritance only applies to Objects and does **not** apply to primitives. 
-Inheritance allows to take an existing Object type, called a Class, and adding to it to make it into something different. 
-This “something different” becomes a Child of the original Class, the parent. The Child still can do everything the parent could do. 
-The top level base Class for all Objects in Java and the Rules DSL is called simply `Object`. 
-
-In addition to other useful things, the class `Object` implements a method called `toString`. 
-And since `Object` is the parent of all Objects, ALL Classes also implement a `toString` method. 
-_However primitives do not inherit from Object. 
-They don't inherit from anything and they don't have any methods at all which includes the lack of a toString Method._
-
-The `sendCommand` is a generic action and needs to be able to work with all Item types. 
-Actions only support two String arguments as all Objects will support the conversion `toString`. 
-`sendCommand (MyItem, new_state)` will automatically use the `MyItem.toString` method to convert MyItem into a String. 
-It will also attempt to do so with the second argument if `new_state` is not already a String. 
-However, if the second argument is a primitive, and not an Object, it does not carry a method `toString`. 
-Thus, Rules DSL will not be able to cast `new_state` as a String. 
-As a consequence, the use of `sendCommand(MyItem, primitive)`, using a primitive as the second argument, will almost always fail. 
-
-The different syntax for the generic and the objective-specific differs and is given in the table below:
-
-| Generic (Action)                 | Specific (Method)               |
-|----------------------------------|---------------------------------|
-| `postUpdate(MyItem, new_state)`  | `MyItem.postUpdate(new_state)`  |
-| `sendCommand(MyItem, new_state)` | `MyItem.sendCommand(new_state)` |
-
-`MyTimes.sendCommand()`, however, will use the `sendCommand` method that is suitable to make the necessary type conversions.
-For example, the `NumberItem` class would have a `sendCommand(int)`, `sendCommand(long)`, `sendCommand(float)`, `sendCommand(double)`, `sendCommand(Number)`, `sendCommand(DecimalType)`, and `sendCommand(String)` method. 
-Each of these separate methods is individually written to handle all of these different types of Objects. 
-MyItem will automatically apply the method that corresponds to the argument type.
-
-In a nutshell, using the syntax `MyItem.sendCommand(new_state)` or `MyItem.sendUpdate(new_state)` will help avoid many problems.
-
-## Scripts
-
-The expression language used within scripts is the same that is used in the Xtend language - see the [documentation of expressions](http://www.eclipse.org/xtend/documentation/203_xtend_expressions.html) on the Xtend homepage.
-
-The syntax is very similar to Java, but has many nice features that allows writing concise code.
-It is especially powerful in handling collections.
-What makes it a good match for openHAB from a technical perspective is the fact that there is no need to compile the scripts as they can be interpreted at runtime.
-
-To be able to do something useful with the scripts, openHAB provides access to
-
-- all defined items, so that you can easily access them by their name
-- all enumerated states/commands, e.g. `ON, OFF, DOWN, INCREASE` etc.
-- all [standard actions](https://github.com/openhab/openhab/wiki/Actions) to make something happen
-
-Combining these features, you can easily write code like:
-
-```java
-if (Temperature.state < 20) {
-    Heating.sendCommand(ON)
-}
 ```
 
 {: #implicit-variables}

--- a/configuration/rules-dsl.md
+++ b/configuration/rules-dsl.md
@@ -213,7 +213,7 @@ As this may, however, not always be possible, here a more nuanced guidance:
 
 As all object-oriented computer languages, Java and the Rules DSL have implemented the concept of inheritance. However, inheritance only applies to Objects and does **not** apply to primitives. Inheritance allows to take an existing Object type, called a Class, and adding to it to make it into something different. This “something different” becomes a Child of the original Class. The Child still can do everything the existing Object could do. The top level base Class for all Objects in Java and the Rules DSL is called simply `Object`. The Child can be treated as if it were the parent because everything the parent can do the child can do too.
 
-In addition to other useful things, teh calss `Object` implements a method called `toString`. And since `Object` is the parent of all Objects, ALL Classes also implement a `toString` method. _However primitives do not inherit from Object. They don't inherit from anything and they don't have any methods at all which includes the lack of a toString Method._
+In addition to other useful things, the class `Object` implements a method called `toString`. And since `Object` is the parent of all Objects, ALL Classes also implement a `toString` method. _However primitives do not inherit from Object. They don't inherit from anything and they don't have any methods at all which includes the lack of a toString Method._
 
 The `sendCommand` is a generic action and therefore, by definition, needs to be able to work with all Item types. Action only supports two String arguments as all Objects will support the conversion `toString`. If the Action `sendCommand (MyItem, new_state)` is called, the Rules DSL will automatically use the `MyItem.toString` method to convert MyItem into a String. It will also attempt to do so with the second argument if `new_state` is not already a String. However, if the second argument is a primitive, and not an Object it does not carry a method `toString`. Thus, Rules DSL will not be able to cast `new_state` as a String. As a consequence, the use of `sendCommand(MyItem, primitive)`, with the use of a primitive as the second argument, will almost always fail. 
 
@@ -221,8 +221,8 @@ The different syntax for the generic and the objective-specific differs and is g
 
 Generic (Action) | Specific (Method)
 -----------|-----------
-`postUpdate(MyItem, "new_state")` | `MyItem.postUpdate(new_state)`
-`sendCommand(MyItem, "new_state")` | `MyItem.sendCommand(new_state)`
+`postUpdate(MyItem, new_state)` | `MyItem.postUpdate(new_state)`
+`sendCommand(MyItem, new_state)` | `MyItem.sendCommand(new_state)`
 
 By invoking the method `sendCommand` method from Items (`MyTimes.send Command()`) the Item will use the `sendCommand` method that is suitable to make the necessary type conversions. For example, the `NumberItem` class would have a `sendCommand(int)`, `sendCommand(long)`, `sendCommand(float)`, `sendCommand(double)`, `sendCommand(Number)`, `sendCommand(DecimalType)`, and `sendCommand(String)` methods. Each of these separate methods is individually written to handle all of these different types of Objects. MyItem will automatically apply the method that corresponds to the argument type.
 

--- a/configuration/rules-dsl.md
+++ b/configuration/rules-dsl.md
@@ -181,13 +181,18 @@ end
 
 ## Manipulating Item States
 
-Rules are often designed to manipulate the state of Items, for example switching lights on or off. Two commands can change the value or state of an Item within rules: `sendCommand` and `postUpdate`. The full syntax is: 
+Rules are often designed to manipulate the state of Items, for example switching lights on or off. 
+Two commands can change the value or state of an Item within rules: `sendCommand` and `postUpdate`. 
+The full syntax is: 
 * `MyItem.postUpdate(new_state)`
 * `MyItem.sendCommand(new_state)`
 
-A `postUpdate` changes the status of an item without causing any further action. This can be used to reflect changes that may be caused by other means (physically switch on a light). A `sendCommand` will cause a change in status and trigger potential actions. 
+A `postUpdate` changes the status of an item without causing any further action. 
+This can be used to reflect changes that may be caused by other means (physically switch on a light). 
+A `sendCommand` will cause a change in status and trigger potential actions. 
 
-`sendCommand` and `postUpdate` interact in different ways with (event-based rule triggers)[{{base}}/configuration/rules-dsl.html#event-based-triggers]. The following table summarizes the interactions between commands and triggers:
+`sendCommand` and `postUpdate` interact in different ways with (event-based rule triggers)[{{base}}/configuration/rules-dsl.html#event-based-triggers]. 
+The following table summarizes the interactions between commands and triggers:
 
 Command | trigger: received update | trigger: received command
 --------|--------|--------
@@ -197,23 +202,51 @@ sendCommand | - |fires
 
 ### MyItem.sendCommand("new state") versus sendCommand(MyItem, "new state")
 
-Using the methods`MyItem.sendCommand(new_state)` and `MyItem.postUpdate(new_state)` is often preferable. These are methods of Objects that can accept a variety of types. Contrary, the Actions `sendCommand ("MyItem", "new_state")` and `postUpdate ("MyItem", "new_state")` can only accept strings as arguments. The reasons lie within Java, the object-oriented program language on which openHAB is built. Java and the Rules DSL have two basic types, primitives and Objects. A lower case letter after a `var` or a `val` statement, for example `var int`, indicates a primitive type. An upper case letter after a `val` and `var` statement, for example `var Number` indicates an Object. Objects are more complex than primitives. Objects have methods associated that among others can make many necessary type conversions. Using `Myitem.sendCommand(new_state)` or `Myitem.postUpdate(new_state)` can in most cases convert `new state` into a type that Object `myItem` can apply. 
+Using the methods`MyItem.sendCommand(new_state)` and `MyItem.postUpdate(new_state)` is often preferable. 
+These are methods of Objects that can accept a variety of types. 
+Contrary, the Actions `sendCommand ("MyItem", "new_state")` and `postUpdate ("MyItem", "new_state")` can only accept strings as arguments. 
+The reasons lie within Java, the object-oriented program language on which openHAB is built. 
+Java and the Rules DSL have two basic types, primitives and Objects. 
+A lower case letter after a `var` or a `val` statement, for example `var int`, indicates a primitive type. 
+An upper case letter after a `val` and `var` statement, for example `var Number` indicates an Object. 
+Objects are more complex than primitives. 
+Objects have methods associated that among others can make many necessary type conversions. 
+Using `Myitem.sendCommand(new_state)` or `Myitem.postUpdate(new_state)` can in most cases convert `new state` into a type that Object `myItem` can apply. 
 
-The Action `sendCommand(MyItem, new_state)` does not provide the same flexibilty. For example, if `new_state` is typed as a primitive (e.g., `var int new_state = 3`) and myItem is of the Object type Dimmer: 
+The Action `sendCommand(MyItem, new_state)` does not provide the same flexibilty. 
+For example, if `new_state` is typed as a primitive (e.g., `var int new_state = 3`) and myItem is of the Object type Dimmer: 
 * the following command ***will fail***: ~~sendCommand(MyItem, new_state)~~. 
 * However, the following command **will work**: `MyItem.sendCommand(new_state)`. 
 
-Using `MyItem.postUpdate(new_state)` or `MyItem.sendCommand(new_state)` will create the most stable code. It provides by far the best option for avoiding most problems. This syntax ensures that any conversion (typing) of the `new_state` is done in a way that is most suitable for `myItem`. 
+Using `MyItem.postUpdate(new_state)` or `MyItem.sendCommand(new_state)` will create the most stable code. 
+It provides by far the best option for avoiding most problems. 
+This syntax ensures that any conversion (typing) of the `new_state` is done in a way that is most suitable for `myItem`. 
 
-However, Actions are useful when only the name of the Item as a String is available. For example, if the name of the Item to receive an update or command was calculated in the Rule by building up a String. Methods are preferable when the reference to the Item is directly is available. For example, if it is hard coded or the Item was retreived from a Group.
+However, Actions are useful when only the name of the Item as a String is available. 
+For example, if the name of the Item to receive an update or command was calculated in the Rule by building up a String.
+Methods are preferable when the reference to the Item is directly is available. 
+For example, if it is hard coded or the Item was retreived from a Group.
 
 ### Details:
 
-As all object-oriented computer languages, Java and the Rules DSL have implemented the concept of inheritance. However, inheritance only applies to Objects and does **not** apply to primitives. Inheritance allows to take an existing Object type, called a Class, and adding to it to make it into something different. This “something different” becomes a Child of the original Class, the parent. The Child still can do everything the parent could do. The top level base Class for all Objects in Java and the Rules DSL is called simply `Object`. 
+As all object-oriented computer languages, Java and the Rules DSL have implemented the concept of inheritance. 
+However, inheritance only applies to Objects and does **not** apply to primitives. 
+Inheritance allows to take an existing Object type, called a Class, and adding to it to make it into something different. 
+This “something different” becomes a Child of the original Class, the parent. The Child still can do everything the parent could do. 
+The top level base Class for all Objects in Java and the Rules DSL is called simply `Object`. 
 
-In addition to other useful things, the class `Object` implements a method called `toString`. And since `Object` is the parent of all Objects, ALL Classes also implement a `toString` method. _However primitives do not inherit from Object. They don't inherit from anything and they don't have any methods at all which includes the lack of a toString Method._
+In addition to other useful things, the class `Object` implements a method called `toString`. 
+And since `Object` is the parent of all Objects, ALL Classes also implement a `toString` method. 
+_However primitives do not inherit from Object. 
+They don't inherit from anything and they don't have any methods at all which includes the lack of a toString Method._
 
-The `sendCommand` is a generic action and needs to be able to work with all Item types. Actions only support two String arguments as all Objects will support the conversion `toString`. `sendCommand (MyItem, new_state)` will automatically use the `MyItem.toString` method to convert MyItem into a String. It will also attempt to do so with the second argument if `new_state` is not already a String. However, if the second argument is a primitive, and not an Object, it does not carry a method `toString`. Thus, Rules DSL will not be able to cast `new_state` as a String. As a consequence, the use of `sendCommand(MyItem, primitive)`, using a primitive as the second argument, will almost always fail. 
+The `sendCommand` is a generic action and needs to be able to work with all Item types. 
+Actions only support two String arguments as all Objects will support the conversion `toString`. 
+`sendCommand (MyItem, new_state)` will automatically use the `MyItem.toString` method to convert MyItem into a String. 
+It will also attempt to do so with the second argument if `new_state` is not already a String. 
+However, if the second argument is a primitive, and not an Object, it does not carry a method `toString`. 
+Thus, Rules DSL will not be able to cast `new_state` as a String. 
+As a consequence, the use of `sendCommand(MyItem, primitive)`, using a primitive as the second argument, will almost always fail. 
 
 The different syntax for the generic and the objective-specific differs and is given in the table below:
 
@@ -222,7 +255,10 @@ Generic (Action) | Specific (Method)
 `postUpdate(MyItem, new_state)` | `MyItem.postUpdate(new_state)`
 `sendCommand(MyItem, new_state)` | `MyItem.sendCommand(new_state)`
 
-`MyTimes.sendCommand()`, however, will use the `sendCommand` method that is suitable to make the necessary type conversions. For example, the `NumberItem` class would have a `sendCommand(int)`, `sendCommand(long)`, `sendCommand(float)`, `sendCommand(double)`, `sendCommand(Number)`, `sendCommand(DecimalType)`, and `sendCommand(String)` method. Each of these separate methods is individually written to handle all of these different types of Objects. MyItem will automatically apply the method that corresponds to the argument type.
+`MyTimes.sendCommand()`, however, will use the `sendCommand` method that is suitable to make the necessary type conversions.
+For example, the `NumberItem` class would have a `sendCommand(int)`, `sendCommand(long)`, `sendCommand(float)`, `sendCommand(double)`, `sendCommand(Number)`, `sendCommand(DecimalType)`, and `sendCommand(String)` method. 
+Each of these separate methods is individually written to handle all of these different types of Objects. 
+MyItem will automatically apply the method that corresponds to the argument type.
 
 In a nutshell, using the syntax `MyItem.sendCommand(new_state)` or `MyItem.sendUpdate(new_state)` will help avoid many problems.
 

--- a/configuration/rules-dsl.md
+++ b/configuration/rules-dsl.md
@@ -181,13 +181,13 @@ end
 
 ## Manipulating Item States
 
-Rules are often designed to manipulate the state of Items, for example switching lights on and off. The two commands that can change the value or state of an Item within rules are `sendCommand` and `postUpdate`. The full syntax is: 
+Rules are often designed to manipulate the state of Items, for example switching lights on or off. Two commands can change the value or state of an Item within rules: `sendCommand` and `postUpdate`. The full syntax is: 
 * `MyItem.postUpdate(new_state)`
 * `MyItem.sendCommand(new_state)`
 
-A `postUpdate` is used to change the status of an item without causing any further action. This can be used to reflect changes that may be caused by other means (physically switch on a light). A `sendCommand` will cause a change in status and trigger potential actions. 
+A `postUpdate` changes the status of an item without causing any further action. This can be used to reflect changes that may be caused by other means (physically switch on a light). A `sendCommand` will cause a change in status and trigger potential actions. 
 
-It is important to understand that `sendCommand` and `postUpdate` interact in different ways with (event-based rule triggers)[{{base}}/configuration/rules-dsl.html#event-based-triggers]. The following table summarizes the interactions between commands and triggers:
+`sendCommand` and `postUpdate` interact in different ways with (event-based rule triggers)[{{base}}/configuration/rules-dsl.html#event-based-triggers]. The following table summarizes the interactions between commands and triggers:
 
 Command | trigger: received update | trigger: received command
 --------|--------|--------
@@ -197,25 +197,23 @@ sendCommand | - |fires
 
 ### MyItem.sendCommand("new state") versus sendCommand(MyItem, "new state")
 
-Using the methods`MyItem.sendCommand(new_state)` and `MyItem.postUpdate(new_state)` is often preferable. These are methods of Objects that can accept a variety of types. On the other hand, the Actions `sendCommand ("MyItem", "new_state")` and `postUpdate ("MyItem", "new_state")` can only accept strings as arguments. The reasons lie within Java, the object-oriented program language on which openHAB and its Items, Rules, etc are built. Java and the Rules DSL have two basic types, primitives and Objects. Any lower case type after a `var` or a `val` statement, for example `var int` or `var boolean` indicates a primitive type. Any upper case type after a `val` and `var` statement, for example `var String`, `var Number`) indicates an Object. Objects are more complex than primitives and have methods associated that among others can make many necessary type conversions. The syntax `Myitem.sendCommand(new_state)` or `Myitem.postUpdate(new_state)` ensures that the most appropriate and best method to convert/type the `new state` into the structure that is needed by the object `myItem`. 
+Using the methods`MyItem.sendCommand(new_state)` and `MyItem.postUpdate(new_state)` is often preferable. These are methods of Objects that can accept a variety of types. Contrary, the Actions `sendCommand ("MyItem", "new_state")` and `postUpdate ("MyItem", "new_state")` can only accept strings as arguments. The reasons lie within Java, the object-oriented program language on which openHAB is built. Java and the Rules DSL have two basic types, primitives and Objects. A lower case letter after a `var` or a `val` statement, for example `var int`, indicates a primitive type. An upper case letter after a `val` and `var` statement, for example `var Number` indicates an Object. Objects are more complex than primitives. Objects have methods associated that among others can make many necessary type conversions. Using `Myitem.sendCommand(new_state)` or `Myitem.postUpdate(new_state)` can in most cases convert `new state` into a type that Object `myItem` can apply. 
 
-The syntax, `sendCommand(MyItem, new_state)` applies only a set of generic methods, which are not able to accommodate all cases of conversion that may be necessary to make sure that `new_state` can be applied to `myItem`. For example, if `new_state` is typed as a primitive (e.g., `var int new_state = 3`) and myItem is of the type Dimmer (note the capitalized ‘D’ denoting an object): 
+The Action `sendCommand(MyItem, new_state)` does not provide the same flexibilty. For example, if `new_state` is typed as a primitive (e.g., `var int new_state = 3`) and myItem is of the Object type Dimmer: 
 * the following command ***will fail***: ~~sendCommand(MyItem, new_state)~~. 
 * However, the following command **will work**: `MyItem.sendCommand(new_state)`. 
 
 Using `MyItem.postUpdate(new_state)` or `MyItem.sendCommand(new_state)` will create the most stable code. It provides by far the best option for avoiding most problems. This syntax ensures that any conversion (typing) of the `new_state` is done in a way that is most suitable for `myItem`. 
 
-As this may, however, not always be possible, here a more nuanced guidance:
-* Actions: are suitable when only the name of the Item as a String is available, for example when the name of the Item to receive an update or command was calculated in the Rule by building up a String.
-* Methods: are preferable when the reference to the Item directly is available because its name is hard coded or the Item was retreived from a Group.
+However, Actions are useful when only the name of the Item as a String is available. For example, if the name of the Item to receive an update or command was calculated in the Rule by building up a String. Methods are preferable when the reference to the Item is directly is available. For example, if it is hard coded or the Item was retreived from a Group.
 
 ### Details:
 
-As all object-oriented computer languages, Java and the Rules DSL have implemented the concept of inheritance. However, inheritance only applies to Objects and does **not** apply to primitives. Inheritance allows to take an existing Object type, called a Class, and adding to it to make it into something different. This “something different” becomes a Child of the original Class. The Child still can do everything the existing Object could do. The top level base Class for all Objects in Java and the Rules DSL is called simply `Object`. The Child can be treated as if it were the parent because everything the parent can do the child can do too.
+As all object-oriented computer languages, Java and the Rules DSL have implemented the concept of inheritance. However, inheritance only applies to Objects and does **not** apply to primitives. Inheritance allows to take an existing Object type, called a Class, and adding to it to make it into something different. This “something different” becomes a Child of the original Class, the parent. The Child still can do everything the parent could do. The top level base Class for all Objects in Java and the Rules DSL is called simply `Object`. 
 
 In addition to other useful things, the class `Object` implements a method called `toString`. And since `Object` is the parent of all Objects, ALL Classes also implement a `toString` method. _However primitives do not inherit from Object. They don't inherit from anything and they don't have any methods at all which includes the lack of a toString Method._
 
-The `sendCommand` is a generic action and therefore, by definition, needs to be able to work with all Item types. Action only supports two String arguments as all Objects will support the conversion `toString`. If the Action `sendCommand (MyItem, new_state)` is called, the Rules DSL will automatically use the `MyItem.toString` method to convert MyItem into a String. It will also attempt to do so with the second argument if `new_state` is not already a String. However, if the second argument is a primitive, and not an Object it does not carry a method `toString`. Thus, Rules DSL will not be able to cast `new_state` as a String. As a consequence, the use of `sendCommand(MyItem, primitive)`, with the use of a primitive as the second argument, will almost always fail. 
+The `sendCommand` is a generic action and needs to be able to work with all Item types. Actions only support two String arguments as all Objects will support the conversion `toString`. `sendCommand (MyItem, new_state)` will automatically use the `MyItem.toString` method to convert MyItem into a String. It will also attempt to do so with the second argument if `new_state` is not already a String. However, if the second argument is a primitive, and not an Object, it does not carry a method `toString`. Thus, Rules DSL will not be able to cast `new_state` as a String. As a consequence, the use of `sendCommand(MyItem, primitive)`, using a primitive as the second argument, will almost always fail. 
 
 The different syntax for the generic and the objective-specific differs and is given in the table below:
 
@@ -224,9 +222,9 @@ Generic (Action) | Specific (Method)
 `postUpdate(MyItem, new_state)` | `MyItem.postUpdate(new_state)`
 `sendCommand(MyItem, new_state)` | `MyItem.sendCommand(new_state)`
 
-By invoking the method `sendCommand` method from Items (`MyTimes.send Command()`) the Item will use the `sendCommand` method that is suitable to make the necessary type conversions. For example, the `NumberItem` class would have a `sendCommand(int)`, `sendCommand(long)`, `sendCommand(float)`, `sendCommand(double)`, `sendCommand(Number)`, `sendCommand(DecimalType)`, and `sendCommand(String)` methods. Each of these separate methods is individually written to handle all of these different types of Objects. MyItem will automatically apply the method that corresponds to the argument type.
+`MyTimes.sendCommand()`, however, will use the `sendCommand` method that is suitable to make the necessary type conversions. For example, the `NumberItem` class would have a `sendCommand(int)`, `sendCommand(long)`, `sendCommand(float)`, `sendCommand(double)`, `sendCommand(Number)`, `sendCommand(DecimalType)`, and `sendCommand(String)` method. Each of these separate methods is individually written to handle all of these different types of Objects. MyItem will automatically apply the method that corresponds to the argument type.
 
-In a nutshell, using the syntax `MyItem.sendCommand(new_state)` or `MyItem.sendUpdate(new_state)` will help avoid many problems that the generic method may cause.
+In a nutshell, using the syntax `MyItem.sendCommand(new_state)` or `MyItem.sendUpdate(new_state)` will help avoid many problems.
 
 
 ## Scripts

--- a/configuration/rules-dsl.md
+++ b/configuration/rules-dsl.md
@@ -182,8 +182,8 @@ end
 ## Causing effects on items
 
 Rules come to life by generating events to cause something else to happen, to cause effects. For example, change the state of an item or switch on a light at sunset. The two most common commands that can change item values or states within rules are `sendCommand` and `postUpdate`. The full syntax to use them is: 
-* `MyItem.postUpdate("new state")`
-* `MyItem.sendCommand("new state")`
+* `MyItem.postUpdate(new_state)`
+* `MyItem.sendCommand(new_state)`
 
 A `postUpdate` is used to change the status of an item without causing any further action. `postUpdate` is used to update openHAB Items to reflect any status changes that may be caused by other means (physically switch on a light) or to indicate state changes that do not require a corresponding action. A `sendCommand` will cause a change in status and trigger potential actions. 
 
@@ -191,36 +191,36 @@ It is important to understand that they act slightly different and interact in s
 
 ### MyItem.sendCommand("new state") versus sendCommand(MyItem, "new state")
 
-`MyItem.sendCommand("new state")` and `myItem.postUpdate("new state")` are the preferred syntax. These are methods of objects that can a variety of types, depending on the items, while the Actions `sendCommand ("MyItem", "new state")` and `postUpdate ("MyItem", "new state")` can only accept strings as arguments. The reasons lie within Java, the object-oriented program languages on which openHab and its items, rules, etc are built. Java and the Rules DSL have two basic types, primitives and objects. Whenever there is a type after a `var` or a `val` statement with lower-case first letter (e.g., `var int` or `var boolean`) we are dealing with a primitive type. Whenever the `val` and `var` are followed with type in upper-case (e.g., `var String`, `var Number`), the type is an object. This means that items are objects. Objects are more complex than simple variables and have methods associated with them that enable interaction with objects, as for example changing the state of an item. The syntax `Myitem.sendCommand` or `Myitem.postUpdate` ensures that the most appropriate and best method to convert/type the `new state` into the structure that is needed by the object (here `myItem`). 
+`MyItem.sendCommand(new_state)` and `MyItem.postUpdate(new_state)` are the preferred syntax. These are methods of objects that can a variety of types, depending on the items, while the Actions `sendCommand ("MyItem", "new_state")` and `postUpdate ("MyItem", "new_state")` can only accept strings as arguments. The reasons lie within Java, the object-oriented program language on which openHAB and its items, rules, etc are built. Java and the Rules DSL have two basic types, primitives and objects. Whenever there is a type after a `var` or a `val` statement with lower-case first letter (e.g., `var int` or `var boolean`) we are dealing with a primitive type. Whenever the `val` and `var` are followed with type in upper-case (e.g., `var String`, `var Number`), the type is an object. This means that items are objects. Objects are more complex than simple variables and have methods associated with them that enable interaction with objects, as for example changing the state of an item. The syntax `Myitem.sendCommand` or `Myitem.postUpdate` ensures that the most appropriate and best method to convert/type the `new state` into the structure that is needed by the object (here `myItem`). 
 
-The alternative syntax, `sendCommand(MyItem, state_or_value)` applies only a set of generic methods, which are not able to accommodate all cases of conversion that may be necessary to make sure that `new state` can be applied to `myItem`. 
+The alternative syntax, `sendCommand(MyItem, "new_state")` applies only a set of generic methods, which are not able to accommodate all cases of conversion that may be necessary to make sure that `new_state` can be applied to `myItem`. 
 
-For example, if `state_or_value` is typed as a primitive (e.g., `var int my_number = 3`) and myItem is of the type Dimmer (note the capitalized ‘D’ denoting an object: 
+For example, if `new_state` is typed as a primitive (e.g., `var int my_number = 3`) and myItem is of the type Dimmer (note the capitalized ‘D’ denoting an object: 
 * the following command ***will fail***: ~~sendCommand(MyItem, my_number)~~. 
 * However, the following command **will work**: `MyItem.sendCommand(my_number)`. 
 
-And as for the answer which one to use, the easiest way is to remember that the syntax that will create the most stable code is the one in the column labeled “specific”: `MyItem.postUpdate("new state")` or `MyItem.sendCommand("new state")`. It provides by far the best option for avoiding most problems. This syntax ensures that any conversion (typing) of the `new state` is done in a way that is most suitable for `myItem`. As this may, however, not always be possible, here a more nuanced guidance:
+And as for the answer which one to use, the easiest way is to remember that the syntax that will create the most stable code is the one in the column labeled “specific”: `MyItem.postUpdate("new_state")` or `MyItem.sendCommand("new_state")`. It provides by far the best option for avoiding most problems. This syntax ensures that any conversion (typing) of the `new_state` is done in a way that is most suitable for `myItem`. As this may, however, not always be possible, here a more nuanced guidance:
 * Actions: may be used when all you have is the name of the Item as a String instead of a reference to the actual Item itself (e.g. when the name of the Item to receive an update or command was calculated in the Rule by building up a String).
 * Methods: are preferable when you have the reference to the Item directly because its name is hard coded or the Item was pulled out of a Group.
 
 ### Details:
 
-As all object-oriented computer languages, Java and the Rules DSL have implemented the concept of Inheritance. However, inheritance only applies to Objects and does **not** apply to primitives. Inheritance allows one to take an existing Object type, called a Class, and adding to it to make it into something different, but it still can do everything the existing Object could do. This “something different” becomes a Child of the original Class. The top level base Class for all Objects in Java and the Rules DSL is called Object. The Child can be treated as if it were the parent because everything the parent can do the child can do too.
+As all object-oriented computer languages, Java and the Rules DSL have implemented the concept of inheritance. However, inheritance only applies to Objects and does **not** apply to primitives. Inheritance allows one to take an existing Object type, called a Class, and adding to it to make it into something different, but it still can do everything the existing Object could do. This “something different” becomes a Child of the original Class. The top level base Class for all Objects in Java and the Rules DSL is called simply `Object`. The Child can be treated as if it were the parent because everything the parent can do the child can do too.
 
 In addition to other useful things, Object implements a method called `toString`. And since Object is the parent of all Objects, that means all Classes also implement a `toString` method. _But primitives do not inherit from Object. They don't inherit from anything and they don't have any methods at all which includes toString._
 
-The `sendCommand` is a generic action and therefore, by definition, needs to be able to work with all Item types. A closer look reveals that this action only supports two arguments: String, String, because all Objects will support the conversion `toString`. But a Primitive is not an object and has no `toString` (in fact a Primitive has no methods at all), as a consequence in almost all cases it cannot convert the primitive value to a String and the use of `sendCommand(MyItem, primitive)`, with the use of a primitive as the second argument, will fail. 
+The `sendCommand` is a generic action and therefore, by definition, needs to be able to work with all Item types. A closer look reveals that this action only supports two arguments: String, String, because all Objects will support the conversion `toString`. If the action sendCommand (MyItem,"new_state") is called, the Rules DSL will automatically use the `MyItem.toString` method to convert MyItem into a string and will attempt to do so with the secodn argument if `new_state` is not already a string. However, if the second argument is a Primitive, and not an Object, by definition it does not carry a method `toString` (in fact a Primitive has no methods at all) and Rules DSL will not be able to cast `new_state` as a string. As a consequence in almost all cases it cannot convert the primitive value to a String and the use of `sendCommand(MyItem, primitive)`, with the use of a primitive as the second argument, will fail. 
 
 The different syntax for the generic and the objective-specific differs and is given in the table below:
 
 Generic | Specific
 -----------|-----------
-`postUpdate(MyItem, "new state")` | `MyItem.postUpdate(" new state")`
-`sendCommand(MyItem, "new state")` | `MyItem.sendCommand("new state")`
+`postUpdate(MyItem, "new_state")` | `MyItem.postUpdate(new_state)`
+`sendCommand(MyItem, "new_state")` | `MyItem.sendCommand(new_state)`
 
 With regard to the `sendCommand` method on the Items, here the `sendCommand` method is defined by the class for that Item which allows the class to create `sendCommand` methods that take different types of data. For example, the `NumberItem` class would have a `sendCommand(int)`, `sendCommand(long)`, `sendCommand(float)`, `sendCommand(double)`, `sendCommand(Number)`, `sendCommand(DecimalType)`, and `sendCommand(String)` methods. Each of these separate methods is individually written to handle all of these different types of Objects and primitives unlike the Action which can only handle Strings.
 
-In a nutshell, using the syntax `MyItem.sendCommand("new state")` or `MyItem.sendUpdate("new state")` will help avoid many problems that the generic method may cause.
+In a nutshell, using the syntax `MyItem.sendCommand(new_state)` or `MyItem.sendUpdate(new_state)` will help avoid many problems that the generic method may cause.
 
 
 ## Scripts

--- a/configuration/rules-dsl.md
+++ b/configuration/rules-dsl.md
@@ -181,44 +181,46 @@ end
 
 ## Causing effects on items
 
-Rules come to life by using input to cause something else to happen, to cause effects, such as change the state of an item and, e.g., switch on a light at sunset. The two most common commands that can change item values or states within rules are `sendCommand` and `postUpdate`. The full syntax to use them is: 
-* `myItem.postUpdate(state_or_value)`
-* `myItem.sendCommand(state_or_value)`
+Rules come to life by generating events to cause something else to happen, to cause effects. For example, change the state of an item or switch on a light at sunset. The two most common commands that can change item values or states within rules are `sendCommand` and `postUpdate`. The full syntax to use them is: 
+* `MyItem.postUpdate("new state")`
+* `MyItem.sendCommand("new state")`
 
-A `postUpdate` is often used to change the status of in item without causing any action to reflect any status changes that may be caused by other means (physically switch on a light). A `sendCommand` will cause a change in status and trigger potential actions. 
+A `postUpdate` is used to change the status of an item without causing any further action. `postUpdate` is used to update openHAB Items to reflect any status changes that may be caused by other means (physically switch on a light) or to indicate state changes that do not require a corresponding action. A `sendCommand` will cause a change in status and trigger potential actions. 
 
-It is important to understand that they act slightly different and interact in specific ways with (event-based rule triggers)[{{base}}/configuration/rules-dsl.html#event-based-triggers]. For example `postUpdate` will will fire `received update`-based triggers, but not fire `received command`-based triggers.Correspondingly, `sendCommand` will fire `received command`-based triggers, but not fire `received update`-based triggers.
+It is important to understand that they act slightly different and interact in specific ways with (event-based rule triggers)[{{base}}/configuration/rules-dsl.html#event-based-triggers]. For example `postUpdate` will will fire `received update`-based triggers, but not fire `received command`-based triggers. Correspondingly, `sendCommand` will fire `received command`-based triggers, but not fire `received update`-based triggers.
 
-### For those who want to have more background, here the long answer:
+### MyItem.sendCommand("new state") versus sendCommand(MyItem, "new state")
 
-The reasons as to why `myItem.sendCommand` and `myItem.postUpdate` are the preferred syntax lie within Java, the object-oriented program languages on which openHab and its items, rules, etc are built. Java and the Rules DSL have two basic types, primitives and objects. Whenever there is a type after a `var` or a `val` statement with lower-case first letter (e.g., `var int` or `var boolean`) we are dealing with a primitive type. Whenever the `val` and `var` are followed with type in upper-case (e.g., `var String`, `var Number`), the type is an object. This means that items are objects. Objects are more complex than simple variables and have methods associated with them that enable interaction with objects, as for example changing the state of an item. The syntax `myitem.sendCommand` or `myitem.postUpdate` ensures that the most appropriate and best method to convert/type the `state_or_value` into the structure that is needed by the object (here `myItem`). 
+`MyItem.sendCommand("new state")` and `myItem.postUpdate("new state")` are the preferred syntax. These are methods of objects that can a variety of types, depending on the items, while the Actions `sendCommand ("MyItem", "new state")` and `postUpdate ("MyItem", "new state")` can only accept strings as arguments. The reasons lie within Java, the object-oriented program languages on which openHab and its items, rules, etc are built. Java and the Rules DSL have two basic types, primitives and objects. Whenever there is a type after a `var` or a `val` statement with lower-case first letter (e.g., `var int` or `var boolean`) we are dealing with a primitive type. Whenever the `val` and `var` are followed with type in upper-case (e.g., `var String`, `var Number`), the type is an object. This means that items are objects. Objects are more complex than simple variables and have methods associated with them that enable interaction with objects, as for example changing the state of an item. The syntax `Myitem.sendCommand` or `Myitem.postUpdate` ensures that the most appropriate and best method to convert/type the `new state` into the structure that is needed by the object (here `myItem`). 
 
-The alternative syntax, `sendCommand(myItem, state_or_value)` applies only a set of generic methods, which are not able to accommodate all cases of conversion that may be necessary to make sure that `state_or_value` can be applied to `myItem`. 
+The alternative syntax, `sendCommand(MyItem, state_or_value)` applies only a set of generic methods, which are not able to accommodate all cases of conversion that may be necessary to make sure that `new state` can be applied to `myItem`. 
 
 For example, if `state_or_value` is typed as a primitive (e.g., `var int my_number = 3`) and myItem is of the type Dimmer (note the capitalized ‘D’ denoting an object: 
-* the following command ***will fail***: ~~sendCommand(myItem, my_number)~~. 
-* However, the following command **will work**: `myItem.sendCommand(my_number)`. 
+* the following command ***will fail***: ~~sendCommand(MyItem, my_number)~~. 
+* However, the following command **will work**: `MyItem.sendCommand(my_number)`. 
 
-And as for the answer which one to use, the easiest way is to remember that the syntax that will create the most stable code is the one in the column labeled “specific”: `myItem.postUpdate(state_or_value)` or `myItem.sendCommand(state_or_value)`. It provides by far the best option for avoiding most problems. This syntax ensures that any conversion (typing) of the `state_or_value` is done in a way that is most suitable for `myItem`. 
+And as for the answer which one to use, the easiest way is to remember that the syntax that will create the most stable code is the one in the column labeled “specific”: `MyItem.postUpdate("new state")` or `MyItem.sendCommand("new state")`. It provides by far the best option for avoiding most problems. This syntax ensures that any conversion (typing) of the `new state` is done in a way that is most suitable for `myItem`. As this may, however, not always be possible, here a more nuanced guidance:
+* Actions: may be used when all you have is the name of the Item as a String instead of a reference to the actual Item itself (e.g. when the name of the Item to receive an update or command was calculated in the Rule by building up a String).
+* Methods: are preferable when you have the reference to the Item directly because its name is hard coded or the Item was pulled out of a Group.
 
-### Even more details:
+### Details:
 
-As all object-oriented computer languages, Java and the Rules DSL have implemented the concept of Inheritance. However, inheritance only applies to Objects and does **not** apply to primitives. Inheritance allows to take an existing Object type, called a Class, and adding to it to make it into something different, but it still can do everything the existing Object could do. This “something different” becomes a Child of the original Class. The top level base Class for all Objects in Java and the Rules DSL is called Object. The Child can be treated as if it were the parent because everything the parent can do the child can do too.
+As all object-oriented computer languages, Java and the Rules DSL have implemented the concept of Inheritance. However, inheritance only applies to Objects and does **not** apply to primitives. Inheritance allows one to take an existing Object type, called a Class, and adding to it to make it into something different, but it still can do everything the existing Object could do. This “something different” becomes a Child of the original Class. The top level base Class for all Objects in Java and the Rules DSL is called Object. The Child can be treated as if it were the parent because everything the parent can do the child can do too.
 
 In addition to other useful things, Object implements a method called `toString`. And since Object is the parent of all Objects, that means all Classes also implement a `toString` method. _But primitives do not inherit from Object. They don't inherit from anything and they don't have any methods at all which includes toString._
 
-The `sendCommand` is a generic action and therefore, by definition, needs to be able to work with all Objects. A closer look reveals that this action only supports two arguments: String, String, because all Objects will support the conversion `toString`. But a Primitive is not an object and has no `toString` (in fact a Primitive has no methods at all), as a consequence in almost all cases it cannot convert the primitive value to a String and the use of `sendCommand(myItem, primitive)`, with the use of a primitive as the second argument, will fail. 
+The `sendCommand` is a generic action and therefore, by definition, needs to be able to work with all Item types. A closer look reveals that this action only supports two arguments: String, String, because all Objects will support the conversion `toString`. But a Primitive is not an object and has no `toString` (in fact a Primitive has no methods at all), as a consequence in almost all cases it cannot convert the primitive value to a String and the use of `sendCommand(MyItem, primitive)`, with the use of a primitive as the second argument, will fail. 
 
 The different syntax for the generic and the objective-specific differs and is given in the table below:
 
 Generic | Specific
 -----------|-----------
-`postUpdate(myItem, state_or_value)` | `myItem.postUpdate(state_or_value)`
-`sendCommand(myItem, state_or_value)` | `myItem.sendCommand(state_or_value)`
+`postUpdate(MyItem, "new state")` | `MyItem.postUpdate(" new state")`
+`sendCommand(MyItem, "new state")` | `MyItem.sendCommand("new state")`
 
 With regard to the `sendCommand` method on the Items, here the `sendCommand` method is defined by the class for that Item which allows the class to create `sendCommand` methods that take different types of data. For example, the `NumberItem` class would have a `sendCommand(int)`, `sendCommand(long)`, `sendCommand(float)`, `sendCommand(double)`, `sendCommand(Number)`, `sendCommand(DecimalType)`, and `sendCommand(String)` methods. Each of these separate methods is individually written to handle all of these different types of Objects and primitives unlike the Action which can only handle Strings.
 
-In a nutshell, using the syntax `myItem.sendCommand(state_or_value)` or `myItem.sendUpdate(state_or_value)` will help avoid many problems that the generic method may cause.
+In a nutshell, using the syntax `MyItem.sendCommand("new state")` or `MyItem.sendUpdate("new state")` will help avoid many problems that the generic method may cause.
 
 
 ## Scripts


### PR DESCRIPTION
The use of sendCommand and postUpdate in rules is explained with an emphasis on discouraging the generic method sendCommand(Item,arg) over the method Item.sendCommand(arg) that provides much more reliable type conversions. Details as to the background have been added
Signed-off-by: Markus Lipp <lipp.markus@gmail.com> (github: LightIsLife)