### PR TITLE
Redirect automatically to pages on the new site

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -1,72 +1,63 @@
 <!DOCTYPE html>
+
+{% assign newsite = 'https://www.openhab.org' %}
+{% assign newurl = newsite | append: '/docs' | append: page.url %}
+{% if page.url == '/tutorials/' %}
+    {% assign newurl = newsite | append: '/docs/tutorial/' %}
+{% elsif page.url contains '/tutorials/beginner/' %}
+    {% assign newurl = newurl | replace: '/tutorials/beginner/', '/tutorial/' %}
+{% elsif page.url contains '/tutorials/migration.html' %}
+    {% assign newurl = newsite | append: '/docs/configuration/migration/' %}
+{% elsif page.url == '/introduction.html' %}
+    {% assign newurl = newsite | append: '/docs/' %}
+{% elsif page.url contains '/addons/uis/paper/' %}
+    {% assign newurl = newsite | append: '/docs/configuration/paperui.html' %}
+{% elsif page.url contains '/addons/uis/basic/' %}
+    {% assign newurl = newsite | append: '/docs/configuration/ui/basic/' %}
+{% elsif page.url contains '/addons/uis/classic/' %}
+    {% assign newurl = newsite | append: '/docs/configuration/ui/classic/' %}
+{% elsif page.url contains '/addons/uis/habmin/' %}
+    {% assign newurl = newsite | append: '/docs/configuration/ui/habmin/' %}
+{% elsif page.url contains '/addons/uis/habpanel/' %}
+    {% assign newurl = newsite | append: '/docs/configuration/habpanel.html' %}
+{% elsif page.url contains '/addons/uis/apps' %}
+    {% assign newurl = newurl | replace: '/addons/uis/apps', '/apps' %}
+{% elsif page.url contains '/addons/ios/alexa-skill' %}
+    {% assign newurl = newsite | append: '/docs/ecosystem/alexa/' %}
+{% elsif page.url contains '/addons/ios/mycroft-skill' %}
+    {% assign newurl = newsite | append: '/docs/ecosystem/mycroft/' %}
+{% elsif page.url contains '/addons/' %}
+    {% if page.url contains 'readme.html' %}
+        {% assign newurl = newsite | append: page.url | replace_first: '/ios', '/integrations' | replace_first: '/voices/', '/voice/' | replace: 'readme.html', '' %}
+    {% elsif page.url contains 'transformations.html' %}
+        {% assign newurl = newsite | append: '/docs/configuration/transformations.html' %}
+    {% elsif page.url contains 'actions.html' %}
+        {% assign newurl = newsite | append: '/docs/configuration/actions.html' %}
+    {% else %}
+        {% assign newurl = newsite | append: '/addons/' %}
+    {% endif %}
+{% elsif page.url contains '/appendix/' %}
+    {% assign newurl = newsite | append: '/about/contributing.html' %}
+{% elsif page.url contains '/developers/' %}
+    {% assign newurl = newurl | replace: '/developers/', '/developer/' %}
+{% endif %}
+
+
 <html lang="en">
 <head>
   <meta charset="utf-8">
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
-  <meta name="viewport" content="width=device-width, initial-scale=1">
-  {% include base.html %}
-  <!--<link rel="shortcut icon" href="https://www.openhab.org/favicon.png"></link>-->
+  <meta http-equiv="refresh" content="0;URL={{ newurl }}" />
   <title>{% if page.title != nil %}{{ page.title }} - {% endif %}openHAB 2 - Empowering the Smart Home</title>
 
-  <!-- CSS -->
-  <link type="text/css" rel="stylesheet" href="{{base}}/css/materialize.css" media="screen,projection" />
-  <link type="text/css" rel="stylesheet" href="{{base}}/css/pygments-jekyll-style.css" />
-  <link type="text/css" rel="stylesheet" href="{{base}}/css/styles.css" />
-  <link type="text/css" rel="stylesheet" href="{{base}}/css/openhab.css" />
-  <link type="text/css" rel="stylesheet" href="{{base}}/css/collapsible.css" />
+  <link rel="canonical" href="{{ newurl }}" />
 
-  <!-- Font -->
-  <link type="text/css" rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons" />
-  <link type="text/css" rel="stylesheet" href="https://fonts.googleapis.com/css?family=Lato:300,400,700" />
-  <link rel="canonical" href="{{ site.url }}{{ page.url }}" />
-  <script type="text/javascript">var gaProperty = 'UA-47717934-3';var disableStr = 'ga-disable-' + gaProperty;if (document.cookie.indexOf(disableStr + '=true') > -1) {window[disableStr] = true;}</script>
-  <script>
-  (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-  })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
-  ga('create', 'UA-47717934-3', 'auto');
-  ga('set', 'anonymizeIp', true);
-  ga('send', 'pageview');
-  </script>
 </head>
 
 
-<body class="{{ include.bodyClass }}">
-  <div id="header" class="navbar-fixed">
-    <nav role="navigation">
-      <div class="container">
-        <div class="nav-wrapper">
-          <a href="{{base}}/index.html"><img id="logo" src="/images/logo.png" /></a>
-          <a href="#" data-activates="nav-mobile" class="button-collapse"><i class="material-icons">menu</i></a>
-          <ul class="right hide-on-med-and-down">
-            <li><a href="{{root}}/tutorials/index.html">Tutorials</a></li>
-            <li><a href="{{base}}/introduction.html">User Manual</a></li>
-            <li><a href="{{root}}/developers/index.html">Developer Guide</a></li>
-            <li><a target="_blank" href="https://community.openhab.org">Community Forum</a></li>
-            <li><a target="_blank" href="https://github.com/openhab">GitHub</a></li>
-            <li class="search"><i class="material-icons">search</i></li>
-            <li class="search">
-              <form method="GET" id="searchform" class="search-form" action="/search">
-                <input id="query" name="q" type="text" class="search-form-input" placeholder="search" />
-              </form>
-            </li>
-          </ul>
-          <ul id="nav-mobile" class="side-nav">
-            <li class="search">
-              <i class="material-icons">search</i>
-              <form method="GET" id="searchformmob" class="search-form" action="/search">
-                <input id="querymob" name="q" type="text" class="search-form-input" placeholder="search" />
-              </form>
-            </li>
-            <li><a href="{{base}}/index.html">Home</a></li>
-            <li><a href="{{root}}/tutorials/index.html">Tutorials</a><div id="side-nav-mobile-tutorials" class="side-nav-mobile"></div></li>
-            <li><a href="{{base}}/introduction.html">User Manual</a><div id="side-nav-mobile-user" class="side-nav-mobile"></div></li>
-            <li><a href="{{root}}/developers/index.html">Developer Guide</a><div id="side-nav-mobile-developer" class="side-nav-mobile"></div></li>
-            <li><a target="_blank" href="https://community.openhab.org">Community Forum</a></li>
-            <li><a target="_blank" href="https://github.com/openhab">GitHub</a></li>
-          </ul>
-        </div>
-      </div>
-    </nav>
-  </div>
+<body>
+  Redirecting to <a href="{{ newurl }}">{{ newurl }}</a>...
+  <script>location='{{ newurl }}'</script>
+</body>
+
+</html>

--- a/_layouts/addon.html
+++ b/_layouts/addon.html
@@ -1,17 +1,1 @@
 {% include header.html bodyClass="documentation"%}
-
-<section id="documentation" class="text content-wrapper">
-  <div class="container">
-    <div class="side-nav-wrapper">
-      {% include user-menu.html %}
-    </div>
-    {% include versioning.html %}
-    <div class="content">
-      {% include newsite-banner.html %}
-      {{ content }}
-    </div>
-  </div>
-</section>
-
-{% include footer.html %}
-{% include ssl-redirect.html %}

--- a/_layouts/documentation.html
+++ b/_layouts/documentation.html
@@ -1,18 +1,1 @@
 {% include header.html bodyClass="documentation"%}
-
-<section id="documentation" class="text content-wrapper">
-  <div class="container">
-    <div class="side-nav-wrapper">
-      {% include user-menu.html %}
-    </div>
-    {% include versioning.html %}
-
-    <div class="content">
-      {% include newsite-banner.html %}
-      {{ content }}
-    </div>
-  </div>
-</section>
-
-{% include footer.html %}
-{% include ssl-redirect.html %}

--- a/_layouts/gettingstarted.html
+++ b/_layouts/gettingstarted.html
@@ -1,16 +1,1 @@
 {% include header.html bodyClass="documentation"%}
-
-<section id="documentation" class="text content-wrapper">
-  <div class="container">
-    <div class="side-nav-wrapper">
-      {% include gettingstarted-menu.html %}
-    </div>
-    <div class="content">
-      {% include newsite-banner.html %}
-      {{ content }}
-    </div>
-  </div>
-</section>
-
-{% include footer.html %}
-{% include ssl-redirect.html %}

--- a/_layouts/intro.html
+++ b/_layouts/intro.html
@@ -1,11 +1,1 @@
 {% include header.html bodyClass="documentation"%}
-
-<section id="documentation" class="text content-wrapper">
-  <div class="container">
-    {% include newsite-banner.html %}
-    {{ content }}
-  </div>
-</section>
-
-{% include footer.html %}
-{% include ssl-redirect.html %}

--- a/_layouts/raw.html
+++ b/_layouts/raw.html
@@ -1,9 +1,1 @@
 {% include header.html bodyClass="documentation" %}
-
-<section id="documentation" class="text content-wrapper">
-  {% include newsite-banner.html %}
-  {{ content }}
-</section>
-
-{% include footer.html %}
-{% include ssl-redirect.html %}

--- a/_layouts/tutorial-advanced.html
+++ b/_layouts/tutorial-advanced.html
@@ -1,15 +1,1 @@
 {% include header.html bodyClass="documentation"%}
-
-<section id="documentation" class="text content-wrapper">
-  <div class="container">
-    <div class="side-nav-wrapper">
-      {% include tutorial-advanced-menu.html %}
-    </div>
-    <div class="content">
-      {{ content }}
-    </div>
-  </div>
-</section>
-
-{% include footer.html %}
-{% include ssl-redirect.html %}

--- a/_layouts/tutorial-beginner.html
+++ b/_layouts/tutorial-beginner.html
@@ -1,16 +1,1 @@
 {% include header.html bodyClass="documentation"%}
-
-<section id="documentation" class="text content-wrapper">
-  <div class="container">
-    <div class="side-nav-wrapper">
-      {% include tutorial-beginner-menu.html %}
-    </div>
-    <div class="content">
-      {% include newsite-banner.html %}
-      {{ content }}
-    </div>
-  </div>
-</section>
-
-{% include footer.html %}
-{% include ssl-redirect.html %}


### PR DESCRIPTION
I think the new site is well established now, so perhaps it's time to phase out the old docs.openhab.org?
I tried doing some search engine queries and while a lot of new URLs are now surfaced, there are still obsolete ones appearing as the content is still there.

This final commit to the gh-pages branch will replace all layouts by a redirect page (both meta link methods and with JavaScript - HTTP 301 redirects are not possible on GitHub Pages AFAIK); according to the info I've gathered this should transfer their PageRank on the new URLs, although it's not well documented:
- https://support.google.com/webmasters/answer/139066?hl=en
- https://www.seroundtable.com/google-meta-refresh-redirects-work-25335.html
- https://plus.google.com/+JohnMueller/posts/E4PqAhRJB2V

I believe the most important part here is having a `<link rel="canonical">` tag so that the search engines know the page has a new URL when indexing.

The series of "ifs" in header.html is the same as the one used for the link on the current warning banner, which should be valid for all pages.

What do you think?

Signed-off-by: Yannick Schaus <github@schaus.net>