### PR TITLE
Replace all ".md" with ".html" inside zwave files on generation

### DIFF
--- a/update-external-resources.sh
+++ b/update-external-resources.sh
@@ -61,3 +61,5 @@ echo_process "Running Maven Clean Plugin... "
 mvn clean
 echo_process "Running Maven Package Plugin... "
 mvn package
+
+find ./_addons_bindings/zwave/ -name '*.md' -type f -exec sed -i 's/\.md)/\.html)/gI' {} \;


### PR DESCRIPTION
Fixes #642 

I'm not sure if this is a "decent" way of doing it. But it does solve the issue of having links broken in either place.

CC: @cdjackson

@kaikreuzer, should I also add the new updated resources to this PR? Or will you run this later? I created a branch of this to see [here](https://github.com/openhab/openhab-docs/compare/gh-pages...BClark09:update-res)

Signed-off-by: Ben Clark <ben@benjyc.uk>