### PR TITLE
Update Things.md in order to show exampels for file created things an…

### DIFF
--- a/configuration/things.md
+++ b/configuration/things.md
@@ -128,21 +128,21 @@ For the contained notation of things the UID will be inherited and the bridge ID
 
 **Example of a MQTT Bridge with Generic MQTT Things :**
 ```xtend
-Bridge mqtt:broker:MyMQTTBroker [ host="192.168.178.50", secure=false, username="MyUserName", password="MyPassword"]
-{
-Thing topic sonoff_Dual_Thing "Light_Dual" @ "Sonoff" {  
+Bridge mqtt:broker:MyMQTTBroker [ host="192.168.178.50", secure=false, username="MyUserName", password="MyPassword"] {
+  Thing topic sonoff_Dual_Thing "Light_Dual" @ "Sonoff" {  
     Channels:
-        Type switch : PowerSwitch1  [ stateTopic="stat/sonoff_dual/POWER1" , commandTopic="cmnd/sonoff_dual/POWER1", on="ON", off="OFF"]
-        Type switch : PowerSwitch2  [ stateTopic="stat/sonoff_dual/POWER2" , commandTopic="cmnd/sonoff_dual/POWER2", on="ON", off="OFF"]
-        Type string : Version [stateTopic="stat/sonoff_dual/STATUS2", transformationPattern="JSONPATH:$.StatusFWR.Version"]
+      Type switch : PowerSwitch1  [ stateTopic="stat/sonoff_dual/POWER1" , commandTopic="cmnd/sonoff_dual/POWER1", on="ON", off="OFF"]
+      Type switch : PowerSwitch2  [ stateTopic="stat/sonoff_dual/POWER2" , commandTopic="cmnd/sonoff_dual/POWER2", on="ON", off="OFF"]
+      Type string : Version [stateTopic="stat/sonoff_dual/STATUS2", transformationPattern="JSONPATH:$.StatusFWR.Version"]
       }     
   Thing topic sonoff_TH_Thing "Light_TH" @ "Sonoff" {
     Channels:
-        Type switch : PowerSwitch  [ stateTopic="stat/sonoff_TH/POWER", commandTopic="cmnd/sonoff_TH/POWER", on="ON", off="OFF" ]
-        Type string : Version [stateTopic="stat/sonoff_TH/STATUS2", transformationPattern="JSONPATH:$.StatusFWR.Version"]
-        Type number : Temperature [stateTopic="tele/sonoff_TH/SENSOR", transformationPattern="JSONPATH:$.AM2301.Temperature"]
-        Type number : Humidity [stateTopic="tele/sonoff_TH/SENSOR", transformationPattern="JSONPATH:$.AM2301.Humidity"]
-      }   
+      Type switch : PowerSwitch  [ stateTopic="stat/sonoff_TH/POWER", commandTopic="cmnd/sonoff_TH/POWER", on="ON", off="OFF" ]
+      Type string : Version [stateTopic="stat/sonoff_TH/STATUS2", transformationPattern="JSONPATH:$.StatusFWR.Version"]
+      Type number : Temperature [stateTopic="tele/sonoff_TH/SENSOR", transformationPattern="JSONPATH:$.AM2301.Temperature"]
+      Type number : Humidity [stateTopic="tele/sonoff_TH/SENSOR", transformationPattern="JSONPATH:$.AM2301.Humidity"]
+   }
+}   
 ```
 
 ### Linking Items

--- a/configuration/things.md
+++ b/configuration/things.md
@@ -75,7 +75,7 @@ The next statement defines the UID of the thing which contains of the following 
 So the first two segments must match to a thing type supported by a binding (e.g. `network:device` or `astro:moon`), whereas the thing id can be freely defined. 
 Optionally, you may provide a label in order to recognize it easily, otherwise the default label from the thing type will be displayed.
 
-To help organizing your things, you also may define a location (here: `Location`).
+To help organizing your things, you also may define a location (`Location` in the example above).
 
 Inside the squared brackets configuration parameters of the thing are defined. 
 The type of the configuration parameter is determined by the binding and must be specified accordingly in the DSL.

--- a/configuration/things.md
+++ b/configuration/things.md
@@ -72,7 +72,7 @@ Thing <binding_id>:<type_id>:<thing_id> "Label" @ "Location" [ <parameters> ]
 
 The first keyword defines whether the entry is a bridge or a thing. 
 The next statement defines the UID of the thing which contains of the following three segments: `binding id`, `thing type id`, `thing id`. 
-So the first two segments must match to thing type supported by a binding (e.g. `network:device` or `astro:moon`), whereas the thing id can be freely defined. 
+So the first two segments must match to a thing type supported by a binding (e.g. `network:device` or `astro:moon`), whereas the thing id can be freely defined. 
 Optionally, you may provide a label in order to recognize it easily, otherwise the default label from the thing type will be displayed.
 
 To help organizing your things, you also may define a location (here: `Location`).

--- a/configuration/things.md
+++ b/configuration/things.md
@@ -70,11 +70,15 @@ The syntax for `.things` files is defined as follows (parts in `<..>` are requir
 Thing <binding_id>:<type_id>:<thing_id> "Label" @ "Location" [ <parameters> ]
 ```
 
-The first keyword defines whether the entry is a bridge or a thing. The next statement defines the UID of the thing which contains of the following three segments: binding id, thing type id, thing id. So the first two segments must match to thing type supported by a binding (e.g. `network:device` or `astro:moon`), whereas the thing id can be freely defined. Optionally, you may provide a label in order to recognize it easily, otherwise the default label from the thing type will be displayed.
+The first keyword defines whether the entry is a bridge or a thing. 
+The next statement defines the UID of the thing which contains of the following three segments: binding id, thing type id, thing id. 
+So the first two segments must match to thing type supported by a binding (e.g. `network:device` or `astro:moon`), whereas the thing id can be freely defined. 
+Optionally, you may provide a label in order to recognize it easily, otherwise the default label from the thing type will be displayed.
 
 To help organizing your things, you also may define a location (here: `Location`).
 
-Inside the squared brackets configuration parameters of the thing are defined. The type of the configuration parameter is determined by the binding and must be specified accordingly in the DSL.
+Inside the squared brackets configuration parameters of the thing are defined. 
+The type of the configuration parameter is determined by the binding and must be specified accordingly in the DSL.
 
 
 **Examples:**
@@ -107,7 +111,10 @@ Bridge hue:bridge:mybridge [ ipAddress="192.168.3.123" ] {
 }
 ```
 
-Within the curly brackets things can be defined, that should be members of the bridge. For the contained thing only the thing type ID and thing ID must be defined (e.g. 0210 bulb1). So the syntax is `Thing <thingTypeId> <thingId> []`. The resulting UID of the thing is `hue:0210:mybridge:bulb1`.
+Within the curly brackets things can be defined, that should be members of the bridge. 
+For the contained thing only the thing type ID and thing ID must be defined (e.g. 0210 bulb1). 
+So the syntax is `Thing <thingTypeId> <thingId> []`. 
+The resulting UID of the thing is `hue:0210:mybridge:bulb1`.
 
 Bridges that are defined somewhere else can also be referenced in the DSL:
 
@@ -115,7 +122,9 @@ Bridges that are defined somewhere else can also be referenced in the DSL:
 Thing hue:0210:mybridge:bulb (hue:bridge:mybridge) [lightId="3"]
 ```
 
-The referenced bridge is specified in the parentheses. Please notice that the UID of the thing also contains the bridge ID as third segment. For the contained notation of things the UID will be inherited and the bridge ID is automatically taken as part of the resulting thing UID.
+The referenced bridge is specified in the parentheses. 
+Please notice that the UID of the thing also contains the bridge ID as third segment. 
+For the contained notation of things the UID will be inherited and the bridge ID is automatically taken as part of the resulting thing UID.
 
 **Example of a MQTT Bridge with Generic MQTT Things :**
 ```xtend

--- a/configuration/things.md
+++ b/configuration/things.md
@@ -71,7 +71,7 @@ Thing <binding_id>:<type_id>:<thing_id> "Label" @ "Location" [ <parameters> ]
 ```
 
 The first keyword defines whether the entry is a bridge or a thing. 
-The next statement defines the UID of the thing which contains of the following three segments: binding id, thing type id, thing id. 
+The next statement defines the UID of the thing which contains of the following three segments: `binding id`, `thing type id`, `thing id`. 
 So the first two segments must match to thing type supported by a binding (e.g. `network:device` or `astro:moon`), whereas the thing id can be freely defined. 
 Optionally, you may provide a label in order to recognize it easily, otherwise the default label from the thing type will be displayed.
 


### PR DESCRIPTION
…d bridges

As the new mqtt binding has a much larger audience then other OH2-bindings which already used bridges the missing examples of bridge definitions in the openHAB core documentation became more then obvious.
I used the text parts from the eclipse smarthome documentation and added an example of a mqtt bridge with generic things.

Signed-off-by: Juergen Baginski opus42@gmx.de (github: JueBag)