### PR TITLE
Update Linux and Console instructions for 2.2.0

### DIFF
--- a/administration/console.md
+++ b/administration/console.md
@@ -20,7 +20,11 @@ The method to access the console depends on how openHAB was started.
 * When started in interactive mode using the provided command line scripts, openHAB naturally transitions directly to the console prompt.
 * When started as a service (e.g. when installed from our package repository), openHAB is running as a background process.
 
-In both cases, the console can be reached via secure shell connection ([SSH](https://en.wikipedia.org/wiki/Secure_Shell)).
+The simplest way of accessing the console is by running the `client` (or `client.bat` for windows) script located in `$OPENHAB_RUNTIME/bin/`. Linux package based installations can also use the command `openhab-cli console`.
+
+### Connecting via SSH
+
+The console can also be reached via secure shell connection ([SSH](https://en.wikipedia.org/wiki/Secure_Shell)).
 
 To reach the console using SSH, use the following command to connect to the localhost interface on TCP port 8101:
 
@@ -55,6 +59,22 @@ The first successful connection triggers generation of the Karaf remote console 
 *Note:* On slower systems, such as Raspberry Pi or Pine64, this first SSH connection may even time out.
 If this happens, simply try connecting again until successful.
 
+If openHAB is removed and reinstalled, then further attempts by SSH may bring the following error:
+
+```text
+@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@
+@ WARNING: REMOTE HOST IDENTIFICATION HAS CHANGED! @
+@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@
+```
+
+This is normal, since a new instance of openHAB will generate a new identification. The warning should also come with instruction on how to resume access to the console through SSH. e.g. by using the command:
+
+```shell
+ssh-keygen -f "/home/<username>/.ssh/known_hosts" -R [localhost]:8101
+```
+
+## Using the Console
+
 After successful connection and authentication, the console will appear:
 
 ```text
@@ -63,7 +83,7 @@ After successful connection and authentication, the console will appear:
  / __ \/ __ \/ _ \/ __ \/ /_/ / /| | / __  |
 / /_/ / /_/ /  __/ / / / __  / ___ |/ /_/ /
 \____/ .___/\___/_/ /_/_/ /_/_/  |_/_____/
-    /_/                        2.0.0
+    /_/                        2.2.0
                                Release Build
 
 Hit '<tab>' for a list of available commands
@@ -72,8 +92,6 @@ Hit '<ctrl-d>' or type 'system:shutdown' or 'logout' to shutdown openHAB.
 
 openhab>
 ```
-
-## Using the Console
 
 The command `help` is listing all available commands or describes a specific subsystem/command:
 

--- a/administration/console.md
+++ b/administration/console.md
@@ -17,10 +17,9 @@ The console offers the option to:
 
 The method to access the console depends on how openHAB was started.
 
-* When started in interactive mode using the provided command line scripts, openHAB naturally transitions directly to the console prompt.
-* When started as a service (e.g. when installed from our package repository), openHAB is running as a background process.
-
-The simplest way of accessing the console is by running the `client` (or `client.bat` for windows) script located in `$OPENHAB_RUNTIME/bin/`. Linux package based installations can also use the command `openhab-cli console`.
+* When started in interactive mode using the provided command line scripts (e.g. `start.sh` or `start.bat`), openHAB naturally transitions directly to the console prompt.
+* When started as a service (i.e. when openHAB is running as a background process), access to the console is given by running the `$OPENHAB_RUNTIME/bin/client` (`client.bat` for Windows) script or by [connecting via SSH](#connecting-via-ssh).
+Linux package based installations can also use the command `openhab-cli console`.
 
 The default username/password is **openhab:habopen**, so enter `habopen` at the password prompt.
 
@@ -60,20 +59,6 @@ The first successful connection triggers generation of the Karaf remote console 
 
 *Note:* On slower systems, such as Raspberry Pi or Pine64, this first SSH connection may even time out.
 If this happens, simply try connecting again until successful.
-
-If openHAB is removed and reinstalled, then further attempts by SSH may bring the following error:
-
-```text
-@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@
-@ WARNING: REMOTE HOST IDENTIFICATION HAS CHANGED! @
-@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@
-```
-
-This is normal, since a new instance of openHAB will generate a new identification. The warning should also come with instruction on how to resume access to the console through SSH. e.g. by using the command:
-
-```shell
-ssh-keygen -f "/home/<username>/.ssh/known_hosts" -R [localhost]:8101
-```
 
 ## Using the Console
 

--- a/administration/console.md
+++ b/administration/console.md
@@ -22,6 +22,8 @@ The method to access the console depends on how openHAB was started.
 
 The simplest way of accessing the console is by running the `client` (or `client.bat` for windows) script located in `$OPENHAB_RUNTIME/bin/`. Linux package based installations can also use the command `openhab-cli console`.
 
+The default username/password is **openhab:habopen**, so enter `habopen` at the password prompt.
+
 ### Connecting via SSH
 
 The console can also be reached via secure shell connection ([SSH](https://en.wikipedia.org/wiki/Secure_Shell)).

--- a/installation/linux.md
+++ b/installation/linux.md
@@ -283,7 +283,7 @@ Systems based on **systemd** (e.g. Debian 8, Ubuntu 15.x, Raspbian Jessie and ne
 
 #### Command Line Interface (CLI)
 
-After installing openHAB, a shortcut named `openhab-cli` provides access to the openHAB specific commands (such as [backup, restore](#backup-and-restore), and [console]({{base}}/administration/logging.html#karaf-console)).
+After installing openHAB, a shortcut named `openhab-cli` provides access to the openHAB specific commands (such as [backup, restore](#backup-and-restore), and [console]({{base}}/administration/console.html)).
 To use the shortcuts in a terminal, simply type `openhab-cli` followed by the command. For example:
 
 ```shell

--- a/installation/linux.md
+++ b/installation/linux.md
@@ -283,8 +283,9 @@ Systems based on **systemd** (e.g. Debian 8, Ubuntu 15.x, Raspbian Jessie and ne
 
 #### Command Line Interface (CLI)
 
-After installing openHAB, a shortcut named `openhab-cli` provides access to the openHAB specific commands (such as [backup, restore](#backup-and-restore), and [console]({{base}}/administration/console.html)).
-To use the shortcuts in a terminal, simply type `openhab-cli` followed by the command. For example:
+After installing openHAB, a shortcut named `openhab-cli` provides access to the openHAB-specific commands (such as [backup, restore](#backup-and-restore), and [console]({{base}}/administration/console.html)).
+To use the shortcuts in a terminal, simply type `openhab-cli` followed by the command.
+For example:
 
 ```shell
 Usage:  openhab-cli command [options]
@@ -605,7 +606,7 @@ $OPENHAB_RUNTIME/bin/backup --help
 
 ## Viewing Log Messages
 
-In order to get more insight on what your openHAB system is doing and to see occurring error messages, it is recommended to always have a look on the openHAB log files.
+You can learn more about openHAB and how it works by looking at your log files.
 These will tell you everything you might need to know.
 Execute the following command in one session or have both files separated in sessions side by side:
 

--- a/installation/windows.md
+++ b/installation/windows.md
@@ -218,6 +218,9 @@ By installing the openHAB process as a service in Windows, you can:
 
 ### Connecting to the openHAB console
 
+You can connect to openHAB's console using the the `C:\openHAB2\runtime\bin\client.bat` script on the local machine. 
+Alternatively, you can use a standard SSH client:
+
 -   Install an SSH client application, e.g., [Putty](https://www.chiark.greenend.org.uk/~sgtatham/putty/latest.html), [KiTTY](http://kitty.9bis.net/) or [Xshell 5](https://www.netsarang.com/products/xsh_overview.html)
 
 -   Setup a session with the following parameters:


### PR DESCRIPTION
 - Removed manual backup instructions as these were out of date and do not work across versions.

Closes #579 
Closes openhab/openhab-distro#554

Signed-off-by: Ben Clark <ben@benjyc.uk>