### PR TITLE
Replace snapshot download link

### DIFF
--- a/installation/index.md
+++ b/installation/index.md
@@ -76,7 +76,7 @@ Before you can start, three decisions have to be made:
 
 2.  Stable release or cutting edge:
     - **Stable:** Use the latest official release ([hosted on Bintray](https://bintray.com/openhab/mvn/openhab-distro)).
-    - **Snapshot:** Benefit from the latest changes in the daily created snapshot ([hosted on CloudBees](https://openhab.ci.cloudbees.com/job/openHAB-Distribution)).
+    - **Snapshot:** Benefit from the latest changes in the daily created snapshot ([hosted on openhab.org](https://ci.openhab.org)).
 
 ## Installation
 

--- a/installation/index.md
+++ b/installation/index.md
@@ -76,7 +76,7 @@ Before you can start, three decisions have to be made:
 
 2.  Stable release or cutting edge:
     - **Stable:** Use the latest official release ([hosted on Bintray](https://bintray.com/openhab/mvn/openhab-distro)).
-    - **Snapshot:** Benefit from the latest changes in the daily created snapshot ([hosted on openhab.org](https://ci.openhab.org)).
+    - **Snapshot:** Benefit from the latest changes in the daily created snapshot ([hosted on openhab.org](https://ci.openhab.org/job/openhab-linuxpkg/)).
 
 ## Installation
 

--- a/installation/index.md
+++ b/installation/index.md
@@ -76,7 +76,7 @@ Before you can start, three decisions have to be made:
 
 2.  Stable release or cutting edge:
     - **Stable:** Use the latest official release ([hosted on Bintray](https://bintray.com/openhab/mvn/openhab-distro)).
-    - **Snapshot:** Benefit from the latest changes in the daily created snapshot ([hosted on openhab.org](https://ci.openhab.org/job/openhab-linuxpkg/)).
+    - **Snapshot:** Benefit from the latest changes in the daily created snapshot ([hosted on openhab.org](https://ci.openhab.org/job/openHAB-Distribution/)).
 
 ## Installation
 


### PR DESCRIPTION
Replace link in Setup variants section to Snapshot version formally hosted at cloudbees.com
https://openhab.ci.cloudbees.com/job/openHAB-Distribution
with new snapshot download location
https://ci.openhab.org