### PR TITLE
postCommand documentation

### DIFF
--- a/configuration/rules-dsl.md
+++ b/configuration/rules-dsl.md
@@ -294,9 +294,13 @@ The following table summarizes the impact of the two manipulator commands on the
 
 | Command \ Rule Trigger   | `received update` | `received command` | `changed` |
 |--------------------------|-------------------|--------------------|-----------|
-| postUpdate               | ⚡ rule fires      | ❌                 | (depends) |
-| sendCommand              | ❌                | ⚡ rule fires       | (depends) |
-| *Change through Binding* | ⚡ rule fires      | ⚡ rule fires       | (depends) |
+| postUpdate               | ⚡ rule fires     | ❌                | (depends) |
+| sendCommand              | ⚡ rule fires     | ⚡ rule fires     | (depends) |
+| *Change through Binding* | ⚡ rule fires     | ⚡ rule fires     | (depends) |
+
+* depends: triggered only when previous state was different from new
+
+* there is no given order when more triggers should be called
 
 **Beware:**
 Besides the specific manipulator command methods `MyItem.sendCommand(<new_state>)` and `MyItem.postUpdate(<new_state>)`, generic manipulators in the form of `sendCommand(MyItem, <new_state>)` and `postUpdate(MyItem, <new_state>)` are available. The specific versions is normally recommended.


### PR DESCRIPTION
Hi, I found one mistake in documentation for rules.
Based on my scripts (attached below), it seems that sendCommand() method triggers rules with received update event.

test.rules:
rule "testSitemapTrigger2"
when
	Item Test_Switch received update ON
then
	logInfo("test", "Switch updated to ON")
	logInfo("test", "sending command with value: {}", Test_Switch.getStateAs(DecimalType))
	Test_Number.sendCommand(Test_Switch.getStateAs(DecimalType) as org.eclipse.smarthome.core.types
.Command)
end

rule "testSitemapTrigger2.1"
when
	Item Test_Switch received update OFF
then
	logInfo("test", "Switch updated to OFF")
	logInfo("test", "posting update with value: {}", Test_Switch.getStateAs(DecimalType))
	Test_Number.postUpdate(Test_Switch.getStateAs(DecimalType) as org.eclipse.smarthome.core.types.State)
end

rule "test1"
when
	Item Test_Number changed 
then
	logInfo("test", "changed triggered")
end

rule "test2"
when
	Item Test_Number received update 
then
	logInfo("test", "update triggered")
end

rule "test3"
when
	Item Test_Number received command 
then
	logInfo("test", "command triggered")
end


test.items:

Switch Test_Switch "Test switch"
Number Test_Number "Test number"


test.sitemap:
sitemap test label="Testing" {
	Switch item=Test_Switch mappings=["ON"="On", "OFF"="Off"]
	Slider item=Test_Number switchSupport
}