### PR TITLE
Add bundles folder logic for binding types

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -144,6 +144,26 @@
             </configuration>
           </execution>
           <execution>
+            <id>copy-oh2-persistence-docs</id>
+            <phase>process-resources</phase>
+            <goals>
+              <goal>copy-resources</goal>
+            </goals>
+            <configuration>
+              <outputDirectory>${basedir}/_addons_persistences/oh2</outputDirectory>
+              <resources>
+                <resource>
+                  <directory>${basedir}/.external-resources/openhab2-addons/bundles</directory>
+                  <includes>
+                    <include>org.openhab.persistence.*/**/README.md</include>
+                    <include>org.openhab.persistence.*/**/doc/**</include>
+                    <include>org.openhab.persistence.*/**/cfg/**</include>
+                  </includes>
+                </resource>
+              </resources>
+            </configuration>
+          </execution>
+          <execution>
             <id>copy-oh2-binding-docs</id>
             <phase>process-resources</phase>
             <goals>
@@ -199,6 +219,14 @@
                     <include>**/README.md</include>
                     <include>**/doc/**</include>
                     <include>**/cfg/**</include>
+                  </includes>
+                </resource>
+                <resource>
+                  <directory>${basedir}/.external-resources/openhab2-addons/bundles</directory>
+                  <includes>
+                    <include>org.openhab.transform.*/**/README.md</include>
+                    <include>org.openhab.transform.*/**/doc/**</include>
+                    <include>org.openhab.transform.*/**/cfg/**</include>
                   </includes>
                 </resource>
               </resources>
@@ -265,6 +293,14 @@
                     <include>**/cfg/**</include>
                   </includes>
                 </resource>
+                <resource>
+                  <directory>${basedir}/.external-resources/openhab2-addons/bundles</directory>
+                  <includes>
+                    <include>org.openhab.voice.*/**/README.md</include>
+                    <include>org.openhab.voice.*/**/doc/**</include>
+                    <include>org.openhab.voice.*/**/cfg/**</include>
+                  </includes>
+                </resource>
               </resources>
             </configuration>
           </execution>
@@ -306,6 +342,14 @@
                     <include>**/README.md</include>
                     <include>**/doc/**</include>
                     <include>**/cfg/**</include>
+                  </includes>
+                </resource>
+                <resource>
+                  <directory>${basedir}/.external-resources/openhab2-addons/bundles</directory>
+                  <includes>
+                    <include>org.openhab.io.*/**/README.md</include>
+                    <include>org.openhab.io.*/**/doc/**</include>
+                    <include>org.openhab.io.*/**/cfg/**</include>
                   </includes>
                 </resource>
               </resources>

--- a/pom.xml
+++ b/pom.xml
@@ -161,6 +161,14 @@
                   </includes>
                 </resource>
                 <resource>
+                  <directory>${basedir}/.external-resources/openhab2-addons/bundles</directory>
+                  <includes>
+                    <include>org.openhab.binding.*/**/README.md</include>
+                    <include>org.openhab.binding.*/**/doc/**</include>
+                    <include>org.openhab.binding.*/**/cfg/**</include>
+                  </includes>
+                </resource>
+                <resource>
                   <directory>${basedir}/.external-resources/openhab-bundles/bindings</directory>
                   <includes>
                     <include>org.openhab.binding.zwave/README.md</include>


### PR DESCRIPTION
This PR should solve the missing addon documentations caused by a folder restructuring in the openhab2-addons repository. 

@wborn, if you agree with my type filter i would prepare that directly for other addon types where already possible,

Signed-off-by: Jerome Luckenbach <github@luckenba.ch>

Closes #918 