### PR TITLE
Network Binding needs update because of a wrong Thing definition

### DIFF
--- a/_addons_bindings/network/readme.md
+++ b/_addons_bindings/network/readme.md
@@ -161,10 +161,10 @@ Things support the following channels:
 
 ## Full Example
 
-demo.Things:
+demo.things:
 
 ```xtend
-network:pingdevice:devicename [ hostname="192.168.0.42" ]
+Thing network:pingdevice:devicename [ hostname="192.168.0.42" ]
 ```
 
 demo.items:


### PR DESCRIPTION
The Eclipse SmartHome detects the lowercase *.things as an real things-file.
The upper case *.Things file will be displayed with an unknown icon.

The Thing declaration is not complete