### PR TITLE
Fix README.md file not found when running update-external-resources.sh on case sensitive file systems

### DIFF
--- a/process_addons.groovy
+++ b/process_addons.groovy
@@ -43,8 +43,9 @@ def process_addon_type = { features, sources, type, collection, suffix, lblremov
                 if (! readme.exists()) {
                     log.warn("No README.md found.")
                 } else {
-                    readme.renameTo(new File(simpleNameDir.path, 'readme.md'))
-                    //println readme
+                    def readmeLowerCase = new File(simpleNameDir.path, 'readme.md')
+                    readme.renameTo(readmeLowerCase)
+                    readme = readmeLowerCase
                     def label = readme.readLines().find{it.startsWith('#')}
                     if (label == null) {
                         log.warn("No level 1 header found.")


### PR DESCRIPTION
This should fix README.md file not found errors when running update-external-resources.sh on case senstive file systems (Linux).

The process_addons.groovy script renames the README.md files to readme.md and then starts reading lines from README.md which ofcourse no longer exists. 