### PR TITLE
Clarify Contact Items

### DIFF
--- a/concepts/items.md
+++ b/concepts/items.md
@@ -16,7 +16,7 @@ The following item types are currently available (alphabetical order):
 | Item Name          | Description | Command Types |
 |--------------------|-------------|---------------|
 | Color              | Color information (RGB) | OnOff, IncreaseDecrease, Percent, HSB |
-| Contact            | Item storing status of e.g. door/window contacts. Does not accept commands. | OpenClosed |
+| Contact            | Item storing status of e.g. door/window contacts | OpenClosed |
 | DateTime           | Stores date and time | - |
 | Dimmer             | Item carrying a percentage value for dimmers | OnOff, IncreaseDecrease, Percent |
 | Group              | Item to nest other items / collect them in groups | - |
@@ -26,8 +26,8 @@ The following item types are currently available (alphabetical order):
 | Number:<dimension> | like Number, additional dimension information for unit support | Quantity |
 | Player             | Allows to control players (e.g. audio players) | PlayPause, NextPrevious, RewindFastforward |
 | Rollershutter      | Typically used for blinds | UpDown, StopMove, Percent |
-| String             | Stores texts. Often used to send string commands to bindings. | String |
-| Switch             | Your typical on/off switch. | OnOff |
+| String             | Stores texts | String |
+| Switch             | Typically used for lights (on/off) | OnOff |
 
 ## Group Items
 

--- a/concepts/items.md
+++ b/concepts/items.md
@@ -16,7 +16,7 @@ The following item types are currently available (alphabetical order):
 | Item Name          | Description | Command Types |
 |--------------------|-------------|---------------|
 | Color              | Color information (RGB) | OnOff, IncreaseDecrease, Percent, HSB |
-| Contact            | Item storing status of e.g. door/window contacts | OpenClosed |
+| Contact            | Item storing status of e.g. door/window contacts | OpenClose |
 | DateTime           | Stores date and time | - |
 | Dimmer             | Item carrying a percentage value for dimmers | OnOff, IncreaseDecrease, Percent |
 | Group              | Item to nest other items / collect them in groups | - |

--- a/concepts/items.md
+++ b/concepts/items.md
@@ -16,7 +16,7 @@ The following item types are currently available (alphabetical order):
 | Item Name          | Description | Command Types |
 |--------------------|-------------|---------------|
 | Color              | Color information (RGB) | OnOff, IncreaseDecrease, Percent, HSB |
-| Contact            | Item storing status of e.g. door/window contacts | OpenClose |
+| Contact            | Item storing status of e.g. door/window contacts. Does not accept commands. | OpenClosed |
 | DateTime           | Stores date and time | - |
 | Dimmer             | Item carrying a percentage value for dimmers | OnOff, IncreaseDecrease, Percent |
 | Group              | Item to nest other items / collect them in groups | - |
@@ -26,8 +26,8 @@ The following item types are currently available (alphabetical order):
 | Number:<dimension> | like Number, additional dimension information for unit support | Quantity |
 | Player             | Allows to control players (e.g. audio players) | PlayPause, NextPrevious, RewindFastforward |
 | Rollershutter      | Typically used for blinds | UpDown, StopMove, Percent |
-| String             | Stores texts | String |
-| Switch             | Typically used for lights (on/off) | OnOff |
+| String             | Stores texts. Often used to send string commands to bindings. | String |
+| Switch             | Your typical on/off switch. | OnOff |
 
 ## Group Items
 


### PR DESCRIPTION
Clarification is needed that a contact item will not accept any commands (for example, MQTT binding with COMMAND does not update item and gives a 'command is NULL' error, that is in fact also confusing). 

The Contact item 'CommandType' should be renamed OpenClosed with a D (and not OpenClose)  as the status is in fact CLOSED and not CLOSE. 

Furthermore a switch is not only used for lights, in fact, lights are nowadays more often controlled by Color items so it's not the best example, best to not be too specific and just mention ON and OFF.

Signed-off-by: Bas Stronks bas.stronks@gmaill.com (github: DomQuixote)