### PR TITLE
Use -e USER_ID instead of --user for systemd, too

### DIFF
--- a/installation/docker.md
+++ b/installation/docker.md
@@ -146,7 +146,8 @@ ExecStart=/usr/bin/docker run --name=%n --net=host --tty \
   -v /opt/openhab/addons:/openhab/addons \
   -v /opt/openhab/.java:/openhab/.java \
   --device=/dev/ttyUSB0 \
-  --user=<uid> \
+  -e USER_ID=<uid_of_openhab> \
+  -e GROUP_ID=<gid_of_openhab> \
   openhab/openhab:<version>-<architecture>-<distributions>
 ExecStop=/usr/bin/docker stop -t 2 %n ; /usr/bin/docker rm -f %n
 


### PR DESCRIPTION
Docker uses --user flag which causes container to not be able to create groups. This has already been fixed in the docs for the docker run command. 
This change just adds the same fix toe the systemd service file.

Signed-off-by: Martin Runge <martin.runge@web.de>