### PR TITLE
Fix broken links

### DIFF
--- a/addons/index.md
+++ b/addons/index.md
@@ -62,11 +62,11 @@ openhab-binding-network                   │ 2.2.0            │          │ 
 According to the [naming convention for bundles]({{base}}/administration/bundles.html#naming-convention-for-bundles) the *id* for the shown example is *network*.
 
 Another way to find the correct `id` is to look at the URL of the add-on documentation page.
-For example the url for the [mqtt Binding documentation]({{base}}/addons/bindings/mqtt1/readme.html) is
+For example the url for the [mqtt Binding documentation](/addons/bindings/mqtt1/) is
 
 ```text
-https://docs.openhab.org/addons/bindings/mqtt1/readme.html
-```
+https://www.openhab.org/addons/bindings/mqtt1/
+``` 
 
 In this case, the `id` would be "mqtt1".
 Did you notice the trailing *1* in this id?

--- a/addons/uis.md
+++ b/addons/uis.md
@@ -11,17 +11,18 @@ openHAB offers a variety of frontends for user interaction, from administrative 
 
 | Web Application | Description   |
 |-----------------|---------------|
-| [Basic UI]({{base}}/addons/uis/basic/readme.html) | The Basic UI is an HTML5 web application in Material Design, designed for operating openHAB. |
-| [Classic UI]({{base}}/addons/uis/classic/readme.html) | The Classic UI is the original openHAB 1.x webui, designed for operating openHAB. |
-| [HABmin]({{base}}/addons/uis/habmin/readme.html) | HABmin is a modern, professional and portable user interface for openHAB, providing both user and administrative functions. |
-| [HABPanel]({{base}}/addons/uis/habpanel/readme.html) | HABPanel is a lightweight dashboard interface for openHAB. |
-| [Paper UI]({{base}}/addons/uis/paper/readme.html) | The Paper UI is an AngularJS-based HTML5 web application in Material Design, designed for setup and administration purposes. |
+| [Basic UI]({{base}}/configuration/ui/basic/) | The Basic UI is an HTML5 web application in Material Design, designed for operating openHAB. |
+| [Classic UI]({{base}}/configuration/ui/classic/) | The Classic UI is the original openHAB 1.x webui, designed for operating openHAB. |
+| [HABmin]({{base}}/configuration/ui/habmin/l) | HABmin is a modern, professional and portable user interface for openHAB, providing both user and administrative functions. |
+| [HABPanel]({{base}}/configuration/ui/habpanel/) | HABPanel is a lightweight dashboard interface for openHAB. |
+| [Paper UI]({{base}}/configuration/ui/paperui/) | The Paper UI is an AngularJS-based HTML5 web application in Material Design, designed for setup and administration purposes. |
+| [HaBot]({{base}}/configuration/ui/habot/) | A chatbot for openHAB |
 
 | App     | Description          |
 |---------|----------------------|
-| [Android App]({{base}}/addons/uis/apps/android.html) | The native Android app to access openHAB on the go. |
-| [iOS App]({{base}}/addons/uis/apps/ios.html) | The native iOS app to access openHAB on the go. |
-| [Windows 10 App]({{base}}/addons/uis/apps/windows.html) | The native Windows 10 app to access openHAB on the go. |
+| [Android App]({{base}}/apps/android.html) | The native Android app to access openHAB on the go. |
+| [iOS App]({{base}}/apps/ios.html) | The native iOS app to access openHAB on the go. |
+| [Windows 10 App]({{base}}/apps/windows.html) | The native Windows 10 app to access openHAB on the go. |
 
 ## Iconsets
 
@@ -34,4 +35,4 @@ See the instructions about [Custom Icons and Custom Dynamic Icons]({{base}}/conf
 
 | Iconset | Description          |
 |---------|----------------------|
-| [Classic Icons]({{base}}/addons/iconsets/classic/readme.html) | This is a modernized version of the original icon set of openHAB 1. |
+| [Classic Icons]({{base}}/configuration/iconsets/classic/) | This is a modernized version of the original icon set of openHAB 1. |

--- a/configuration/habmin.md
+++ b/configuration/habmin.md
@@ -11,6 +11,6 @@ HABmin is a modern, professional and portable user interface for openHAB,
 providing both user and administrative functions (eg sitemaps for users, and configuration utilities
 to aid setup).
 
-Please refer to the [HABmin Addon documentation]({{docu}}/addons/uis/habmin/readme.html).
+Please refer to the [HABmin Addon documentation]({{base}}/configuration/ui/habmin/).
 
 {% include contribution-wanted.html %}

--- a/configuration/items.md
+++ b/configuration/items.md
@@ -32,7 +32,7 @@ For example, an Item bound to a sensor receives updated sensor readings and an I
 
 There are two methods for defining Items:
 
-1.  Through [Paper UI]({{base}}/addons/uis/paper/readme.html).
+1.  Through [Paper UI]({{base}}/configuration/paperui.html).
     Generally all 2.x version Bindings can be configured through Paper UI.
     (Note that 1.x and legacy Bindings do not offer this option)
 
@@ -204,7 +204,7 @@ Two naming schemes are established in the community for Group names:
 ### Label
 
 Label text is used to describe an Item in a human-readable way.
-Graphical UIs will display the label text when the Item is included, e.g. in [Basic UI]({{base}}/addons/uis/basic/readme.html) in a [Sitemap]({{base}}/configuration/sitemaps.html) definition.
+Graphical UIs will display the label text when the Item is included, e.g. in [Basic UI]({{base}}/configuration/ui/basic/) in a [Sitemap]({{base}}/configuration/sitemaps.html) definition.
 Some I/O services (e.g. the Amazon Alexa skill) also use the label to match an external voice command to an Item.
 
 In textual configurations the label, in quotation marks, appears next to the optional state presentation field in square brackets (see below).
@@ -648,7 +648,7 @@ Number Temperature {mysensors="24;1;V_TEMP", expire="5m,-999"}
 ```
 
 The first example shows a symbiosis of the network health Binding and the Wake-on-LAN Binding to interact with a PC.
-The second example shows a common use case for the [Expire Binding]({{base}}/addons/bindings/expire1/)
+The second example shows a common use case for the [Expire Binding](/addons/bindings/expire1/)
 where the mysensors Binding will update temperature readings regularly but the expire Binding will also listen and eventually modify the Item state.
 
 #### Parameter `autoupdate`

--- a/configuration/packages.md
+++ b/configuration/packages.md
@@ -23,10 +23,10 @@ This is the recommended package for the normal user. It contains the most common
 
 This package thus installs:
 
-- [Home Builder](homebuilder.html){:target="_blank"} as a getting-started generator for your home
-- [Paper UI](../addons/uis/paper/readme.html){:target="_blank"} for system administration, including item access
-- [Basic UI](../addons/uis/basic/readme.html){:target="_blank"} as the new modern web UI for mobile devices
-- [HABPanel](../addons/uis/habpanel/readme.html){:target="_blank"} as a dashboard UI for (e.g. wall-mounted) tablets
+- [Home Builder]({{base}}/configuration/homebuilder.html]) as a getting-started generator for your home
+- [Paper UI]({{base}}/configuration/paperui.html) for system administration, including item access
+- [Basic UI]({{base}}/configuration/ui/basic) as the new modern web UI for mobile devices
+- [HABPanel]({{base}}/configuration/habpanel.html) as a dashboard UI for (e.g. wall-mounted) tablets
 
 Additional add-ons can be installed through Paper UI or directly by defining them in `addons.cfg`.
 
@@ -38,11 +38,11 @@ All users coming from openHAB 1.x should choose this package. It contains everyt
 
 This package thus installs:
 
-- [Paper UI](../addons/uis/paper/readme.html){:target="_blank"} for system administration, including item access
-- [Classic UI](../addons/uis/classic/readme.html){:target="_blank"} as the well-known web UI from openHAB 1.x
-- [Basic UI](../addons/uis/basic/readme.html){:target="_blank"} as the new modern web UI for mobile devices
-- [HABPanel](../addons/uis/habpanel/readme.html){:target="_blank"} as a dashboard UI for (e.g. wall-mounted) tablets
-- [HABmin](../addons/uis/habmin/readme.html){:target="_blank"} as a powerful administration console, specifically suited for Z-Wave setups
+- [Paper UI]({{base}}/configuration/paperui.html) for system administration, including item access
+- [Classic UI]({{base}}/configuration/ui/classic/) as the well-known web UI from openHAB 1.x
+- [Basic UI]({{base}}/configuration/ui/basic) as the new modern web UI for mobile devices
+- [HABPanel]({{base}}/configuration/habpanel.html) as a dashboard UI for (e.g. wall-mounted) tablets
+- [HABmin]({{base}}/configuration/ui/habmin/) as a powerful administration console, specifically suited for Z-Wave setups
 - Interactive REST API that easily allows exploring the REST features through a documented UI
 - all available transformations as they used to be part of the core 1.x runtime
 
@@ -53,9 +53,9 @@ This package thus installs:
 This package contains only components that allow a fully UI-driven setup and configuration process.
 These are:
 
-- [Paper UI](../addons/uis/paper/readme.html){:target="_blank"} for system administration, configured with "simple linking", i.e. no items are exposed to the user
-- the [new rule engine](rules-ng.html){:target="_blank"} to set up automation rules without scripting
-- [HABPanel](../addons/uis/habpanel/readme.html){:target="_blank"} as a dashboard UI for daily use
+- [Paper UI]({{base}}/configuration/paperui.html) for system administration, configured with "simple linking", i.e. no items are exposed to the user
+- the [new rule engine]({{base}}/configuration/rules-ng.html) to set up automation rules without scripting
+- [HABPanel]({{base}}/configuration/habpanel.html) as a dashboard UI for daily use
 - only "native" openHAB 2 bindings are available, 1.x add-ons are excluded
 
 **WARNING**: Note that the UI-driven configuration features are new and still under development, so many features will be enhanced in upcoming versions.
@@ -67,13 +67,13 @@ This package therefore should only be used for very simple setups or as an demon
 
 ![demo](images/package_demo.jpg){:style="float: right;margin-left: 20px;margin-top: 7px;margin-bottom: 20px"}
 
-This package is suitable for demo purposes and for quickly checking out openHAB. It not only installs a few common bindings, but also defines sample textual configuration files, which are also used on the public [openHAB Demo Server](https://demo.openhab.org/){:target="_blank"}.
+This package is suitable for demo purposes and for quickly checking out openHAB. It not only installs a few common bindings, but also defines sample textual configuration files, which are also used on the public [openHAB Demo Server](https://demo.openhab.org/).
 
 This includes:
 
-- [Paper UI](../addons/uis/paper/readme.html){:target="_blank"} for system administration, configured in "simple" mode, such that newly added Things directly become available on the control UIs
-- [Basic UI](../addons/uis/basic/readme.html){:target="_blank"} as the new modern web UI for mobile devices
-- [HABPanel](../addons/uis/habpanel/readme.html){:target="_blank"} as a dashboard UI for tablets
+- [Paper UI]({{base}}/configuration/paperui.html) for system administration, configured in "simple" mode, such that newly added Things directly become available on the control UIs
+- [Basic UI]({{base}}/configuration/ui/basic) as the new modern web UI for mobile devices
+- [HABPanel]({{base}}/configuration/habpanel.html) as a dashboard UI for tablets
 - Bindings for Yahoo Weather, Belkin WeMo, Philips Hue, Sonos, IPP, Astro, AVM!Fritz and NTP
 - RRD4j persistence service for storing time-series locally
 - MAP transformation service as this is heavily used by the sample files

--- a/configuration/paperui.md
+++ b/configuration/paperui.md
@@ -7,7 +7,7 @@ title: Configuration though Paper UI
 
 # Configuration though Paper UI
 
-Please refer to the [Paper UI Addon documentation]({{docu}}/addons/uis/paper/readme.html).
+Please refer to the [Paper UI Addon documentation]({{base}}/configuration/paperui.html).
 
 The Paper UI is a new interface that helps setting up and configuring your openHAB instance.
 It does not (yet) cover all aspects, so you still need to resort to textual configuration files, but it already offers the following:

--- a/configuration/sitemaps.md
+++ b/configuration/sitemaps.md
@@ -9,7 +9,7 @@ title: Sitemaps
 
 In openHAB a collection of [Things]({{base}}/concepts/things.html) and [Items]({{base}}/concepts/items.html) represent physical or logical objects in the user's home automation setup.
 Sitemaps are used to select and prepare these elements in order to compose a user-oriented presentation of this setup for various User Interfaces (UIs),
-including [BasicUI]({{base}}/addons/uis/basic/readme.html),
+including [BasicUI]({{base}}/docs/configuration/ui/basic/),
 the [Android openHAB app](https://play.google.com/store/apps/details?id=org.openhab.habdroid) and others.
 
 This page is structured as follows:

--- a/configuration/things.md
+++ b/configuration/things.md
@@ -42,8 +42,8 @@ through [discovery]({{base}}/concepts/discovery.html) or by manual definition in
 
 *Note:* Some bindings do not fully support auto-discovery, others are hard to manually cover by the file based approach.
 Please consult the documentation for each binding to determine the best way to add that binding's Things and Items to openHAB.
-For some bindings (such as the [YahooWeater]({{base}}/addons/bindings/yahooweather/readme.html) binding), manual Thing definitions are required.
-Other bindings (such as the [ZWave]({{base}}/addons/bindings/zwave/readme.html) binding) currently prefer or require the discovery method.
+For some bindings, manual Thing definitions are required.
+Other bindings (such as the [ZWave](https://www.openhab.org/addons/bindings/zwave/) binding) currently prefer or require the discovery method.
 
 ### Defining Things Using Discovery
 
@@ -83,7 +83,7 @@ Thing ntp:ntp:local [ hostname="de.pool.ntp.org" ]
 
 Looking at the first example:
 
-- the binding ID is "network" (using the [Network Binding]({{base}}/addons/bindings/network/readme.html))
+- the binding ID is "network" (using the [Network Binding](https://www.openhab.org/addons/bindings/network/)
 - the type ID is "device", indicating the Thing is a device
 - the Thing ID is "webcam", which is an ID to uniquely identify the Thing
 - the label is "Webcam", this is how the Thing will be named in the various user interfaces

--- a/configuration/transform.md
+++ b/configuration/transform.md
@@ -10,7 +10,7 @@ title: Transformations Configuration
 Transformations are used to translate data from a cluttered or technical raw value to a processed or human-readable representation.
 They are often useful, to **interpret received Item values**, like sensor readings or state variables, and to translate them into a human-readable or better processible format.
 
-Details about the usage of Transformations and the available Transformation services can be found in the [main Transformation services article]({{base}}/addons/transformations.html).
+Details about the usage of Transformations and the available Transformation services can be found in the [main Transformation services article](/addons/#transform).
 
 Be aware that a transformation service just as any other openHAB add-on needs to be installed prior to first usage.
 

--- a/installation/windows.md
+++ b/installation/windows.md
@@ -49,7 +49,7 @@ To install it, follow these simple steps:
 
 4.  Point your browser to `http://localhost:8080`.
     You should be looking at the openHAB [package selection page]({{base}}/configuration/packages.html).
-    When you've selected an appropriate package, this page will contain the [UI]({{base}}/addons/uis.html) selection screen.
+    When you've selected an appropriate package, this page will contain the UI [see docs under section "Interfaces and Ecosystem"]({{base}}/docs/) selection screen.
 
 ### File Locations
 

--- a/tutorials/beginner/configuration.md
+++ b/tutorials/beginner/configuration.md
@@ -123,7 +123,7 @@ To demonstrate that, we'll proceed and install the Zwave binding in order to add
 However, this is a demonstration about how to install and configure add-ons.
 As mentioned before, the pure procedure to install and configure add-ons is mostly the same with other addons.**
 
-**More information about the Zwave binding and the other available bindings can be found [on the bindings page of the user manual]({{base}}/addons/bindings.html)!**
+**More information about the Zwave binding and the other available bindings can be found [on the bindings page of the user manual](https://www.openhab.org/addons/#bindings)!**
 
 The installation is just like the example with the network binding above.
 Use the "Add-ons" menu item, search for the "Zwave" binding, click "INSTALL" and go directly to the "Inbox" afterwards.

--- a/tutorials/migration.md
+++ b/tutorials/migration.md
@@ -124,13 +124,13 @@ It will include the standard UIs, all transformation services and the 1.x compat
 If you are in doubt of the name of a binding, look in openhab.cfg for that binding's configurations. 
 The first part of the tag in openhab.cfg will be that name of the binding, then append a 1.
 For example, the configuration parameters for the MQTT Binding start with "mqtt" in openhab.cfg so the name of the binding is "mqtt1".
-You can find the list of bindings [here]({{base}}/addons/bindings.html).
+You can find the list of bindings [here](/addons/#bindings).
 - `ui = ` - if you intend on using PaperUI include "paper", if you use zwave I recommend "habmin". 
-The list of UIs are [here]({{base}}/addons/uis.html).
-- `action = ` - the list of action add-ons.
-- `transformation = ` - the list of transformations you use. 
+The list of UIs are [here]({{base}}/docs/configuration/).
+- `action = ` - the list of action add-ons, see [here](/addons/#action) for list of possible actions.
+- `transformation = ` - the list of transformations you use, for a list of possible transformations, see [here](/addons/#transform). 
 Unlike in openHAB 1, one must install transformations separately.
-- `voice = ` - see [here]({{base}}/addons/voices.html)
+- `voice = ` - see [here](/addons#voice)
 - `misc = ` - homekit, etc. 
 Do not list myopenhab/openhabcloud at this time, instructions for it are below.
 Do not install any 2.x version binding at this time.
@@ -481,32 +481,33 @@ A Thing represents a configurable device/system/unit, which provides different f
 Each Channel corresponds exactly to one binding configuration string (stuff in { }) in openHAB 1.x.
 
 Let's look at a concrete example. 
-The [Yahoo Weather Binding]({{base}}/addons/bindings/yahooweather/readme.html) supports exactly one Thing which takes two parameters: a WOEID location and unit.
-
+The [Network Binding](addons/bindings/network) (the impoved binding to the OH1 Network Health binding) supports exaclty one Thing which takes one parameter: the IP number of the device on the network.
 Thus, as described in the Binding's readme one would manually define a Thing in a .things file (located in conf/things) with the line:
 
 ```java
-Thing yahooweather:weather:berlin [ location=638242 ]
+//For OH2 Network Binding
+Thing network:pingdevice:devicename [ hostname="192.168.0.42" ]
 ```
 
-As described in the Binding's readme, three Channels are supported: temperature, humidity, and pressure. 
-Thus, rather than the old openHAB 1.x syntax:
+As described in the Binding's documentation, two Channels are supported in the version for openHAB2: online status and latency.
+The older version 1 of the Network binding only supported online status 
+Thus, rather than the old openHAB 1.x syntax (Network Health):
 
 ```java
-// openHAB 1 Syntax
-Number Temperature   { yahooweather="woeid=638242,value=temperature,unit=c" }
-Number Humidity      { yahooweather="woeid=638242,value=humidity,unit=c" }
+// openHAB 1 Syntax for Network Health Binding
+Switch MyDevice "My Decive" { nh="192.168.0.42" }
 ```
 
 with everything defined on in the { } part of the Item, we now merely reference the Channels.
 
+
 ```java
-// openHAB 2 Syntax
-Number Temperature   { channel="yahooweather:weather:berlin:temperature" }
-Number Humidity      { channel="yahooweather:weather:berlin:humidity" }
+// openHAB 2 Syntax for Network Binding
+Switch MyDevice { channel="network:pingdevice:devicename:online" }
+Number MyDeviceResponseTime { channel="network:pingdevice:devicename:latency" }
 ```
 
-As you can see, the Channel ID consists of the Thing's name, a "#" and the Channel name.
+As you can see, the Channel ID consists of the Thing's name and the Channel name.
 
 For manually defined Things, you can find the syntax for defining a Thing on a given Item in that Binding's readme.
 
@@ -575,7 +576,8 @@ It should now show your system as being online and running openHAB 2.
 
 One is not required to use 2.x version addi-ons with openHAB 2. 
 It is highly recommended to do so as most cases where there is a 1.x and a 2.x add-on, only the 2.x binding is undergoing continued development. 
-On-the-other-hand, some of the 2.x bindings work significantly differently from their 1.x versions. See the add-on's 1.x [readme]({{base}}/addons/1xaddons.html) and 2.x [readme page]({{base}}/addons/bindings.html) to compare and contrast the two versions.
+On-the-other-hand, some of the 2.x bindings work significantly differently from their 1.x versions. All binding versions are available [here](/addons/bindings.html) to compare and contrast the two versions.
+It is worth noting, however, that where a version 2 binding exist, it is unlikely that the older version 1 binding continue to be updated.
 
 Identify an add-on where there is a 2.x version that you want to migrate to. 
 Begin by identifying those Items that use this binding. 


### PR DESCRIPTION
fixes #808
reference to Yahooweather (now obsolete) deleted
replaced Yahooweather (obsolete) with Network binding in migration example
fixed misc links