### PR TITLE
Add Section on Item State; fixes #507

### DIFF
--- a/configuration/items.md
+++ b/configuration/items.md
@@ -213,16 +213,39 @@ This section provides information about what a user can expect regarding the beh
 
 -  Items are created with a state of `NULL`.
 The Item will remain in this state until it has been acted upon
--  Subsequent to the creation of an Item, operations in openHAB such as a user interacting with the Item using the `Basic UI`, or a Binding updating the state of an Item will change the state of the Item 
+-  Subsequent to the creation of an Item, operations in openHAB such as a user interacting with the Item using the `Basic UI`, or a Binding updating the state of an Item will change the state of the Item
 -  Once an Item is being used, its state will depend upon the Thing to which it is linked, or upon the specifics of the Binding that created the Item.
 Example - The state of a Switch may change from `NULL` to `ON` or `OFF`
 -  A Binding may set the state of an Item to `UNDEF` if it looses communications with a Thing (for example, a Z-wave doorbell with a dead battery).
 The Binding may also set the state to `UNDEF` if an error exists in the binding configuration, or under other conditions
 -  An Item may be assigned a particular state as part of the execution of a [Rule]({{base}}/configuration/rules-dsl.html).
 See, particularly, [Manipulating Item States]({{base}}/configuration/rules-dsl.html#manipulating-item-states)
--  The state of an Item after an openHAB startup will depend upon whether the user has configured [Persistence]({{base}}/configuration/persistence.html) or has created a set of ["System started"]({{base}/concepts/things.html#status-transitions) rules
+
 
 *N.B.*  Many openHAB users find that it can be very useful to use Persistence and "System started" rules so that their systems behaves in a predictable way after an openHAB restart.
+
+## Restoring States
+
+The state of an Item after an openHAB startup will depend upon whether the user has configured [Persistence]({{base}}/configuration/persistence.html) and has created a set of ["System started"]({{base}/concepts/things.html#status-transitions) rules.
+If you have not configured Persistence, you may find there are times after an openHAB startup when your logs indicate some Items are `UNDEF` or undefined.
+This is because, by default, Item states are not persisted when openHAB restarts.
+To have your states persist across restarts you will need to install a Persistence extension.
+
+Specifically, you need to use a `restoreOnStartup` strategy for all your Items.
+Then whatever state Items were in before the restart will be restored automatically.
+
+Example:
+
+```java
+Strategies {
+    default = everyUpdate
+}
+
+Items {
+    // persist all Items on every change and restore them at startup
+    * : strategy = everyChange, restoreOnStartup
+}
+```
 
 {: #state-presentation}
 #### State Presentation
@@ -482,7 +505,7 @@ See the [Hue Emulation]({{base}}/addons/io/hueemulation/readme.html) or [HomeKit
 
 Each Item can be bound to a Binding to receive or trigger external changes.
 The binding of an Item is given in the last part of the Item definition:
- 
+
 ```java
 Number Livingroom_Temperature "Temperature [%.1f °C]" {/*Binding part*/}
 ```
@@ -588,25 +611,4 @@ This way, the Item is always unchanged unless you explicitly post an *update* to
 ```java
 Switch Garage_Gate {binding="xxx", autoupdate="false"}
 ```
-
-<!-- TODO: This should be part of a separate Item state chapter -->
-
-## Restore States
-
-When restarting your openHAB installation you may find there are times when your logs indicate some Items are UNDEF.
-This is because, by default, Item states are not persisted when openHAB restarts.
-To have your states persist across restarts you will need to install a [Persistence]({{base}}/configuration/persistence.html) extension.
-
-Specifically, you need to use a `restoreOnStartup` strategy for all your Items.
-Then whatever state they were in before the restart will be restored automatically.
-
-```java
-Strategies {
-    default = everyUpdate
-}
-
-Items {
-    // persist all Items on every change and restore them from the MapDB at startup
-    * : strategy = everyChange, restoreOnStartup
-}
 ```

--- a/configuration/items.md
+++ b/configuration/items.md
@@ -206,8 +206,6 @@ Number Livingroom_Temperature "Temperature [%.1f °C]"
 The state of an Item depends on the Item type, the Channel bound to the Item, and internal or external events.
 A analogy can be drawn between the state of an Item and the value of a variable in a computer program.
 
-<!-- TODO: It would be great to add a state diagram for Items
-
 {: #item-state}
 #### Item State
 

--- a/configuration/items.md
+++ b/configuration/items.md
@@ -209,18 +209,16 @@ A analogy can be drawn between the state of an Item and the value of a variable 
 {: #item-state}
 #### Item State
 
-This section provides information about what a user can expect regarding the behavior of the state of an Item
+This section provides information about what a user can expect regarding the behavior of the state of an Item.
 
--  Items are created with a state of `NULL`.
-The Item will remain in this state until it has been acted upon
--  Subsequent to the creation of an Item, operations in openHAB such as a user interacting with the Item using the `Basic UI`, or a Binding updating the state of an Item will change the state of the Item
--  Once an Item is being used, its state will depend upon the Thing to which it is linked, or upon the specifics of the Binding that created the Item.
-Example - The state of a Switch may change from `NULL` to `ON` or `OFF`
--  A Binding may set the state of an Item to `UNDEF` if it looses communications with a Thing (for example, a Z-wave doorbell with a dead battery).
+- Items are created with a state of `NULL`.
+
+- Operations in openHAB such as a user interacting with the Item using the `Basic UI`, or a Binding updating the state of an Item will change the state of the Item
+
+- An Item's state may also be set through a Binding which may be reacting to changes in the real world.
+
+- A Binding may set the state of an Item to `UNDEF` if it looses communications with a Thing (for example, a Z-wave doorbell with a dead battery).
 The Binding may also set the state to `UNDEF` if an error exists in the binding configuration, or under other conditions
--  An Item may be assigned a particular state as part of the execution of a [Rule]({{base}}/configuration/rules-dsl.html).
-See, particularly, [Manipulating Item States]({{base}}/configuration/rules-dsl.html#manipulating-item-states)
-
 
 *N.B.*  Many openHAB users find that it can be very useful to use Persistence and "System started" rules so that their systems behaves in a predictable way after an openHAB restart.
 

--- a/configuration/items.md
+++ b/configuration/items.md
@@ -219,8 +219,8 @@ Example - The state of a Switch may change from `NULL` to `ON` or `OFF`
 -  A Binding may set the state of an Item to `UNDEF` if it looses communications with a Thing (for example, a Z-wave doorbell with a dead battery).
 The Binding may also set the state to `UNDEF` if an error exists in the binding configuration, or under other conditions
 -  An Item may be assigned a particular state as part of the execution of a [Rule]({{base}}/configuration/rules-dsl.html).
-See, particularly, [Manipulating Item States]({{base}}/configuration/rules-dsl.html#Manipulating Item States)
--  The state of an Item after an openHAB startup will depend upon whether the user has configured [Persistence]({{base}}/configuration/persistence.html) or has created a set of ["System started"](https://github.com/openhab/openhab1-addons/wiki/Persistence#Startup Behavior) rules
+See, particularly, [Manipulating Item States]({{base}}/configuration/rules-dsl.html#manipulating-item-states)
+-  The state of an Item after an openHAB startup will depend upon whether the user has configured [Persistence]({{base}}/configuration/persistence.html) or has created a set of ["System started"]({{base}/concepts/things.html#status-transitions) rules
 
 *N.B.*  Many openHAB users find that it can be very useful to use Persistence and "System started" rules so that their systems behaves in a predictable way after an openHAB restart.
 

--- a/configuration/items.md
+++ b/configuration/items.md
@@ -210,7 +210,6 @@ A analogy can be drawn between the state of an Item and the value of a variable 
 #### Item State
 
 This section provides information about what a user can expect regarding the behavior of the state of an Item
-<!-- TODO: It would be great to have an Item state diagram similar to the one on this page (docs.openhab.org/concepts/things.html)
 
 -  Items are created with a state of `NULL`.  The Item will remain in this state until it has been acted upon
 -  Subsequent to the creation of an Item, operations in openHAB such as a user interacting with the Item using the `Basic UI`, or a Binding updating the state of an Item will change the state of the Item 

--- a/configuration/items.md
+++ b/configuration/items.md
@@ -211,16 +211,16 @@ A analogy can be drawn between the state of an Item and the value of a variable 
 
 This section provides information about what a user can expect regarding the behavior of the state of an Item.
 
--   Items are created with a state of `NULL`.
+-   Items are created with a state of `NULL`
 
--   Operations in openHAB such as a user interacting with the Item using the `Basic UI`, or a Binding updating the state of an Item will change the state of the Item
+-   Operations in openHAB such as a user interacting with the Item using the Basic UI, or a Binding updating the state of an Item will change the state of the Item
 
--   An Item's state may also be set through a Binding which may be reacting to changes in the real world.
+-   An Item's state may also be set through a Binding which may be reacting to changes in the real world
 
 -   A Binding may set the state of an Item to `UNDEF` if it looses communications with a Thing (for example, a Z-wave doorbell with a dead battery).
 The Binding may also set the state to `UNDEF` if an error exists in the binding configuration, or under other conditions
 
-*N.B.*  Many openHAB users find that it can be very useful to use Persistence and "System started" rules so that their systems behaves in a predictable way after an openHAB restart.
+*N.B.*  Many openHAB users find that it can be very useful to use [Persistence]({{base}}/addons/persistence.html) and [System started]({{base}}/configuration/rules-dsl.html#system-based-triggers) rules so that their systems behaves in a predictable way after an openHAB restart.
 
 {: #state-presentation}
 #### State Presentation

--- a/configuration/items.md
+++ b/configuration/items.md
@@ -206,7 +206,20 @@ Number Livingroom_Temperature "Temperature [%.1f °C]"
 The state of an Item depends on the Item type, the Channel bound to the Item, and internal or external events.
 A analogy can be drawn between the state of an Item and the value of a variable in a computer program.
 
-<!-- TODO add a complete description about the actual state of an Item, e.g. Initialization, UNDEF, Binding etc. -->
+{: #item-state}
+#### Item State
+
+This section provides information about what a user can expect regarding the behavior of the state of an Item
+<!-- TODO: It would be great to have an Item state diagram similar to the one on this page (docs.openhab.org/concepts/things.html)
+
+-  Items are created with a state of `NULL`.  The Item will remain in this state until it has been acted upon
+-  Subsequent to the creation of an Item, operations in openHAB such as a user interacting with the Item using the `Basic UI`, or a Binding updating the state of an Item will change the state of the Item 
+-  Once an Item is being used, its state will depend upon the Thing to which it is linked, or upon the specifics of the Binding that created the Item.  Example - The state of a Switch may change from `NULL` to `ON` or `OFF`
+-  A Binding may set the state of an Item to `UNDEF` if it looses communications with a Thing (for example, a Z-wave doorbell with a dead battery). The Binding may also set the state to `UNDEF` if an error exists in the binding configuration, or under other conditions
+-  An Item may be assigned a particular state as part of the execution of a [Rule]({{base}}/configuration/rules-dsl.html).  See, particularly, [Manipulating Item States]({{base}}/configuration/rules-dsl.html#Manipulating Item States)
+-  The state of an Item after an openHAB startup will depend upon whether the user has configured [Persistence]({{base}}/configuration/persistence.html) or has created a set of ["System started"](https://github.com/openhab/openhab1-addons/wiki/Persistence#Startup Behavior) rules
+
+*N.B.*  Many openHAB users find that it can be very useful to use Persistence and "System started" rules so that their systems behaves in a predictable way after an openHAB restart.
 
 {: #state-presentation}
 #### State Presentation

--- a/configuration/items.md
+++ b/configuration/items.md
@@ -211,39 +211,16 @@ A analogy can be drawn between the state of an Item and the value of a variable 
 
 This section provides information about what a user can expect regarding the behavior of the state of an Item.
 
-- Items are created with a state of `NULL`.
+-   Items are created with a state of `NULL`.
 
-- Operations in openHAB such as a user interacting with the Item using the `Basic UI`, or a Binding updating the state of an Item will change the state of the Item
+-   Operations in openHAB such as a user interacting with the Item using the `Basic UI`, or a Binding updating the state of an Item will change the state of the Item
 
-- An Item's state may also be set through a Binding which may be reacting to changes in the real world.
+-   An Item's state may also be set through a Binding which may be reacting to changes in the real world.
 
-- A Binding may set the state of an Item to `UNDEF` if it looses communications with a Thing (for example, a Z-wave doorbell with a dead battery).
+-   A Binding may set the state of an Item to `UNDEF` if it looses communications with a Thing (for example, a Z-wave doorbell with a dead battery).
 The Binding may also set the state to `UNDEF` if an error exists in the binding configuration, or under other conditions
 
 *N.B.*  Many openHAB users find that it can be very useful to use Persistence and "System started" rules so that their systems behaves in a predictable way after an openHAB restart.
-
-## Restoring States
-
-The state of an Item after an openHAB startup will depend upon whether the user has configured [Persistence]({{base}}/configuration/persistence.html) and has created a set of ["System started"]({{base}/concepts/things.html#status-transitions) rules.
-If you have not configured Persistence, you may find there are times after an openHAB startup when your logs indicate some Items are `UNDEF` or undefined.
-This is because, by default, Item states are not persisted when openHAB restarts.
-To have your states persist across restarts you will need to install a Persistence extension.
-
-Specifically, you need to use a `restoreOnStartup` strategy for all your Items.
-Then whatever state Items were in before the restart will be restored automatically.
-
-Example:
-
-```java
-Strategies {
-    default = everyUpdate
-}
-
-Items {
-    // persist all Items on every change and restore them at startup
-    * : strategy = everyChange, restoreOnStartup
-}
-```
 
 {: #state-presentation}
 #### State Presentation

--- a/configuration/items.md
+++ b/configuration/items.md
@@ -206,16 +206,22 @@ Number Livingroom_Temperature "Temperature [%.1f °C]"
 The state of an Item depends on the Item type, the Channel bound to the Item, and internal or external events.
 A analogy can be drawn between the state of an Item and the value of a variable in a computer program.
 
+<!-- TODO: It would be great to add a state diagram for Items
+
 {: #item-state}
 #### Item State
 
 This section provides information about what a user can expect regarding the behavior of the state of an Item
 
--  Items are created with a state of `NULL`.  The Item will remain in this state until it has been acted upon
+-  Items are created with a state of `NULL`.
+The Item will remain in this state until it has been acted upon
 -  Subsequent to the creation of an Item, operations in openHAB such as a user interacting with the Item using the `Basic UI`, or a Binding updating the state of an Item will change the state of the Item 
--  Once an Item is being used, its state will depend upon the Thing to which it is linked, or upon the specifics of the Binding that created the Item.  Example - The state of a Switch may change from `NULL` to `ON` or `OFF`
--  A Binding may set the state of an Item to `UNDEF` if it looses communications with a Thing (for example, a Z-wave doorbell with a dead battery). The Binding may also set the state to `UNDEF` if an error exists in the binding configuration, or under other conditions
--  An Item may be assigned a particular state as part of the execution of a [Rule]({{base}}/configuration/rules-dsl.html).  See, particularly, [Manipulating Item States]({{base}}/configuration/rules-dsl.html#Manipulating Item States)
+-  Once an Item is being used, its state will depend upon the Thing to which it is linked, or upon the specifics of the Binding that created the Item.
+Example - The state of a Switch may change from `NULL` to `ON` or `OFF`
+-  A Binding may set the state of an Item to `UNDEF` if it looses communications with a Thing (for example, a Z-wave doorbell with a dead battery).
+The Binding may also set the state to `UNDEF` if an error exists in the binding configuration, or under other conditions
+-  An Item may be assigned a particular state as part of the execution of a [Rule]({{base}}/configuration/rules-dsl.html).
+See, particularly, [Manipulating Item States]({{base}}/configuration/rules-dsl.html#Manipulating Item States)
 -  The state of an Item after an openHAB startup will depend upon whether the user has configured [Persistence]({{base}}/configuration/persistence.html) or has created a set of ["System started"](https://github.com/openhab/openhab1-addons/wiki/Persistence#Startup Behavior) rules
 
 *N.B.*  Many openHAB users find that it can be very useful to use Persistence and "System started" rules so that their systems behaves in a predictable way after an openHAB restart.


### PR DESCRIPTION
Propose to add a section on "Item State" to the documentation on Items to address #507.
Adding an Item state diagram to this contribution would be very useful.
Signed-off-by: Brad Gilmer <brad@gilmer.tv> (github: bgilmer77)