### PR TITLE
Rename all variants to macOS

### DIFF
--- a/addons/index.md
+++ b/addons/index.md
@@ -112,4 +112,4 @@ One way of retrieving those files is mentiones above in the openHAB console part
 
 Place the `.jar` file in the `add-ons` folder on the machine you are running openHAB on.
 As described already for the addons.cfg option, the path is depending on your installation.
-Place the .jar file in the folder Additional add-on files as described in File Locations ([Linux]({{base}}/installation/linux.html#file-locations), [Windows]({{base}}/installation/windows.html#file-locations) or [macOS]({{base}}/installation/macosx.html#file-locations)).
+Place the .jar file in the folder Additional add-on files as described in File Locations ([Linux]({{base}}/installation/linux.html#file-locations), [Windows]({{base}}/installation/windows.html#file-locations) or [macOS]({{base}}/installation/macos.html#file-locations)).

--- a/configuration/addons.md
+++ b/configuration/addons.md
@@ -95,4 +95,4 @@ One way of retrieving those files is mentiones above in the openHAB console part
 
 Place the `.jar` file in the `add-ons` folder on the machine you are running openHAB on.
 As described already for the addons.cfg option, the path is depending on your installation.
-Place the .jar file in the folder Additional add-on files as described in File Locations ([Linux](/docs/installation/linux.html#file-locations), [Windows](/docs/installation/windows.html#file-locations) or [macOS](/docs/installation/macosx.html#file-locations)).
+Place the .jar file in the folder Additional add-on files as described in File Locations ([Linux](/docs/installation/linux.html#file-locations), [Windows](/docs/installation/windows.html#file-locations) or [macOS](/docs/installation/macos.html#file-locations)).

--- a/configuration/editors.md
+++ b/configuration/editors.md
@@ -78,5 +78,5 @@ You can find the syntax file and installation instructions on [openhabnano](http
 
 ### Textwrangler
 
-Textwrangler is a text and code editor for MAC OS X.
+Textwrangler is a text and code editor for macOS.
 You can find the syntax file and installation instructions on [openhab-syntax-textwrangler](https://github.com/GrisoMG/openhab-syntax-textwrangler).

--- a/installation/index.md
+++ b/installation/index.md
@@ -9,7 +9,7 @@ title: Installation Overview
 
 openHAB 2 is based on the Eclipse SmartHome framework and is fully written in Java.
 As such, it only depends on a Java Virtual Machine, which is available for many platforms.
-openHAB can be executed on different versions of **Mac OS X** and **Windows** and many different variants of **Linux** (Ubuntu, Raspbian, ...).
+openHAB can be executed on different versions of **macOS** and **Windows** and many different variants of **Linux** (Ubuntu, Raspbian, ...).
 
 Please be aware of the fact, that openHAB 2 is based on a new core and introduces new concepts.
 Therefore, tutorials and help you may find on the internet for openHAB 1 **might** be outdated!
@@ -70,7 +70,7 @@ Java HotSpot(TM) Client VM (build 25.121-b13, mixed mode)
 Before you can start, three decisions have to be made:
 
 1.  openHAB 2 is available as a platform independent archive file or through a package repository:
-    - **Manual setup:** Download and extract a platform independent zip archive: [Mac OS X](macosx.html), [Windows](windows.html), [Linux](linux.html#manual-installation)
+    - **Manual setup:** Download and extract a platform independent zip archive: [macOS](macos.html), [Windows](windows.html), [Linux](linux.html#manual-installation)
     - **Package setup:** Install though a package repository, including automatic updates.
     This option is only available for Debian or Ubuntu derivatives and the recommended choice: [Linux (apt/deb)](linux.html#package-repository-installation)
 

--- a/installation/linux.md
+++ b/installation/linux.md
@@ -772,7 +772,7 @@ Check the network devices manager of your local operating system to find and acc
 These might however not be auto-discovered.
 You can also manually connect:
 
-- **On Mac OS X:** Open Finder → Go → Connect to Server: `smb://openhab@openhab-device.local`
+- **On macOS:** Open Finder → Go → Connect to Server: `smb://openhab@openhab-device.local`
 - **On Windows:** Open Windows Explorer → Address bar: `\\openhab-device.local` → Right click a share and assign a drive letter
 
 Be sure to use the actual host name instead of `openhab-device`.

--- a/installation/macos.md
+++ b/installation/macos.md
@@ -1,11 +1,11 @@
 ---
 layout: documentation
-title: Mac OS X
+title: macOS
 ---
 
 {% include base.html %}
 
-# Installation on Mac OS X
+# Installation on macOS
 
 This page is structured as follows:
 
@@ -14,7 +14,7 @@ This page is structured as follows:
 - TOC
 {:toc}
 
-If you're unfamiliar with using the Mac OS terminal, then feel free to follow the many guides on the internet. For example:
+If you're unfamiliar with using the macOS terminal, then feel free to follow the many guides on the internet. For example:
 
 [Macworld: How to use Terminal on mac](http://www.macworld.co.uk/feature/mac-software/how-use-terminal-on-mac-3608274/)
 

--- a/introduction.md
+++ b/introduction.md
@@ -14,7 +14,7 @@ It provides uniform user interfaces, and a common approach to automation rules a
 We highly recommend that you read the next chapter titled [Concepts]({{base}}/concepts/index.html).
 It introduces a number of important ideas that will help you as you install and begin to configure openHAB for the first time.
 
-openHAB runs on many popular platforms including Linux, Windows and Mac OSx.
+openHAB runs on many popular platforms including Linux, Windows and macOS.
 You can find specific installation instructions for these and other platforms in the [Installation Overview]({{base}}/installation/index.html) article.
 Many people find that the simplest way to experiment with openHAB is to get a [Raspberry Pi](https://raspberrypi.org) and install [openHABian]({{base}}/installation/openhabian.html); a "hastle-free openHAB setup".
 While openHABian offers a streamlined and simplified way to get up and running quickly, it is a complete openHAB home automation system capable of automating your entire home.

--- a/tutorials/advanced/connecting.md
+++ b/tutorials/advanced/connecting.md
@@ -59,7 +59,7 @@ Working with the Z-Wave devices will be done in __HABmin__.
 
 ## Configuring the port
 ---
-*This section is so far centred on Mac OS. It must be modified in order to cover Linux and Windows.*
+*This section is so far centred on macOS. It must be modified in order to cover Linux and Windows.*
 ---
 
 ### Finding the port name

--- a/tutorials/advanced/installing.md
+++ b/tutorials/advanced/installing.md
@@ -52,7 +52,7 @@ HABmin install
 
 ---
 
-* This section is so far centred on Mac OS. It must be modified in order to cover Linux and Windows.*
+* This section is so far centred on macOS. It must be modified in order to cover Linux and Windows.*
 
 
 ---

--- a/tutorials/beginner/sitemap.md
+++ b/tutorials/beginner/sitemap.md
@@ -13,7 +13,7 @@ But before that, you have to create an items file.
 Both the items and the sitemap files are edited in your editor of choice.
 The files' location is in the `$OPENHAB_CONF` directory, which is different on different operating systems.
 See the linux installation instructions for the [file locations]({{base}}/installation/linux.html#file-locations) specific to linux, or the Windows [file locations]({{base}}/installation/windows.html#file-locations) specific to Windows.
-Mac OSx files are located in the same place as Linux files.
+macOS files are located in the same place as Linux files.
 
 ```bash
 conf/items    <-- *.items files

--- a/tutorials/migration.md
+++ b/tutorials/migration.md
@@ -6,7 +6,7 @@ layout: intro
 
 # Migration from openHAB 1.x to openHAB 2
 
-This tutorial provides a step-by-step procedure for migrating an existing openHAB 1.x installation to openHAB 2 snapshot. These procedures were generated starting from an apt-get installed openHAB 1.8.3, though they should work for previous versions. Where needed, additional details are provided for other platforms (Windows, OSX, non-Debian based Linux, etc.) and manually installed openHAB 1.x installs.
+This tutorial provides a step-by-step procedure for migrating an existing openHAB 1.x installation to openHAB 2 snapshot. These procedures were generated starting from an apt-get installed openHAB 1.8.3, though they should work for previous versions. Where needed, additional details are provided for other platforms (Windows, macOS, non-Debian based Linux, etc.) and manually installed openHAB 1.x installs.
 
 
 These instructions emphasize the text based procedures over the use of PaperUI and Habmin which is closer to the openHAB 1.x experience.
@@ -689,7 +689,7 @@ Astro). See the add-on's [wiki page]({{base}}/addons/1xaddons.html)  and
 [readme page]({{base}}/addons/bindings.html) to compare and contrast the two versions.
 
 Identify an add-on where there is a 2.0 version that you want to migrate to. Begin
-by identifying those Items that use this binding. On Linux/OSX this can easily be
+by identifying those Items that use this binding. On Linux/macOS this can easily be
 done with the following command
 
 ```bash


### PR DESCRIPTION
The documentation contains a lot of (outdated) variants of the OS that runs on Apple computers named "macOS" nowadays.