### PR TITLE
Automate external content update and website redeploy with Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,9 +6,9 @@ branches:
   - gh-pages
 env:
   global:
-  - USER="ghys"
-  - EMAIL="github@schaus.net"
-  - REPO="ghys/openhab-docs"
+  - USER="openhab-bot"
+  - EMAIL="bot@openhab.org"
+  - REPO="openhab/openhab-docs"
   - BRANCH="gh-pages"
   - GH_REPO="github.com/${REPO}.git"
   - secure: omm7zbQZz/XmRzz/5N97d3IqRKqViqMuYx6mrGI4iY3TmkZrSNut1PUaLgv+svrXMJTt2SvD+UWmyR2EFaVNrjqQzi9BcY6df8Zn1E6lgiNKF0mSatYNKLt+JJvr1kCvkHmJAijZBOSM3oHOnm3fgRKF/bTkl9dMFVmSl9dG9b2BhZyjvByJV7GDPNXKsrQWFqKoY0nO/+25u4gUsmQDJkVCPHexSgD2aWKSStgU556FxegihifGIEyYBDLVwlboFFrZ+/nKSxgvoR0ESbdLTqExgZGyPg5cZOnRTztA+YlV2YKxIYiU6RHWFIak2uD5aV9EXr2GG1AkQEX3kn0PGBn/c+y37O3/lTXIUFXNV2etc0L1aMNlE7rMDiezinByQuWrZqwMxPKtPj6DI3CSVr0uOYglL1E0u9euYE2coTilc78x033gV19wvkCRLiNeFWlht7MF+//apO0mr3iS+FLD8zh+33VQ1xnj57oD+WsSwJB1oUJX4ZEGQkE3WbISpdy4VeBTzBNdi10pl6cJr7GWrlpHluC9tP8609N/puSPCotbQh8RhwgMQLdxYS/YFTT6tMjp6czc64MIgEPABTWNGd79J7pp7m/7tYRmiSC/nat3d5MGlG0u557FasKUAYZphl+wAcEQCSIMZ3wQ27u+BZNjp5i30as0Q6yZpow=

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,4 +22,5 @@ script:
 - git remote add origin-pages https://${GH_TOKEN}@${GH_REPO} > /dev/null 2>&1
 - git commit -am "Updated external content (Travis build ${TRAVIS_BUILD_NUMBER})"
 - git push -u origin-pages ${BRANCH}
+after_success:
 - curl -X POST -d '' https://api.netlify.com/build_hooks/${NETLIFY_BUILD_HOOK}

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,16 @@
+language: groovy
+rvm:
+- 2.0.0
+env:
+  global:
+  - USER="ghys"
+  - EMAIL="github@schaus.net"
+  - REPO="ghys/openhab-docs"
+  - GH_REPO="github.com/${USER}/${REPO}.git"
+  - secure: omm7zbQZz/XmRzz/5N97d3IqRKqViqMuYx6mrGI4iY3TmkZrSNut1PUaLgv+svrXMJTt2SvD+UWmyR2EFaVNrjqQzi9BcY6df8Zn1E6lgiNKF0mSatYNKLt+JJvr1kCvkHmJAijZBOSM3oHOnm3fgRKF/bTkl9dMFVmSl9dG9b2BhZyjvByJV7GDPNXKsrQWFqKoY0nO/+25u4gUsmQDJkVCPHexSgD2aWKSStgU556FxegihifGIEyYBDLVwlboFFrZ+/nKSxgvoR0ESbdLTqExgZGyPg5cZOnRTztA+YlV2YKxIYiU6RHWFIak2uD5aV9EXr2GG1AkQEX3kn0PGBn/c+y37O3/lTXIUFXNV2etc0L1aMNlE7rMDiezinByQuWrZqwMxPKtPj6DI3CSVr0uOYglL1E0u9euYE2coTilc78x033gV19wvkCRLiNeFWlht7MF+//apO0mr3iS+FLD8zh+33VQ1xnj57oD+WsSwJB1oUJX4ZEGQkE3WbISpdy4VeBTzBNdi10pl6cJr7GWrlpHluC9tP8609N/puSPCotbQh8RhwgMQLdxYS/YFTT6tMjp6czc64MIgEPABTWNGd79J7pp7m/7tYRmiSC/nat3d5MGlG0u557FasKUAYZphl+wAcEQCSIMZ3wQ27u+BZNjp5i30as0Q6yZpow=
+before_install:
+- sh update-external-resources.sh
+script:
+- mvn clean package
+after_success:
+- git status

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,9 +21,10 @@ script:
 - git status
 - git config user.email ${EMAIL}
 - git config user.name ${USER}
-- git checkout -b ${BRANCH}
+- git checkout ${BRANCH}
 - git remote add origin-pages https://${GH_TOKEN}@${GH_REPO} > /dev/null 2>&1
-- git commit -am "Updated external content (Travis build ${TRAVIS_BUILD_NUMBER})"
+- git add -A
+- git commit -m "Updated external content (Travis build ${TRAVIS_BUILD_NUMBER})"
 - git push -u origin-pages ${BRANCH}
 after_success:
 - curl -X POST -d '' https://api.netlify.com/build_hooks/${NETLIFY_BUILD_HOOK}

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,11 +6,20 @@ env:
   - USER="ghys"
   - EMAIL="github@schaus.net"
   - REPO="ghys/openhab-docs"
-  - GH_REPO="github.com/${USER}/${REPO}.git"
+  - BRANCH="gh-pages"
+  - GH_REPO="github.com/${REPO}.git"
   - secure: omm7zbQZz/XmRzz/5N97d3IqRKqViqMuYx6mrGI4iY3TmkZrSNut1PUaLgv+svrXMJTt2SvD+UWmyR2EFaVNrjqQzi9BcY6df8Zn1E6lgiNKF0mSatYNKLt+JJvr1kCvkHmJAijZBOSM3oHOnm3fgRKF/bTkl9dMFVmSl9dG9b2BhZyjvByJV7GDPNXKsrQWFqKoY0nO/+25u4gUsmQDJkVCPHexSgD2aWKSStgU556FxegihifGIEyYBDLVwlboFFrZ+/nKSxgvoR0ESbdLTqExgZGyPg5cZOnRTztA+YlV2YKxIYiU6RHWFIak2uD5aV9EXr2GG1AkQEX3kn0PGBn/c+y37O3/lTXIUFXNV2etc0L1aMNlE7rMDiezinByQuWrZqwMxPKtPj6DI3CSVr0uOYglL1E0u9euYE2coTilc78x033gV19wvkCRLiNeFWlht7MF+//apO0mr3iS+FLD8zh+33VQ1xnj57oD+WsSwJB1oUJX4ZEGQkE3WbISpdy4VeBTzBNdi10pl6cJr7GWrlpHluC9tP8609N/puSPCotbQh8RhwgMQLdxYS/YFTT6tMjp6czc64MIgEPABTWNGd79J7pp7m/7tYRmiSC/nat3d5MGlG0u557FasKUAYZphl+wAcEQCSIMZ3wQ27u+BZNjp5i30as0Q6yZpow=
+  - secure: ImpL0ic+fHnxDGKSnLURrV3p1zJ+6U2VUVIcElT2blIlirXyauebOWMZmqgR1hzW/u2aQuEYKUmKW04BYJ8PodcLH8Ct6QspSP+gOS/fgNJa0VHGV9zysnrVRXat5S6eX3uWcQkfrykwWK2WmNoAsNAgCEnUO+/iwWEjuCZJea0mNKm52bALFCp0LyIdEcbj8lc0DDAvmnDT/yawcooO2bHZuCjd/sX5R0RCPS8rVV8o9VJ4H/45ekYZ/E4ggmJQ8+CckKNn6Rmxl1g5LSNMPzEJoYjQt7bIg2ISrQ/UcWrhoZtPEk1u5duEMlAuHTFImEmCLE4BdpMhA7PFhXQnzJVj+0qZ53+BMLv+MGC1LIDBt/KDQgfbUMUc0chfsbkSM58MJBXotklVhp4D2xawmMJY85CbegiO8m48wpqomjMynmXb0xfcLZf/ra4Eu5ql0I0sICrI36c+E4wGNKLxApLnve1ykY80WkmSZvnwPPq7JPNZSEmI7b0rsSi+bfcABm3VX04cbm4nQ59bj031rjyo8/OzQI7YeLaEEMVDqMWiE+n2nfj+R1BdDpdfQMDyrjdqKcMjIQE9i2zR3GGbOlGsQatBI1qvtEZO9vRYKq0fe1WXc7ChSjFlnbl0/mg/Et5iUyQGNc9GiT4sBT6390p6+DcPug4AqGYdQN+8g6s=
 before_install:
-- ./update-external-resources.sh
+- "./update-external-resources.sh"
 script:
 - mvn clean package
 after_success:
 - git status
+- git config user.email ${EMAIL}
+- git config user.name ${USER}
+- git checkout ${BRANCH}
+- git remote add origin-pages https://${GH_TOKEN}@{GH_REPO} > /dev/null 2>&1
+- git commit -am "Updated external content (Travis build ${TRAVIS_BUILD_NUMBER})"
+- git push origin-pages
+- curl -X POST -d '' https://api.netlify.com/build_hooks/${NETLIFY_BUILD_HOOK}

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,14 +12,14 @@ env:
   - secure: ImpL0ic+fHnxDGKSnLURrV3p1zJ+6U2VUVIcElT2blIlirXyauebOWMZmqgR1hzW/u2aQuEYKUmKW04BYJ8PodcLH8Ct6QspSP+gOS/fgNJa0VHGV9zysnrVRXat5S6eX3uWcQkfrykwWK2WmNoAsNAgCEnUO+/iwWEjuCZJea0mNKm52bALFCp0LyIdEcbj8lc0DDAvmnDT/yawcooO2bHZuCjd/sX5R0RCPS8rVV8o9VJ4H/45ekYZ/E4ggmJQ8+CckKNn6Rmxl1g5LSNMPzEJoYjQt7bIg2ISrQ/UcWrhoZtPEk1u5duEMlAuHTFImEmCLE4BdpMhA7PFhXQnzJVj+0qZ53+BMLv+MGC1LIDBt/KDQgfbUMUc0chfsbkSM58MJBXotklVhp4D2xawmMJY85CbegiO8m48wpqomjMynmXb0xfcLZf/ra4Eu5ql0I0sICrI36c+E4wGNKLxApLnve1ykY80WkmSZvnwPPq7JPNZSEmI7b0rsSi+bfcABm3VX04cbm4nQ59bj031rjyo8/OzQI7YeLaEEMVDqMWiE+n2nfj+R1BdDpdfQMDyrjdqKcMjIQE9i2zR3GGbOlGsQatBI1qvtEZO9vRYKq0fe1WXc7ChSjFlnbl0/mg/Et5iUyQGNc9GiT4sBT6390p6+DcPug4AqGYdQN+8g6s=
 before_install:
 - "./update-external-resources.sh"
-script:
+install:
 - mvn clean package
-after_success:
+script:
 - git status
 - git config user.email ${EMAIL}
 - git config user.name ${USER}
 - git checkout -b ${BRANCH}
-- git remote add origin-pages https://${GH_TOKEN}@{GH_REPO} > /dev/null 2>&1
+- git remote add origin-pages https://${GH_TOKEN}@${GH_REPO} > /dev/null 2>&1
 - git commit -am "Updated external content (Travis build ${TRAVIS_BUILD_NUMBER})"
 - git push -u origin-pages ${BRANCH}
 - curl -X POST -d '' https://api.netlify.com/build_hooks/${NETLIFY_BUILD_HOOK}

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,9 @@
 language: groovy
 rvm:
 - 2.0.0
+branches:
+  only:
+  - gh-pages
 env:
   global:
   - USER="ghys"

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,8 +18,8 @@ after_success:
 - git status
 - git config user.email ${EMAIL}
 - git config user.name ${USER}
-- git checkout ${BRANCH}
+- git checkout -b ${BRANCH}
 - git remote add origin-pages https://${GH_TOKEN}@{GH_REPO} > /dev/null 2>&1
 - git commit -am "Updated external content (Travis build ${TRAVIS_BUILD_NUMBER})"
-- git push origin-pages
+- git push -u origin-pages ${BRANCH}
 - curl -X POST -d '' https://api.netlify.com/build_hooks/${NETLIFY_BUILD_HOOK}

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ script:
 - git checkout ${BRANCH}
 - git remote add origin-pages https://${GH_TOKEN}@${GH_REPO} > /dev/null 2>&1
 - git add -A
-- git commit -m "Updated external content (Travis build ${TRAVIS_BUILD_NUMBER})"
+- git commit -m "Updated external content (Travis build ${TRAVIS_BUILD_NUMBER}) [skip ci]"
 - git push -u origin-pages ${BRANCH}
 after_success:
 - curl -X POST -d '' https://api.netlify.com/build_hooks/${NETLIFY_BUILD_HOOK}

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ env:
   - GH_REPO="github.com/${USER}/${REPO}.git"
   - secure: omm7zbQZz/XmRzz/5N97d3IqRKqViqMuYx6mrGI4iY3TmkZrSNut1PUaLgv+svrXMJTt2SvD+UWmyR2EFaVNrjqQzi9BcY6df8Zn1E6lgiNKF0mSatYNKLt+JJvr1kCvkHmJAijZBOSM3oHOnm3fgRKF/bTkl9dMFVmSl9dG9b2BhZyjvByJV7GDPNXKsrQWFqKoY0nO/+25u4gUsmQDJkVCPHexSgD2aWKSStgU556FxegihifGIEyYBDLVwlboFFrZ+/nKSxgvoR0ESbdLTqExgZGyPg5cZOnRTztA+YlV2YKxIYiU6RHWFIak2uD5aV9EXr2GG1AkQEX3kn0PGBn/c+y37O3/lTXIUFXNV2etc0L1aMNlE7rMDiezinByQuWrZqwMxPKtPj6DI3CSVr0uOYglL1E0u9euYE2coTilc78x033gV19wvkCRLiNeFWlht7MF+//apO0mr3iS+FLD8zh+33VQ1xnj57oD+WsSwJB1oUJX4ZEGQkE3WbISpdy4VeBTzBNdi10pl6cJr7GWrlpHluC9tP8609N/puSPCotbQh8RhwgMQLdxYS/YFTT6tMjp6czc64MIgEPABTWNGd79J7pp7m/7tYRmiSC/nat3d5MGlG0u557FasKUAYZphl+wAcEQCSIMZ3wQ27u+BZNjp5i30as0Q6yZpow=
 before_install:
-- sh update-external-resources.sh
+- ./update-external-resources.sh
 script:
 - mvn clean package
 after_success:

--- a/update-external-resources.sh
+++ b/update-external-resources.sh
@@ -57,7 +57,7 @@ pull_or_clone_repo "openhab-android" "openhab/openhab-android.git"
 echo_process "Updating submodules of the 'openhab-bundles' repo... "
 git -C "$resourcefolder/openhab-bundles" submodule update --recursive --remote --init
 
-echo_process "Running Maven Clean Plugin... "
-mvn clean
-echo_process "Running Maven Package Plugin... "
-mvn package
+#echo_process "Running Maven Clean Plugin... "
+#mvn clean
+#echo_process "Running Maven Package Plugin... "
+#mvn package

--- a/update-external-resources.sh
+++ b/update-external-resources.sh
@@ -23,10 +23,10 @@ mkdir -p "$resourcefolder"
 echo -e "# About\\n\\nUsed to temporarily store repository clones from related openHAB projects for 'update-external-resources.sh'." > "$resourcefolder/README.md"
 
 # Prerequisites
-if ! command -v git &>/dev/null || ! command -v mvn &>/dev/null; then
-  echo "The git or mvn command were not found on the system. Please install. Exiting."
-  exit 1
-fi
+#if ! command -v git &>/dev/null || ! command -v mvn &>/dev/null; then
+#  echo "The git or mvn command were not found on the system. Please install. Exiting."
+#  exit 1
+#fi
 
 echo_process "Updating the base openhab-docs repo... (skipping)"
 #git pull


### PR DESCRIPTION
This is an solution to keep the docs updated automatically on this repo, and the website, using Travis CI builds.

Once this PR is merged and Travis is configured for this repo, the builds will:
1. run `update-external-resources.sh`
2. run `mvn clean package` which will execute the Groovy script
3. add a commit with the results
4. push the results back to the gh-pages branch (no PR) (the _[skip ci]_ in the commit message will prevent triggering another build)
5. call a hook at Netlify to trigger the redeploy of the website, which will pick up the changes

If any of these steps fail, 5. won't be executed.

The build will only consider changes to the gh-pages branch; it can also run manually or more interestingly as a cron job (configured in the settings):

![image](https://user-images.githubusercontent.com/2004147/41062539-66cfa1d0-69d6-11e8-9f2a-73518c759c75.png)

Inspired by https://gist.github.com/willprice/e07efd73fb7f13f917ea and https://gist.github.com/Maumagnaguagno/84a9807ed71d233e5d3f

Example build log: https://travis-ci.org/ghys/openhab-docs/builds/388941296
Example resulting commit by the above build: https://github.com/ghys/openhab-docs/commit/245359a141fd369a175db6204a1206ee3cf2c756

@kaikreuzer if you agree with the principle of this PR, the 2 "secure" lines in `.travis.yml` have to be replaced ([background info](https://gist.github.com/willprice/e07efd73fb7f13f917ea#guided-tutorial)) - you need Ruby and the `travis` command line tool (`gem install travis`).

- `echo "GH_TOKEN=92..." | travis encrypt --add`
- `echo "NETLIFY_BUILD_HOOK=5b..." | travis encrypt --add`

For the value of GH_TOKEN, create one at https://github.com/settings/tokens with the openhab-bot account (with the public_repo scope). For the value of NETLIFY_BUILD_HOOK go to https://app.netlify.com/sites/openhab-website/settings/deploys#build-hooks (it's already there)
