### PR TITLE
config: items: Correcting label in table of types

### DIFF
--- a/configuration/items.md
+++ b/configuration/items.md
@@ -100,7 +100,7 @@ This optimization is reflected in the data and command types.
 
 Available Item types are:
 
-| Item Name      | Description | Command Types |
+| Type Name      | Description | Command Types |
 |----------------|-------------|---------------|
 | Color          | Color information (RGB) | OnOff, IncreaseDecrease, Percent, HSB |
 | Contact        | Status of contacts, e.g. door/window contacts | OpenClose |


### PR DESCRIPTION
I think that way it is more clear that we are talking about the name of the type.
My first thought on this was, that this column is about the name of the item, but that one is free to choose of course.

Signed-off-by: Thomas Karl Pietrowski <thopiekar@gmail.com> (github: thopiekar)