### PR TITLE
Extraxt null annotations explanation into conventions Section, see ESH

### DIFF
--- a/_includes/dev-menu.html
+++ b/_includes/dev-menu.html
@@ -24,6 +24,7 @@
     <ul>
       <li><a href="{{docu}}/development/ide.html">IDE Setup</a></li>
       <li><a href="{{docu}}/development/guidelines.html">Code Guidelines</a></li>
+      <li><a href="{{docu}}/development/conventions.html">Conventions</a></li>
       <li><a href="{{docu}}/development/bindings.html">Developing Bindings</a></li>
       <li><a href="{{docu}}/development/logging.html">Logging</a></li>
     </ul>

--- a/developers/development/conventions.md
+++ b/developers/development/conventions.md
@@ -1,0 +1,35 @@
+---
+layout: documentation
+---
+
+{% include base.html %}
+
+# Conventions
+
+## Null annotations
+
+[Null annotations](https://wiki.eclipse.org/JDT_Core/Null_Analysis) are used from the Eclipse JDT project.
+Our intention with these annotations is to transfer a method's contract written in its JavaDoc into the code to be processed by tools.
+We are aware that these annotations can be used for **static** checks, but **not** at runtime.
+
+Thus for publicly exposed methods that belong to our API and are (potentially) called by external callers, we cannot omit a `null` check although a method parameter is marked to be not `null` via an annotation.
+We will get a warning in the IDE for this check, but we decided to live with that.
+For private methods or methods in an internal package we agreed to respect the annotations and omit an additional `null` check.
+
+To use the annotations, every bundle should have an **optional** `Import-Package` dependency to `org.eclipse.jdt.annotation`.
+Classes should be annotated by `@NonNullByDefault` and return types, parameter types, generic types etc. are annotated with `@Nullable` only.
+Fields that get a static and mandatory reference injected through OSGi Declarative Services can be annotated with
+
+```java
+@NonNullByDefault({})
+private MyService injectedService;
+```
+
+to skip the nullevaluation for these fields.
+Fields within `ThingHandler` classes that are initialized within the `initialize()` method may also be annotated like this, because the framework ensures that `initialize()` will be called before any other method.
+However please watch the scenario where the initialization of the handler fails, because then fields might not have been initialized and using them should be prepended by a `null` check.
+
+There is **no need** for a `@NonNull` annotation because it is set as default.
+Test classes do not have to be annotated (the usage of `SuppressWarnings("null")` in tests is allowed too).
+
+The transition of existing classes could be a longer process but if you want to use nullness annotation in a class / interface you need to set the default for the whole class and annotate all types that differ from the default.

--- a/developers/development/conventions.md
+++ b/developers/development/conventions.md
@@ -12,7 +12,7 @@ layout: documentation
 The intention of these annotations is to transfer a method's contract written in its JavaDoc into the code to be processed by tools.
 These annotations can be used for **static** checks, but **not** at runtime.
 
-Thus for publicly exposed methods that belong to our API and are (potentially) called by external callers, a `null` check cannot be omitted, although a method parameter is marked to be not `null` via an annotation.
+Thus for publicly exposed methods that belong to the API and are (potentially) called by external callers, a `null` check cannot be omitted, although a method parameter is marked to be not `null` via an annotation.
 There will be a warning in the IDE for this check, but that is fine.
 For private methods or methods in an internal package the annotations are respected and additional `null` checks are omitted.
 

--- a/developers/development/conventions.md
+++ b/developers/development/conventions.md
@@ -6,17 +6,17 @@ layout: documentation
 
 # Conventions
 
-## Null annotations
+## Null Annotations
 
 [Null annotations](https://wiki.eclipse.org/JDT_Core/Null_Analysis) are used from the Eclipse JDT project.
-Our intention with these annotations is to transfer a method's contract written in its JavaDoc into the code to be processed by tools.
-We are aware that these annotations can be used for **static** checks, but **not** at runtime.
+The intention of these annotations is to transfer a method's contract written in its JavaDoc into the code to be processed by tools.
+These annotations can be used for **static** checks, but **not** at runtime.
 
-Thus for publicly exposed methods that belong to our API and are (potentially) called by external callers, we cannot omit a `null` check although a method parameter is marked to be not `null` via an annotation.
-We will get a warning in the IDE for this check, but we decided to live with that.
-For private methods or methods in an internal package we agreed to respect the annotations and omit an additional `null` check.
+Thus for publicly exposed methods that belong to our API and are (potentially) called by external callers, a `null` check cannot be omitted, although a method parameter is marked to be not `null` via an annotation.
+There will be a warning in the IDE for this check, but that is fine.
+For private methods or methods in an internal package the annotations are respected and additional `null` checks are omitted.
 
-To use the annotations, every bundle should have an **optional** `Import-Package` dependency to `org.eclipse.jdt.annotation`.
+To use the annotations, every bundle must have an **optional** `Import-Package` dependency to `org.eclipse.jdt.annotation`.
 Classes should be annotated by `@NonNullByDefault` and return types, parameter types, generic types etc. are annotated with `@Nullable` only.
 Fields that get a static and mandatory reference injected through OSGi Declarative Services can be annotated with
 
@@ -27,9 +27,9 @@ private MyService injectedService;
 
 to skip the nullevaluation for these fields.
 Fields within `ThingHandler` classes that are initialized within the `initialize()` method may also be annotated like this, because the framework ensures that `initialize()` will be called before any other method.
-However please watch the scenario where the initialization of the handler fails, because then fields might not have been initialized and using them should be prepended by a `null` check.
+However, please watch the scenario where the initialization of the handler fails, because fields might not have been initialized and using them should be prepended by a `null` check.
 
 There is **no need** for a `@NonNull` annotation because it is set as default.
-Test classes do not have to be annotated (the usage of `SuppressWarnings("null")` in tests is allowed too).
+Test classes do not have to be annotated (the usage of `SuppressWarnings("null")` is allowed, too).
 
-The transition of existing classes could be a longer process but if you want to use nullness annotation in a class / interface you need to set the default for the whole class and annotate all types that differ from the default.
+The transition of existing classes can be a longer process, but using nullness annotations in a class / interface requires to set the default for the whole class and annotations on all types that differ from the default.

--- a/developers/development/guidelines.md
+++ b/developers/development/guidelines.md
@@ -27,27 +27,7 @@ To speed up the contribution process, we therefore advice to go through this che
 1. For dependency injection, OSGi Declarative Services should be used.
 1. OSGi Declarative Services should be declared using annotations. The IDE will take care of the service `*.xml` file creation. See the official OSGi documentation for an [example here](http://enroute.osgi.org/services/org.osgi.service.component.html).
 1. Packages that contain classes that are not meant to be used by other bundles should have "internal" in their package name.
-1. [Null annotations](https://wiki.eclipse.org/JDT_Core/Null_Analysis) are used from the Eclipse JDT project.
-Our intention with these annotations is to transfer a method's contract written in its JavaDoc into the code to be processed by tools.
-We are aware that these annotations can be used for **static** checks, but **not** at runtime.  
-Thus for publicly exposed methods that belong to our API and are (potentially) called by external callers, we cannot omit a `null` check although a method parameter is marked to be not `null` via an annotation.
-We will get a warning in the IDE for this check, but we decided to live with that.
-For private methods or methods in an internal package we agreed to respect the annotations and omit an additional `null` check.  
-To use the annotations, every bundle should have an **optional** `Import-Package` dependency to `org.eclipse.jdt.annotation`.
-Classes should be annotated by `@NonNullByDefault` and return types, parameter types, generic types etc. are annotated with `@Nullable` only.
-Fields that get a static and mandatory reference injected through OSGi Declarative Services can be annotated with
-
-```java
-@NonNullByDefault({})
-private MyService injectedService;
-```
-
-to skip the nullevaluation for these fields.  
-Fields within `ThingHandler` classes that are initialized within the `initialize()` method may also be annotated like this, because the framework ensures that `initialize()` will be called before any other method.
-However please watch the scenario where the initialization of the handler fails, because then fields might not have been initialized and using them should be prepended by a `null` check.  
-There is **no need** for a `@NonNull` annotation because it is set as default.
-The transition of existing classes could be a longer process but if you want to use nullness annotation in a class / interface you need to set the default for the whole class and annotate all types that differ from the default.
-Test classes do not have to be annotated.
+[Null annotations](https://wiki.eclipse.org/JDT_Core/Null_Analysis) are used from the Eclipse JDT project. `@NonNullByDefault` and `@Nullable` should be used, for details see [Null annotation conventions](conventions.html#null-annotations).
 
 ## B. OSGi Bundles
 


### PR DESCRIPTION
See https://github.com/eclipse/smarthome/pull/5389

Signed-off-by: Stefan Triller <stefan.triller@telekom.de>