### PR TITLE
Prevent non-binding folders from being added to the list

### DIFF
--- a/addons/bindings.md
+++ b/addons/bindings.md
@@ -84,6 +84,7 @@ Bindings connect your smart home's devices and technologies to openHAB.
   </thead>
   <tbody>
     {% for binding in site.addons_bindings %}
+        {% if binding.install %}
         <tr class="install-{{binding.install}} since-{{binding.since}}">
           <td>
             <h4><a href="{{base}}{{binding.url}}">{% if binding.logo %}<img class="logo" src="{{base}}/{{binding.logo}}" title="{{ binding.label }}" alt="{{ binding.label }}" />{% else %}{{ binding.label }}{% endif %}</a></h4>
@@ -91,6 +92,7 @@ Bindings connect your smart home's devices and technologies to openHAB.
           </td>
           <td>{{ binding.description | markdownify }}</td>
         </tr>
+        {% endif %}
     {% endfor %}
- </tbody>
+  </tbody>
 </table>


### PR DESCRIPTION
Fixes #661 

I'd admit I'm unfamiliar with Jekyll, but from the looks of things, the [binding list is generated](https://github.com/openhab/openhab-docs/blob/gh-pages/_config.yml#L18) using a Jekyll collection, which covers the whole directory tree, not just the single level of folders we want to use.

I couldn't find a way of limiting the depth created by the for loop, but we can make a simple check inside it to see if the binding in the collection has a relevant item.

Before:
![image](https://user-images.githubusercontent.com/8983584/40314716-37fe61b0-5d11-11e8-8570-96524541259b.png)

After:
![image](https://user-images.githubusercontent.com/8983584/40314689-27293950-5d11-11e8-936b-35533d13c945.png)


Signed-off-by: Ben Clark <ben@benjyc.uk>