### PR TITLE
Fix link to Java homepage

### DIFF
--- a/introduction.md
+++ b/introduction.md
@@ -180,7 +180,7 @@ But it comes with a rather steep learning curve.
 
 ## A deeper dive: openHAB Structure for advanced users
 
-openHAB 2 is developed in [Java](https:/www.java.com/) and uses [OSGi](https://www.osgi.org/) for modularity. 
+openHAB 2 is developed in [Java](https://www.java.com/) and uses [OSGi](https://www.osgi.org/) for modularity. 
 [Apache Karaf](http://karaf.apache.org/) serves as a container with [Eclipse Equinox](https://www.eclipse.org/equinox/) as the OSGi runtime environment. 
 [Jetty](https://www.eclipse.org/jetty/) is included as an HTTP server.
 


### PR DESCRIPTION
This is an insanely minor fix but the link to the Java homepage was missing a second slash after the protocol which caused the link to render out to https://www.openhab.org/www.java.com/ on the live site.