### PR TITLE
Update contribution doc to disallow noreply e-mail addresses

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -79,7 +79,10 @@ then you just add a line to every git commit message:
 
     Signed-off-by: Joe Smith <joe.smith@email.com> (github: github_handle)
 
-using your real name (sorry, no pseudonyms or anonymous contributions.)
+using your real name (sorry, no pseudonyms or anonymous contributions.) and an
+e-mail address under which you can be reached (sorry, no github noreply e-mail
+addresses (such as username@users.noreply.github.com) or other non-reachable
+addresses are allowed).
 
 #### Small patch exception
 

--- a/developers/contributing/contributing.md
+++ b/developers/contributing/contributing.md
@@ -158,7 +158,10 @@ then you just add a line to every git commit message:
 
     Signed-off-by: Joe Smith <joe.smith@email.com> (github: github_handle)
 
-using your real name (sorry, no pseudonyms or anonymous contributions.)
+using your real name (sorry, no pseudonyms or anonymous contributions.) and an
+e-mail address under which you can be reached (sorry, no github noreply e-mail
+addresses (such as username@users.noreply.github.com) or other non-reachable
+addresses are allowed).
 
 If your commit contains code from others as well, please ensure that they certify the DCO as well and add them with an "Also-By" line to your commit message:
 


### PR DESCRIPTION
It should be possible to reach authors via their e-mail address whenever GitHub itself is not used for storing the source code.

See also the discussion in: https://github.com/openhab/openhab2-addons/pull/3696#issuecomment-410025110

There was already https://github.com/openhab/openhab2-addons/pull/3789 to add this to openhab2-addons.

With this PR this requirement will also be added to the [Sign Your Work](https://www.openhab.org/docs/developer/contributing/contributing.html#sign-your-work) section of the documentation website.