### PR TITLE
[Sitemaps] Revise article, add element examples

### DIFF
--- a/configuration/sitemaps.md
+++ b/configuration/sitemaps.md
@@ -20,12 +20,12 @@ This page is structured as follows:
 {:toc}
 
 The definition of Sitemaps happens declaratively in a file with a clear syntax, described below.
-A Sitemap definition file is stored in the folder `<openhab_config>/sitemaps` and has to have the `.sitemap` filename extension.
-For easy editing, the [Eclipse SmartHome Designer]({{base}}/configuration/editors.html#esh-designer) brings full IDE support for these files.
+A Sitemap definition file is stored in the folder `$OPENHAB_CONF/sitemaps` and has to have the `.sitemap` filename extension.
+For easy editing, profit from the IDE support of the [openHAB supporting editors]({{base}}/configuration/editors.html).
 
 The openHAB runtime comes with a demo configuration package containing a [`demo.sitemap`](https://github.com/openhab/openhab-distro/blob/master/features/distro-resources/src/main/resources/sitemaps/demo.sitemap),
 which should let you easily understand possible elements and structures.
-It is recommended to use the `demo.sitemap` or another example Sitemap as a starting point towards building a customized Sitemap that fits your personal home setup.
+It is recommended to use this demo file or another example Sitemap as a starting point towards building a customized Sitemap that fits your personal home setup.
 
 The following example illustrates what a typical Sitemap definition might look like:
 
@@ -35,12 +35,12 @@ sitemap demo label="My home automation" {
         Text item=Date
     }
     Frame label="Demo" {
+        Switch item=Lights icon="light"
+        Text item=LR_Temperature label="Livingroom [%.1f °C]"
         Group item=Heating
-        Switch item=Lights icon="big_bulb" mappings=[OFF="All Off"]
-        Text item=Temperature valuecolor=[>25="orange",>15="green",<=15="blue"]
-        Text item=Multimedia_Summary label="Multimedia" icon="video" {
-            Selection item=TV_Channel mappings=[0="off", 1="DasErste", 2="BBC One", 3="Cartoon Network"]
-            Slider item=Volume
+        Text item=LR_Multimedia_Summary label="Multimedia [%s]" icon="video" {
+            Selection item=LR_TV_Channel mappings=[0="off", 1="DasErste", 2="BBC One", 3="Cartoon Network"]
+            Slider item=LR_TV_Volume
         }
     }
 }
@@ -59,24 +59,25 @@ A full explanation for this example can be found [at the end of this article](#f
 
 **Elements:**
 Sitemaps are composed by arranging various user interface elements.
-A counted set of different element types supports a user-friendly and clear presentation.
-The example above contains `Frame`, `Text` or `Switch` elements besides others.
-Elements will present information or status data, allow interaction and are highly configurable based on the system state.
+A set of different element types supports a user-friendly and clear presentation.
+The example above contains `Frame`, `Text` and `Switch` elements among others.
+Elements present information, allow interaction and are highly configurable based on the system state.
 One line of Sitemap element definition produces one corresponding UI element.
-As can be seen in the example, an important design decision was, to have a descriptive text next to an icon on the left side and the status or interaction element(s) on the right.
+As shown in the example, each element generates a descriptive text next to an icon on the left side and a status and/or interaction elements on the right.
 
 **Parameters:**
 A certain set of parameters can be configured to customize the presentation of an element.
-In the shown example `item`, `label` or `valuecolor` are parameters.
+In the shown example `item`, `label` and `valuecolor` are parameters.
 Almost all parameters are optional, some are however needed to result in a meaningful user interface.
 To avoid very long or unstructured lines of element definition, parameters can be broken down to multiple code lines.
 
 **Blocks:**
 By encapsulating elements with curly brackets, multiple elements can be nested inside or behind others.
-The `Frame` element type is often used in combination with element blocks and a bit special in that matter.
+The `Frame` element type is often used in combination with element blocks.
 Frames are used to visually distinguish multiple elements of the same topic on one interface page.
 When using code blocks behind other element types like `Text`, `Group` or `Switch`, these UI elements will - in addition to their normal function - be links to a new view, presenting the nested elements.
-In the above example, multiple frames are defined and some elements are not visible on the main view but are accessible behind their parent element.
+In the above example, multiple Frames are defined and some elements are not visible on the main view but are accessible behind their parent element.
+These are indicated by the ">" control icon on the right of an element.
 
 **Dependencies:**
 Sitemaps contain dozens of individual elements.
@@ -85,7 +86,7 @@ openHAB supports these dependencies by providing parameters for dynamic behavior
 Be sure to check out the [Dynamic Sitemaps](#dynamic-sitemaps) chapter.
 
 For the technically interested: The Sitemap definition language is an
-[Xtext DSL](https://github.com/openhab/openhab/blob/master/bundles/model/org.openhab.model.sitemap/src/org/openhab/model/Sitemap.xtext).
+Xtext Domain Specific Language and the sitemap file model can be found [here](https://github.com/eclipse/smarthome/blob/master/bundles/model/org.eclipse.smarthome.model.sitemap/src/org/eclipse/smarthome/model/Sitemap.xtext).
 
 ### Special Element 'sitemap'
 
@@ -93,7 +94,9 @@ The `sitemap` element is **mandatory** in a Sitemap definition and has to be nam
 The element will always be the first line and the following code block encloses the whole Sitemap definition.
 
 ```perl
-sitemap <sitemapname> label="<title of the main screen>"
+sitemap <sitemapname> label="<title of the main screen>" {
+    [all sitemap elements]
+}
 ```
 
 - `sitemapname` is always equal to the Sitemaps file name, e.g. `demo.sitemap` -> "demo"
@@ -107,37 +110,41 @@ The following element types can be used in a Sitemap definition file.
 
 | Element                                   | Description                                               |
 |-------------------------------------------|-----------------------------------------------------------|
-| [Frame](#element-type-frame)              | Area containing various other Sitemap elements. |
+| [Chart](#element-type-chart)              | Adds a time-series chart object for [persisted](persistence.html) data. |
+| [Colorpicker](#element-type-colorpicker)  | Allows the user to choose a color from a color wheel. |
 | [Default](#element-type-default)          | Renders an Item in the default UI representation specified by the type of the given item. |
-| [Text](#element-type-text)                | Renders an Item in a text representation. |
-| [Group](#element-type-group)              | Concentrates all elements of a given group nested in one group element. |
-| [Switch](#element-type-switch)            | Renders an Item as a ON/OFF or multiple buttons switch. |
-| [Selection](#element-type-selection)      | Provides a dropdown or modal popup presenting values to choose from for an item. |
+| [Frame](#element-type-frame)              | Area containing various other Sitemap elements. |
+| [Group](#element-type-group)              | Concentrates all elements of a given group in a nested block. |
+| [Image](#element-type-image)              | Renders an image given by an URL. |
+| [Selection](#element-type-selection)      | Provides a dropdown or modal popup presenting values to choose from for an Item. |
 | [Setpoint](#element-type-setpoint)        | Renders a value between an increase and a decrease buttons. |
 | [Slider](#element-type-slider)            | A value is presented in a progress bar like slider. |
-| [Colorpicker](#element-type-colorpicker)  | Allows the user to choose a color from a color wheel. |
-| [Chart](#element-type-chart)              | Adds a time-series chart object for displaying logged data. |
+| [Switch](#element-type-switch)            | Renders an Item as a ON/OFF or multi-button switch. |
+| [Text](#element-type-text)                | Renders an Item in a text representation. |
+| [Video](#element-type-video)              | Displays a video stream given a direct URL. |
 | [Webview](#element-type-webview)          | Displays the content of a webpage. |
-| [Image](#element-type-image)              | Renders an image given by an URL. |
-| [Video](#element-type-video)              | Displays a video given by a direct URL. |
 
 <!-- TODO: check for new element types -->
 
 **Choosing the right element type:**
-Data presented by Sitemap elements will almost always originate from the referenced items.
-Each Item is of a certain datatype, for example `Switch`, `Number` or `String`.
-While not all combinations are allowed or meaningful, items of one datatype can be linked to different Sitemap element types.
+Data presented by Sitemap elements will almost always originate from a referenced item.
+Each Item is of a certain Item type, for example `Switch`, `Number` or `String`.
 
+While not all combinations are meaningful, items of one datatype can be linked to different Sitemap element types.
 This provides the flexibility to present items in the way desired in your home automation user interface.
 
 **General remarks on parameters:**
 
--   In the following definitions, parameters in `[square brackets]` are optional, parameters in front are considered more relevant.
+-   In the following definitions, parameters in `[square brackets]` are optional.
+
+-   Parameters must be supplied in the order described.
 
 -   Common parameters, also known from [items definition](items.html#item-syntax):
     - `item` defines the name of the Item you want to present (e.g. `Temperature`), [more details](items.html#item-name).
     - `label` sets the textual description besides the preprocessed Item data (e.g. "`Now [%s °C]`"), [more details](items.html#item-label).
     - `icon` is the name of the icon file to show next to the element, [more details](items.html#icons).
+
+-   Setting a value for `label` or `icon` of a Sitemap element will override the values defined for the linked Item.
 
 -   Additional parameters like `mappings` or `valuecolor` are described below.
 
@@ -145,13 +152,22 @@ This provides the flexibility to present items in the way desired in your home a
 
 ```perl
 Frame [label="<labelname>"] [icon="<icon>"] {
-        [additional sitemap elements]
+    [additional sitemap elements]
 }
 ```
 
 Frames are used to create visually separated areas of items.
 
-![Presentation of the frame element in BasicUI](images/sitemap_demo_frame.png)
+**Example:**
+
+```perl
+Frame label="Demo" {
+    Switch item=Lights icon="light"
+    //# and so on...
+}
+```
+
+![Presentation of the Frame element in BasicUI](images/sitemap_demo_frame.png)
 
 ### Element Type 'Default'
 
@@ -174,7 +190,13 @@ Presents data as normal text.
 Most Item types can be used, the values can be prepared and reformatted by using string formatters and transformations.
 Please check with the documentation on the [item label](items.html#item-label) for details.
 
-![Presentation of the text element in BasicUI](images/sitemap_demo_text.png)
+**Example:**
+
+```perl
+Text item=Temperature label="Livingroom [%.1f °C]" icon="temperature"
+```
+
+![Presentation of the Text element in BasicUI](images/sitemap_demo_text.png)
 
 ### Element Type 'Group'
 
@@ -184,13 +206,21 @@ Group item=<itemname> [label="<labelname>"] [icon="<iconname>"]
 
 The element will be clickable, revealing a new view showing all group items using the [Default](#element-type-default) element type.
 In addition, Item groups may be configured to hold a value, just like with normal items.
-Please refer to the documentation on [items](items.html) for details.
-
-<!--TODO: Link to items-groups -->
+Please refer to the documentation on [Item groups](items.html#groups) for details.
 
 - `item` refers to the name of the Item group to be presented.
 
-![Presentation of the group element in BasicUI](images/sitemap_demo_group.png)
+**Attention:**
+There is no way to override the parameters, change the default element type, change the order, use dynamic tags, or insert other elements (e.g. Chart, Image, Webview, etc) in the subframe generated by using the Group element.
+Please see the Blocks section above for how to create a custom subframe with full control over its contents and appearance.
+
+**Example:**
+
+```perl
+Group item=gTemperature label="Room Temperatures [%.1f °C]"
+```
+
+![Presentation of the Group element in BasicUI](images/sitemap_demo_group.png)
 
 ### Element Type 'Switch'
 
@@ -199,14 +229,21 @@ Switch item=<itemname> [label="<labelname>"] [icon="<iconname>"] [mappings="<map
 ```
 
 Switches are one of the more common elements of a typical Sitemap.
-A switch will present a discrete state Item and allow changing of it's value.
-Note that switch elements can be rendered differently on the user interface, based on the Item type and the `mappings` parameter.
+A Switch will present a discrete state Item and allow changing of it's value.
+Note that Switch elements can be rendered differently on the user interface, based on the Item type and the `mappings` parameter.
 
 - `mappings` comes as an array of value-to-string translations, [documented further down](#mappings).
   Without the mappings parameter, user interfaces will present an On/Off Switch, if mappings are given several labeled buttons are rendered.
 
-![Presentation of the On/Off switch element in BasicUI](images/sitemap_demo_switch1.png)
-![Presentation of the multi-state switch element in BasicUI](images/sitemap_demo_switch2.png)
+**Examples:**
+
+```perl
+Switch item=LR_CeilingLight label="Ceiling Light" icon="light"
+Switch item=LR_TV_Channel label="TV Channel" mappings=[0="DasErste", 1="BBC One", 2="Cartoon Network"]
+```
+
+![Presentation of the On/Off Switch element in BasicUI](images/sitemap_demo_switch1.png)
+![Presentation of the multi-state Switch element in BasicUI](images/sitemap_demo_switch2.png)
 
 ### Element Type 'Selection'
 
@@ -214,26 +251,38 @@ Note that switch elements can be rendered differently on the user interface, bas
 Selection item=<itemname> [label="<labelname>"] [icon="<iconname>"] [mappings="<mapping definition>"]
 ```
 
-The selection element type allows to select from different settings, similar to a switch with multiple states.
-The selection renders the options as lines in a menu shown as a dropdown menu or a modal dialog prompt, depending on your user interface.
+The Selection element type allows to select from different settings, similar to a Switch with multiple states.
+The Selection renders the options as lines in a menu shown as a dropdown menu or a modal dialog prompt, depending on your user interface.
 
 - `mappings` comes as an array of value-to-string translations, [documented further down](#mappings).
 
-![Presentation of the selection element in BasicUI](images/sitemap_demo_selection.png)
+**Example:**
+
+```perl
+Selection item=LR_TV_Channel label="TV Channel" mappings=[0="DasErste", 1="BBC One", 2="Cartoon Network"]
+```
+
+![Presentation of the Selection element in BasicUI](images/sitemap_demo_selection.png)
 
 ### Element Type 'Setpoint'
 
 ```perl
-Setpoint item=<itemname> [label="<labelname>"] [icon="<iconname>"] minValue="<min value>" maxValue="<max value>" step="<step value>"
+Setpoint item=<itemname> [label="<labelname>"] [icon="<iconname>"] minValue=<min value> maxValue=<max value> step=<step value>
 ```
 
-A special switch-like element to increase or decrease the value of an item.
+A special Switch-like element to increase or decrease the value of an item.
 The element is often used to gradually change a number item.
 
 - `minValue` and `maxValue` limit the possible range of the value (both included in the range).
 - `step` defines the change in value one button press will cause.
 
-![Presentation of the setpoint element in BasicUI](images/sitemap_demo_setpoint.png)
+**Example:**
+
+```perl
+Setpoint item=KI_Temperature label="Kitchen [%.1f °C]" minValue=4.5 maxValue=30 step=0.5
+```
+
+![Presentation of the Setpoint element in BasicUI](images/sitemap_demo_setpoint.png)
 
 ### Element Type 'Slider'
 
@@ -241,17 +290,21 @@ The element is often used to gradually change a number item.
 Slider item=<itemname> [label="<labelname>"] [icon="<iconname>"] [sendFrequency="frequency"] [switchSupport]
 ```
 
-This type presents a value as a slider or percentage bar like UI element and allows manipulation.
+This type presents a value as a user-adjustable control which slides from left (0) to right (100).
 
 -   `sendFrequency` is used to distinguish between long and short button presses in the classic (web) frontend.
     This parameter defines the interval in milliseconds for sending increase/decrease requests.
 
--   `switchSupport` is a parameter without assignment.
-    If specified a short press on the "up" or "down" button/arrow in the classic (web) frontend switched the Item on/off completely.
+-   `switchSupport` is a parameter without an assignment (Classic UI only!).
+    If specified, a short press on the "up" or "down" buttons switch the item "on" or "off" completely.
 
-<!-- TODO: This paragraph needs an update -->
+**Example:**
 
-![Presentation of the slider element in BasicUI](images/sitemap_demo_slider.png)
+```perl
+Slider item=KI_Temperature label="Kitchen"
+```
+
+![Presentation of the Slider element in BasicUI](images/sitemap_demo_slider.png)
 
 ### Element Type 'Colorpicker'
 
@@ -267,52 +320,13 @@ Upon clicking the middle button, a color wheel will be presented.
 
 <!-- TODO: This paragraph needs an update. What are the left and the right buttons for? -->
 
-![Presentation of the colorpicker element in BasicUI](images/sitemap_demo_colorpicker.png)
-
-### Element Type 'Chart'
+**Example:**
 
 ```perl
-Chart [item=<itemname>] [icon="<iconname>"] [label="<labelname>"] [refresh=xxxx]
-[period=xxxx] [service="<service>"] [begin=yyyyMMddHHmm] [end=yyyyMMddHHmm]
+Colorpicker item=LR_LEDLight_Color label="LED Light Color" icon="colorwheel"
 ```
 
-Adds a time-series chart object for displaying logged data.
-
--   `refresh` defines the refresh period of the image (in milliseconds).
-
--   `service` sets the persistence service to use.
-    If no service is set, openHAB will use the first queryable persistence service it finds.
-    Therefore, for an installation with only a single persistence service, this is not required.
-
--   `period` is the length of the time axis of the chart. Valid values are `h, 4h, 8h, 12h, D, 2D, 3D, W, 2W, M, 2M, 4M or Y`.
-
--   `begin` / `end` represent the beginning and end of the time axis of the chart.
-    Valid values are in the format: "yyyyMMddHHmm" (yyyy = year, MM = month, dd = day, HH = hour (0-23), mm = minutes).
-
-<!-- TODO: This paragraph needs an update -->
-
-Visit [Charts](https://github.com/openhab/openhab/wiki/Charts) in the Wiki for examples.
-Charts by most logging and graphing solutions (e.g. [Grafana](http://grafana.org)) may also be generated as images and presented by the [image element type](#element-type-image).
-
-<!-- TODO
-![Presentation of the chart element in BasicUI](images/sitemap_demo_chart.png)
--->
-
-**Note on chart providers:**
-The openHAB system provides a default chart provider, which will work with all queryable persistence services.
-Other chart providers can be used to render the chart.
-Currently, the only alternative is to use the rrd4j provider to render the graphs.
-
-<!-- TODO: This paragraph needs an update -->
-
-**Technical constraints and details:**
-
-- When using rrd4j persistence, you must use the `everyMinute` (60 seconds) logging strategy otherwise rrd4j thinks that there is no data and will not properly draw the charts
-- When using chart:provider=rrd4j, the `service=<service>` is ignored and only the persistence service rrd4j is used
-- The visibility of multiple chart objects can be toggled to simulate changing the chart period, and the non-visible chart widgets are NOT generated behind the scenes until it becomes visible
-- When charting a group of items make sure every label is unique. If the label contains spaces, the first word of the label must be unique. Identical labels result in an empty chart
-
-<!-- TODO: This paragraph needs an update -->
+![Presentation of the Colorpicker element in BasicUI](images/sitemap_demo_colorpicker.png)
 
 ### Element Type 'Webview'
 
@@ -321,10 +335,17 @@ Webview item=<itemname> [label="<labelname>"] [icon="<iconname>"] url="<url>" [h
 ```
 
 The content of a webpage will be presented live on your user interface besides other Sitemap elements.
+Please be aware, that Webview elements are not usable by all user interface options.
 
 - `height` is the number of element rows to fill.
 
-![Presentation of the webview element in BasicUI](images/sitemap_demo_webview.png)
+**Example:**
+
+```perl
+Webview url="http://www.openhab.org" height=5
+```
+
+![Presentation of the Webview element in BasicUI](images/sitemap_demo_webview.png)
 
 ### Element Type 'Image'
 
@@ -337,11 +358,17 @@ The image has to be available on a reachable website or webserver without passwo
 It's also possible to place an image in the `html` folder under your configuration folder.
 The file will be available under the "static" route, [http://<my.openHAB.device>:8080/static/image.png](http://127.0.0.1:8080/static).
 
-- `item` can refer to either an Image Item whose state is the raw data of the image, or a String Item whose state is an URL to an image.  Some clients may not (yet) consider `item`.
+- `item` can refer to either an Image Item whose state is the raw data of the image, or a String Item whose state is an URL to an image. Some clients may not (yet) consider `item`.
 - `url` is the default URL from which to retrieve the image, if there is no associated Item or if the associated item's state is not an URL.
 - `refresh` is the refresh period of the image in milliseconds ("60000" for minutely updates).
 
-![Presentation of the image element in BasicUI](images/sitemap_demo_image.png)
+**Example:**
+
+```perl
+Image url="https://raw.githubusercontent.com/wiki/openhab/openhab/images/features.png"
+```
+
+![Presentation of the Image element in BasicUI](images/sitemap_demo_image.png)
 
 ### Element Type 'Video'
 
@@ -358,7 +385,54 @@ An embedded or protected video is not supported.
 - `url` is the default URL from which to retrieve the video, if there is no associated Item or if the associated item's state is not an URL.
 - `encoding` can stay left empty for auto selection, for an MJPEG video please set the "mjpeg" encoding explicitly.
 
-![Presentation of the video element in BasicUI](images/sitemap_demo_video.png)
+**Example:**
+
+```perl
+Video url="http://demo.openhab.org/Hue.m4v"
+```
+
+![Presentation of the Video element in BasicUI](images/sitemap_demo_video.png)
+
+### Element Type 'Chart'
+
+```perl
+Chart [item=<itemname>] [icon="<iconname>"] [label="<labelname>"] [refresh=xxxx]
+[period=xxxx] [service="<service>"] [begin=yyyyMMddHHmm] [end=yyyyMMddHHmm]
+```
+
+Adds a time-series chart object for displaying logged data.
+
+-   `refresh` defines the refresh period of the Image (in milliseconds).
+
+-   `service` sets the persistence service to use.
+If no service is set, openHAB will use the first queryable persistence service it finds.
+Therefore, for an installation with only a single persistence service, this is not required.
+
+-   `period` is the length of the time axis of the Chart. Valid values are `h, 4h, 8h, 12h, D, 2D, 3D, W, 2W, M, 2M, 4M or Y`.
+
+-   `begin` / `end` represent the beginning and end of the time axis of the Chart.
+Valid values are in the format: "yyyyMMddHHmm" (yyyy = year, MM = month, dd = day, HH = hour (0-23), mm = minutes).
+
+<!-- TODO: This paragraph needs an update -->
+
+Visit [Charts](https://github.com/openhab/openhab/wiki/Charts) in the Wiki for examples.
+
+<!-- TODO
+![Presentation of the Chart element in BasicUI](images/sitemap_demo_chart.png)
+-->
+
+**Other options to look out for:**
+The Chart element type is a good way to present time series quickly.
+For more sophisticated diagrams, openHAB supports the integration of outside sources like most logging and graphing solutions (e.g. [Grafana](http://grafana.org)).
+See this [Tutorial](https://community.openhab.org/t/13761/1) for more details.
+
+**Technical constraints and details:**
+
+- When using rrd4j persistence, you must use the `everyMinute` (60 seconds) logging strategy otherwise rrd4j thinks that there is no data and will not properly draw the charts.
+- The visibility of multiple Chart objects can be toggled to simulate changing the Chart period, and the non-visible Chart widgets are NOT generated behind the scenes until it becomes visible.
+- When charting a group of item, make sure that every label is unique. If the label contains spaces, the first word of the label must be unique. Identical labels result in an empty chart.
+
+<!-- TODO: This paragraph needs an update -->
 
 <!-- TODO: Element type list is not supported and throws NPE in BasicUI
 ### Element Type 'List'
@@ -369,14 +443,12 @@ List item=<itemname> [label="<labelname>"] [icon="<iconname>"] [separator=""]
 Splits a String Item at each separator into multiple rows.
 -->
 
-<!-- TODO: Further element types? -->
-
 ## Mappings
 
-Mappings is an optional parameter for the [switch](#element-type-switch) and [selection](#element-type-selection) element types.
+Mappings is an optional parameter for the [Switch](#element-type-switch) and [Selection](#element-type-selection) element types.
 
-Please be aware of the fact, that both switch and selection are input element types.
-If you are looking to transform Item data into meaningful outputs, a [text element](#element-type-text) with it's label parameter may be a better choice.
+Please be aware of the fact, that both Switch and Selection are input element types.
+If you are looking to transform Item data into meaningful outputs, a [Text element](#element-type-text) with it's label parameter may be a better choice.
 
 ```perl
 mappings=[value_1="description_1", value_2="description_2", ...]
@@ -396,8 +468,8 @@ mappings=[15="Gone", 19="Chilly", 21="Cozy"]
 As you can see, different Item data types are accepted as mappings values.
 The first two lines show very typical use cases.
 Imagine your TV as part of your openHAB setup.
-It's power state and channel number are internally represented by a binary switch Item (OFF/ON) and a discrete number Item with only a few selectable states.
-By using a switch or selection element with a mappings array, you can replace these meaningless values by meaningful descriptions for your inputs in the user interface.
+It's power state and channel number are internally represented by a binary Switch Item (OFF/ON) and a discrete number Item with only a few selectable states.
+By using a Switch or Selection element with a mappings array, you can replace these meaningless values by meaningful descriptions for your inputs in the user interface.
 
 In the third and forth line only a subset of the possible values of items belonging to a heating system is presented to the user.
 This limits the possible input values, which is yet another often occurring use case.
@@ -441,7 +513,7 @@ Valid comparison operators are:
 - smaller or equal to `<=`, bigger or equal to`>=`.
 - smaller than `<`, bigger than `>`
 
-### Colors
+### Label and Value Colors
 
 Colors can be used to emphasize an items label or its value based on conditions.
 
@@ -485,7 +557,7 @@ Please take note, that other colors can be used.
 It is generally expected that valid HTML colors will be accepted (e.g. "green", "lightgrey", "#334455"), but a UI may only accept internally defined colors or work with a special theme.
 The given color names are agreed on between all openHAB UIs and are therefor your safest choice.
 
-Please note that there currently is a [known issue with the iOS app](https://github.com/openhab/openhab.ios/issues/112) where named colors (e.g. 'green') do not work for valuecolor. 
+Please note that there currently is a [known issue with the iOS app](https://github.com/openhab/openhab.ios/issues/112) where named colors (e.g. 'green') do not work for `valuecolor`.
 Until resolved you can use the corresponding HTML code (e.g. '#008000') instead.
 
 | Color Name  | Preview and RGB Color Code              |
@@ -511,7 +583,7 @@ Until resolved you can use the corresponding HTML code (e.g. '#008000') instead.
 ### Icons
 
 openHAB allows a set of icons to be assigned to the different states of an Item and therefor to be presented in a Sitemap.
-Please refer to the documentation on [item configuration](items.html) for details.
+Please refer to the documentation on [Item configuration](items.html) for details.
 
 ![battery-0]({{base}}/addons/iconsets/classic/icons/battery-0.png "battery-0")
 ![battery-30]({{base}}/addons/iconsets/classic/icons/battery-30.png "battery-30")
@@ -530,12 +602,12 @@ sitemap demo label="My home automation" {
         Text item=Date
     }
     Frame label="Demo" {
+        Switch item=Lights icon="light"
+        Text item=LR_Temperature label="Livingroom [%.1f °C]"
         Group item=Heating
-        Switch item=Lights icon="big_bulb" mappings=[OFF="All Off"]
-        Text item=Temperature valuecolor=[>25="orange",>15="green",<=15="blue"]
-        Text item=Multimedia_Summary label="Multimedia" icon="video" {
-            Selection item=TV_Channel mappings=[0="off", 1="DasErste", 2="BBC One", 3="Cartoon Network"]
-            Slider item=Volume
+        Text item=LR_Multimedia_Summary label="Multimedia [%s]" icon="video" {
+            Selection item=LR_TV_Channel mappings=[0="off", 1="DasErste", 2="BBC One", 3="Cartoon Network"]
+            Slider item=LR_TV_Volume
         }
     }
 }
@@ -547,22 +619,21 @@ Explanation:
 
 -   The Sitemap "demo" with the shown title "My home automation" is defined.
 
--   One first frame with a date stamp is shown.
+-   One first Frame with a date stamp is shown.
 
--   Another frame with a visual label "Demo" is presented, containing:
+-   Another Frame with a visual label "Demo" is presented, containing:
 
-    -   A Group element. Upon clicking the element, a new view containing all "Heating" items will be shown.
+    -   A Switch for the Item "Lights"
 
-    -   A Switch for the Item "Lights" with the only available button "All Off". Because the associated value is `OFF`, it's clear, that "Lights" is of the Switch Item typ.
+    -   A Text element showing a temperature in a given format
 
-    -   A text element showing a temperature colored based on value.
-        Take note, that the presentation is not defined as a label parameter and hence taken from the "Temperature" Item definition
+    -   A Group element. Upon clicking the element, a new view containing all "Heating" Items will be shown.
 
-    -   Another text element showing a "Multimedia" summary, e.g. "Currently playing".
+    -   Another Text element showing a "Multimedia" summary, e.g. "Currently playing".
         The element is additionally the host for a nested block.
         By clicking in the element, a new view with two elements is presented:
         - A Selection presenting four options in a modal dialog prompt
-        - A slider to set the volume (e.g. 0-100%)
+        - A Slider to set the volume (e.g. 0-100%)
 
 <!-- Note to author: If you update this example, remember to copy it to the beginning of this article as well! -->
 
@@ -592,7 +663,7 @@ sitemap demo label="My home automation" {
         Frame label="Demo" {
                 Switch item=Lights icon="light" mappings=[OFF="All Off"]
                 Text item=Temperature label="Livingroom [21.3 °C]" icon="temperature" valuecolor=[>25="orange",>15="green",<=15="blue"]
-        Group item=Heating
+                Group item=Heating
                 Text item=Multimedia_Summary label="Multimedia" icon="video" {
                         Selection item=TV_Channel mappings=[0="off", 1="DasErste", 2="BBC One", 3="Cartoon Network"]
                         Slider item=Volume

--- a/configuration/sitemaps.md
+++ b/configuration/sitemaps.md
@@ -251,8 +251,8 @@ Switch item=LR_TV_Channel label="TV Channel" mappings=[0="DasErste", 1="BBC One"
 Selection item=<itemname> [label="<labelname>"] [icon="<iconname>"] [mappings="<mapping definition>"]
 ```
 
-The Selection element type allows to select from different settings, similar to a Switch with multiple states.
-The Selection renders the options as lines in a menu shown as a dropdown menu or a modal dialog prompt, depending on your user interface.
+The Selection element type renders the options as a dropdown menu or as a modal dialog prompt, depending on the user interface.
+The element type is in its use cases similar to a Switch with multiple states but has the advantage that the main UI stays clean and more options can be offered.
 
 - `mappings` comes as an array of value-to-string translations, [documented further down](#mappings).
 


### PR DESCRIPTION
Includes all fixes for what was mentioned in https://github.com/openhab/openhab-docs/issues/53

I've also added the actual code used to create the sitemap elements in the screenshots for more clarity.

A typical section now looks like:

![grafik](https://user-images.githubusercontent.com/2870104/30004544-d904b120-90d1-11e7-9f5c-2e81e652639d.png)


Signed-off-by: Thomas Dietrich <thomas.dietrich@tu-ilmenau.de> (github: ThomDietrich)