### PR TITLE
items.md: override labels

### DIFF
--- a/configuration/items.md
+++ b/configuration/items.md
@@ -202,15 +202,32 @@ Two naming schemes are established in the community for Group names:
 {: #label}
 ### Label
 
-Label text is used to describe an Item in a human-readable way.
-Graphical UIs will display the label text when the Item is included, e.g. in [Basic UI]({{base}}/addons/uis/basic/readme.html) in a [Sitemap]({{base}}/configuration/sitemaps.html) definition.
+The label is used to describe an Item in a human-readable way.
+Graphical UIs will display the label when the Item is included, e.g. in [Basic UI]({{base}}/addons/uis/basic/readme.html) in a [Sitemap]({{base}}/configuration/sitemaps.html) definition.
 Some I/O services (e.g. the Amazon Alexa skill) also use the label to match an external voice command to an Item.
 
-In textual configurations the label, in quotation marks, appears next to the optional state presentation field in square brackets (see below).
-The label for the Item in the following example is "Temperature":
+In textual configurations the label in quotation marks, contains the label text and the optional state presentation field in square brackets (see below).
+They will be showed side by side, the text left aligned and the state representation right-aligned.
+The label text for the Item in the following example is "Temperature" and the optional state representation is set to be displayed e.g as "23.9 °C":
 
 ```java
 Number Livingroom_Temperature "Temperature [%.1f °C]"
+```
+
+The label defined for an item can be overwritten by the label definition on a sitemap with the label atribute.
+If the label definition on the item contained label text and state representations these have to be considered seperatly.
+
+```perl
+sitemap demo label="My home automation" {
+    Frame label="Date" {
+        // Overrides label text only, keeps state representation defined by Item
+        Text item=Livingroom_Temperature label="Livingroom"
+        // Overrides label text and sets state representation to be empty, not displayed
+        Text item=Livingroom_Temperature label="Livingroom []"
+        // Overrides label text and state representation
+        Text item=Livingroom_Temperature label="Livingroom [%.2f °F]"
+    }
+}
 ```
 
 {: #state}

--- a/configuration/items.md
+++ b/configuration/items.md
@@ -214,8 +214,8 @@ The label text for the Item in the following example is "Temperature" and the op
 Number Livingroom_Temperature "Temperature [%.1f °C]"
 ```
 
-The label defined for an item can be overwritten by the label definition on a sitemap with the label atribute.
-If the label definition on the item contained label text and state representations these have to be considered seperatly.
+The label defined for an Item can be overwritten by the label definition on a sitemap.
+If the label definition on the Item contained label text and the state representation these have to be considered separatly.
 
 ```perl
 sitemap demo label="My home automation" {

--- a/configuration/items.md
+++ b/configuration/items.md
@@ -202,33 +202,18 @@ Two naming schemes are established in the community for Group names:
 {: #label}
 ### Label
 
-The label is used to describe an Item in a human-readable way.
-Graphical UIs will display the label when the Item is included, e.g. in [Basic UI]({{base}}/addons/uis/basic/readme.html) in a [Sitemap]({{base}}/configuration/sitemaps.html) definition.
+Label text is used to describe an Item in a human-readable way.
+Graphical UIs will display the label text when the Item is included, e.g. in [Basic UI]({{base}}/addons/uis/basic/readme.html) in a [Sitemap]({{base}}/configuration/sitemaps.html) definition.
 Some I/O services (e.g. the Amazon Alexa skill) also use the label to match an external voice command to an Item.
 
-In textual configurations the label in quotation marks, contains the label text and the optional state presentation field in square brackets (see below).
-They will be showed side by side, the text left aligned and the state representation right-aligned.
-The label text for the Item in the following example is "Temperature" and the optional state representation is set to be displayed e.g as "23.9 °C":
+In textual configurations the label, in quotation marks, appears next to the optional state presentation field in square brackets (see below).
+The label for the Item in the following example is "Temperature and the optional state representation is set to be displayed, e.g. as "23.9 °C":
 
 ```java
 Number Livingroom_Temperature "Temperature [%.1f °C]"
 ```
 
-The label defined for an Item can be overwritten by the label definition on a sitemap.
-If the label definition on the Item contained label text and the state representation these have to be considered separatly.
-
-```perl
-sitemap demo label="My home automation" {
-    Frame label="Date" {
-        // Overrides label text only, keeps state representation defined by Item
-        Text item=Livingroom_Temperature label="Livingroom"
-        // Overrides label text and sets state representation to be empty, not displayed
-        Text item=Livingroom_Temperature label="Livingroom []"
-        // Overrides label text and state representation
-        Text item=Livingroom_Temperature label="Livingroom [%.2f °F]"
-    }
-}
-```
+Channel labels can be overwritten by Item definitions and Item labels can be overwritten in [Sitemaps]({{base}}/configuration/sitemaps.html#element-types).
 
 {: #state}
 ### State

--- a/configuration/sitemaps.md
+++ b/configuration/sitemaps.md
@@ -155,16 +155,16 @@ Setting a value for `label` or `icon` of a Sitemap element will override the val
 It has to be considered that if the label defined in a Channel or an Item contains text and state, these representations have to be overwritten separately in the Sitemap.
 In the following example a Item which has a label and state defined is overwritten.
 
-```perl
+```java
 sitemap demo label="My home automation" {
     Frame label="Temperature" {
-        # Overrides only the text, but will keep the state format from the Item definition
+        // Overrides only the text, but will keep the state format from the Item definition
         Text item=Livingroom_Temperature label="Livingroom"
-        # Overrides the text and hides any state representation.
+        // Overrides the text and hides any state representation.
         Text item=Livingroom_Temperature label="Livingroom []"
-        # Overrides the text and state representation
-        # and also changes the state unit to Fahrenheit
-        # if the value of the item supports UoM (link below) the value will be transformed.
+        // Overrides the text and state representation
+        // and also changes the state unit to Fahrenheit
+        // if the value of the item supports UoM (link below) the value will be transformed.
         Text item=Livingroom_Temperature label="Livingroom [%.2f °F]"
     }
 }

--- a/configuration/sitemaps.md
+++ b/configuration/sitemaps.md
@@ -152,6 +152,24 @@ This provides the flexibility to present Items in the way desired in your home a
 If no label or icon are specified in the Sitemap, then the label and/or icon you assigned to the Item will be displayed.
 Setting a value for `label` or `icon` of a Sitemap element will override the values defined for the linked Item.
 
+It has to be considered that if the label defined in a Channel or an Item contains text and state, these representations have to be overwritten separately in the Sitemap.
+In the following example a Item which has a label and state defined is overwritten.
+
+```perl
+sitemap demo label="My home automation" {
+    Frame label="Temperature" {
+        //# Overrides only the text, but will keep the state format from the Item definition
+        Text item=Livingroom_Temperature label="Livingroom"
+        //# Overrides the text and hides any state representation.
+        Text item=Livingroom_Temperature label="Livingroom []"
+        //# Overrides the text and state representation
+        //# and also changes the state unit to Fahrenheit
+        //# if the value of the item supports [UoM]({{base}}/concepts/units-of-measurement.html) also the value will be transformed.
+        Text item=Livingroom_Temperature label="Livingroom [%.2f °F]"
+    }
+}
+```
+
 -   Additional parameters such as `mappings` and `valuecolor` are described below.
 
 ### Element Type 'Frame'

--- a/configuration/sitemaps.md
+++ b/configuration/sitemaps.md
@@ -158,17 +158,18 @@ In the following example a Item which has a label and state defined is overwritt
 ```perl
 sitemap demo label="My home automation" {
     Frame label="Temperature" {
-        //# Overrides only the text, but will keep the state format from the Item definition
+        # Overrides only the text, but will keep the state format from the Item definition
         Text item=Livingroom_Temperature label="Livingroom"
-        //# Overrides the text and hides any state representation.
+        # Overrides the text and hides any state representation.
         Text item=Livingroom_Temperature label="Livingroom []"
-        //# Overrides the text and state representation
-        //# and also changes the state unit to Fahrenheit
-        //# if the value of the item supports [UoM]({{base}}/concepts/units-of-measurement.html) also the value will be transformed.
+        # Overrides the text and state representation
+        # and also changes the state unit to Fahrenheit
+        # if the value of the item supports UoM (link below) the value will be transformed.
         Text item=Livingroom_Temperature label="Livingroom [%.2f °F]"
     }
 }
 ```
+UoM = [Units of Measurment]({{base}}/concepts/units-of-measurement.html)
 
 -   Additional parameters such as `mappings` and `valuecolor` are described below.
 


### PR DESCRIPTION
Added information about how to override label text and state representation on sitemaps.

https://github.com/eclipse/smarthome/issues/5867#issuecomment-403367270