### PR TITLE
Changed smarthome:script (incorrect syntax)

### DIFF
--- a/administration/runtime.md
+++ b/administration/runtime.md
@@ -107,7 +107,7 @@ Usage: smarthome:send <item> <command> - sends a command for an item
 
 | Command | Description |
 |---------|-------------|
-| `smarthome:> <script to execute>` | Executes a script from the `$OPENHAB_CONF/scripts` folder
+| `smarthome:script <script to execute>` | Executes a script from the `$OPENHAB_CONF/scripts` folder
 
 ### Firmware
 


### PR DESCRIPTION
By the way, it doesn't work
**test.script**
```
logInfo("TEST", "SCRIPT")
```

`openhab> smarthome:script test.script`
```
 ___ test.script
   The method or field test is undefined; line 1, column 0, length 4
```