### PR TITLE
Clarify rules-dsl.md

### DIFF
--- a/configuration/rules-dsl.md
+++ b/configuration/rules-dsl.md
@@ -295,10 +295,14 @@ The following table summarizes the impact of the two manipulator commands on the
 | Command \ Rule Trigger   | `received update` | `received command` | `changed` |
 |--------------------------|-------------------|--------------------|-----------|
 | postUpdate               | ⚡ rule fires      | ❌                 | (depends) |
-| sendCommand              | ❌                | ⚡ rule fires       | (depends) |
+| sendCommand              | (❌) see below               | ⚡ rule fires       | (depends) |
 | *Change through Binding* | ⚡ rule fires      | ⚡ rule fires       | (depends) |
 
 **Beware:**
+In most cases, a rule with a trigger of ```receveived update``` will fire following the command ```sendCommand``` as:
+- openHAB auto-updates the status of Items for which the item definition does not contain ```autoupdate="false"```
+- the Thing sends an status update to the Item.
+
 Besides the specific manipulator command methods `MyItem.sendCommand(<new_state>)` and `MyItem.postUpdate(<new_state>)`, generic manipulators in the form of `sendCommand(MyItem, <new_state>)` and `postUpdate(MyItem, <new_state>)` are available. The specific versions is normally recommended.
 
 {: #sendcommand-method-vs-action}


### PR DESCRIPTION
fixes #860 
Added language to clarify that sendCommand can trigger rules with received update trigger

Signed-off-by: Markus Lipp lipp_markus@gmail.com (github: LightIsLife)