### PR TITLE
Fixing a bug in the Apache Karaf change password command

### DIFF
--- a/administration/console.md
+++ b/administration/console.md
@@ -150,7 +150,7 @@ Alternately, run the following Linux shell command, which will perform the repla
 Substitute `securePassword` with your desired password.
 
 ```shell
-sudo sed -i -e "s/openhab = .*,/openhab = securePassword/g" /var/lib/openhab2/etc/users.properties
+sudo sed -i -e "s/openhab = .*,/openhab = securePassword,/g" /var/lib/openhab2/etc/users.properties
 ```
 
 Depending on your system, you may have to [change the directory](#console-settings-files-and-directories) at the end of the command.


### PR DESCRIPTION
This command will remove the comma which makes the new password unusable so it needs put a "," in the replacement string as well.
For comparison look at the password change function which has the "," in both the search and replace.
https://github.com/openhab/openhabian/blob/master/functions/passwords.sh
sed -i "s/openhab = .*,/openhab = $passwordChange,/g" /var/lib/openhab2/etc/users.properties