### PR TITLE
Correct chat id for Telegram action

### DIFF
--- a/_addons_actions/telegram/readme.md
+++ b/_addons_actions/telegram/readme.md
@@ -27,7 +27,7 @@ As described in the Telegram Bot API, this is the manual procedure needed in ord
 1. Create the destination chat and get the chatId
   * Open a new chat with your new Bot and post a message on the chat
   * Open a browser and invoke `https://api.telegram.org/bot<token>/getUpdates` (where `<token>` is the authentication token previously obtained)
-  * Look at the JSON result and write down the value of `result[0].message.from.id`. That is the chatId.
+  * Look at the JSON result and write down the value of `result[0].message.chat.id`. That is the chatId.
 
 ## Configuration
 


### PR DESCRIPTION
With `chat.id` it's also possible to add the bot to a group