### PR TITLE
updated Designer download information

### DIFF
--- a/configuration/editors.md
+++ b/configuration/editors.md
@@ -58,8 +58,7 @@ If you are using [openHABian]({{base}}/installation/openhabian.html), the needed
 
 ### Setup
 
-- Get the latest version from: [Eclipse SmartHome Designer Downloads](https://github.com/eclipse/smarthome/blob/master/docs/documentation/community/downloads.md#designer-builds)
-  (*Note:* the "Snapshot" build is currently not recommended for daily use)
+- Get the latest version from: [Eclipse SmartHome Designer Downloads](https://www.eclipse.org/smarthome/documentation/community/downloads.html#binary-artifacts).
 
 The downloaded `.zip` archive contains the Designer executable.
 


### PR DESCRIPTION
Note: The snapshot Designer is about to be removed, see https://github.com/eclipse/smarthome/pull/4573, I therefore updated the info in our docs.

Signed-off-by: Kai Kreuzer <kai@openhab.org>