### PR TITLE
Added 'everyMinute' strategy to persistence examples

### DIFF
--- a/configuration/persistence.md
+++ b/configuration/persistence.md
@@ -112,8 +112,9 @@ Below you will find a complete example persistence configuration file:
 ```java
 // persistence strategies have a name and definition and are referred to in the "Items" section
 Strategies {
-        everyHour : "0 0 * * * ?"
-        everyDay  : "0 0 0 * * ?"
+        everyMinute : "0 * * * * ?"
+        everyHour   : "0 0 * * * ?"
+        everyDay    : "0 0 0 * * ?"
 
         // if no strategy is specified for an Item entry below, the default list will be used
        default = everyChange

--- a/configuration/sitemaps.md
+++ b/configuration/sitemaps.md
@@ -454,7 +454,7 @@ See this [Tutorial](https://community.openhab.org/t/13761/1) for more details.
 
 **Technical constraints and details:**
 
-- When using rrd4j persistence, you must use the `everyMinute` (60 seconds) logging strategy.  Otherwise rrd4j thinks that there is no data and will not properly draw the charts.
+- When using rrd4j persistence, the strategy `everyMinute` (60 seconds) has to be used. Otherwise no data will be persisted (stored) and the chart will not be drawn properly.
 - The visibility of multiple Chart objects may be toggled to simulate changing the Chart period; non-visible Chart widgets are NOT generated behind the scenes until they become visible.
 - When charting a group of item, make sure that every label is unique. If the label contains spaces, the first word of the label must be unique. Identical labels result in an empty chart.
 


### PR DESCRIPTION
We talk about it [in the sitemap section](https://www.openhab.org/docs/configuration/sitemaps.html#element-type-chart) and [in the page for rrd4j](https://www.openhab.org/addons/persistence/rrd4j/#example) but never gave an explanation how it looks like. This will make it easier for new user.

Signed-off-by: Christoph Weitkamp <github@christophweitkamp.de>