### PR TITLE
Adds "val" to reentrantlock declaration statement

### DIFF
--- a/configuration/rules-dsl.md
+++ b/configuration/rules-dsl.md
@@ -627,7 +627,7 @@ If a rule triggers on UI events it may be necessary to guard against concurrency
 ```javascript
 import java.util.concurrent.locks.ReentrantLock
 
-ReentrantLock lock  = new ReentrantLock()
+val ReentrantLock lock  = new ReentrantLock()
 
 rule ConcurrentCode
 when


### PR DESCRIPTION
This is a small typo but it can confuse beginners (e.g. me).