### PR TITLE
Update restore state on restart documentation

### DIFF
--- a/configuration/persistence.md
+++ b/configuration/persistence.md
@@ -135,11 +135,11 @@ Items {
 
 ## Restoring Item States on Restart
 
-When restarting your openHAB installation you may find there are times when your logs indicate some Items have the state, `UNDEF`.
+When restarting your openHAB installation you may find there are times when your logs indicate some Items have the state `NULL`.
 This is because, by default, Item states are not persisted when openHAB restarts - even if you have installed a persistence add-on.
-In order for items to be persisted across openHAB restarts, you must define a `restoreOnStartup` strategy for all your items.
-Then, whatever state they were in before the restart will be restored automatically.
-The following example persists all items on every change and restores them at startup:
+In order for items to be persisted across openHAB restarts, you must define a `restoreOnStartup` strategy for your items.
+Then whatever state they were in before the restart will be restored automatically.
+The following example persists two items on every change and restores them at startup:
 
 ```java
 Strategies {
@@ -147,9 +147,11 @@ Strategies {
 }
 
 Items {
-  * : strategy = everyChange, restoreOnStartup
+  item1, item2 : strategy = everyChange, restoreOnStartup
 }
 ```
+It is usually not necessary to restore all Items since there is a good chance that they are no longer accurate (switches may have been toggled, sensor values are likely to have changed), and the restoration may result in unwanted rule actions.
+
 
 ## Persistence Extensions in Scripts and Rules
 


### PR DESCRIPTION
See discussion with rossko57 here: https://community.openhab.org/t/nightmare-stop-oh2-turning-on-my-relays/70016/15
Update "Restoring Item States on Restart" to give an example of two Items instead of all Items. Generally restoring all states has led to issues, so it is better to guide users to restore specific Items.

Signed-off-by: John Schmitz jswim400im@gmail.com (github: jswim788)