### PR TITLE
Update logging.md to exclude FATAL level

### DIFF
--- a/administration/logging.md
+++ b/administration/logging.md
@@ -80,7 +80,6 @@ The **detail** of logging is defined by one of the following levels:
 | Log Level           | Log Weight    | When it should be used                                                                  |
 |---------------------|---------------|-----------------------------------------------------------------------------------------|
 | OFF                 | 0             | When no events will be logged                                                           |
-| FATAL               | 100           | When a severe error will prevent the application from continuing                        |
 | ERROR               | 200           | When an error in the application, possibly recoverable                                  |
 | WARN                | 300           | When an event that might possible lead to an error                                      |
 | INFO                | 400           | When an event for informational purposes                                                |


### PR DESCRIPTION
Closes: https://github.com/openhab/openhab-docs/issues/822

Remove Log Level `FATAL` since it does not exist in Karaf 4.x
Ref: http://karaf.apache.org/manual/latest/#_log4j_v2_support
It does exist as a standard log level built-in to log4j2 (https://logging.apache.org/log4j/2.x/manual/customloglevels.html) but it is not available on Karaf.

Signed-off-by: Angelos Fountoulakis agf@wired-net.gr (github: AngelosF)