### PR TITLE
Update jsr223.md with multiple scope additions

### DIFF
--- a/configuration/jsr223.md
+++ b/configuration/jsr223.md
@@ -122,6 +122,9 @@ To faciliate JSR223 scripting, several openHAB-related variables are automatical
 | `FileUtils` | `org.apache.commons.io.FileUtils` |
 | `FilenameUtils` | `org.apache.commons.io.FilenameUtils` |
 | `File` | `java.io.File` |
+| `UnDefType` | `org.eclipse.smarthome.core.library.types.UnDefType` |
+| `NULL` | `UnDefType` enum item |
+| `UNDEF` | `UnDefType` enum item |
 | `IncreaseDecreaseType` | `org.eclipse.smarthome.core.library.types.IncreaseDecreaseType` |
 | `DECREASE` | `IncreaseDecreaseType` enum item |
 | `INCREASE` | `IncreaseDecreaseType` enum item |
@@ -134,14 +137,26 @@ To faciliate JSR223 scripting, several openHAB-related variables are automatical
 | `StopMoveType` | `org.eclipse.smarthome.core.library.types.StopMoveType` |
 | `STOP` | `StopMoveType` enum item |
 | `MOVE` | `StopMoveType` enum item |
+| `RewindFastforwardType` | `org.eclipse.smarthome.core.library.types.RewindFastforwardType` |
+| `REWIND` | `RewindFastforwardType` enum item |
+| `FASTFORWARD` | `RewindFastforwardType` enum item |
+| `NextPreviousType` | `org.eclipse.smarthome.core.library.types.NextPreviusType` |
+| `NEXT` | `NextPreviousType` enum item |
+| `PREVIOUS` | `NextPreviousType` enum item |
+| `PlayPauseType` | `org.eclipse.smarthome.core.library.types.PlayPauseType` |
+| `PLAY` | `PlayPauseType` enum item |
+| `PAUSE` | `PlayPauseType` enum item |
 | `UpDownType` | `org.eclipse.smarthome.core.library.types.UpDownType` |
 | `UP` | `UpDownType` enum item |
 | `DOWN` | `UpDownType` enum item |
 | `DecimalType` | `org.eclipse.smarthome.core.library.types.DecimalType` |
+| `QuantityType` | `org.eclipse.smarthome.core.library.types.QuantityType` |
 | `HSBType` | `org.eclipse.smarthome.core.library.types.HSBType` |
 | `PercentType` | `org.eclipse.smarthome.core.library.types.PercentType` |
 | `PointType` | `org.eclipse.smarthome.core.library.types.PointType` |
 | `StringType` | `org.eclipse.smarthome.core.library.types.StringType` |
+| `StringListType` | `org.eclipse.smarthome.core.library.types.StringListType` |
+| `RawType` | `org.eclipse.smarthome.core.library.types.RawType` |
 | `items` | Instance of `java.util.Map&lt;String, State&gt;` | 
 | `itemRegistry` | Instance of `org.eclipse.smarthome.core.items.ItemRegistry` |
 | `ir` | Alias for `itemRegistry` |


### PR DESCRIPTION
This updates the documentation for the changes made to DefaultScriptScopeProvider.java made in  https://github.com/eclipse/smarthome/pull/5879.

Signed-off-by: Scott Rushworth <openhab@5iver.com> (github: openhab-5iver)