### PR TITLE
Reword first paragragh and fix snapshot link

### DIFF
--- a/installation/index.md
+++ b/installation/index.md
@@ -8,7 +8,8 @@ title: Installation Overview
 # Installation Overview
 
 openHAB 2 is based on the Eclipse SmartHome framework and is fully written in Java.
-As such, it only depends on a Java Virtual Machine, which is available for many platforms.
+As such, OpenHAB requires a Java Virtual Machine to be installed on the system you intend to install openHAB on.
+A Java Vitual Machine is available for many platforms.
 openHAB can be executed on different versions of **Mac OS X** and **Windows** and many different variants of **Linux** (Ubuntu, Raspbian, ...).
 
 Please be aware of the fact, that openHAB 2 is based on a new core and introduces new concepts.
@@ -73,7 +74,7 @@ Before you can start, three decisions have to be made:
 
 2. Stable release or cutting edge:
   - **Stable:** Use the latest official release ([hosted on Bintray](https://bintray.com/openhab/mvn/openhab-distro)).
-  - **Snapshot:** Benefit from the latest changes in the daily created snapshot ([hosted on CloudBees](https://openhab.ci.cloudbees.com/job/openHAB-Distribution)).
+  - **Snapshot:** Benefit from the latest changes in the daily created snapshot ([hosted on openhab.org](https://ci.openhab.org/job/openHAB-Distribution/)).
 
 ## Installation
 


### PR DESCRIPTION
replace line 11 with line 11 and 12 to make more clear that Java is required to run openHAB and why
replace line 77 to fix broken snapshot link which was pointed at old cloudbees.com repo changed to new repo https://ci.openhab.org/job/openHAB-Distribution/

Signed-off-by: Andrew Rowe exectechnology@gmail.com (github: MyRaceData)