### PR TITLE
Removed GitHub handle from the sign off example

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -77,7 +77,7 @@ By making a contribution to this project, I certify that:
 
 then you just add a line to every git commit message:
 
-    Signed-off-by: Joe Smith <joe.smith@email.com> (github: github_handle)
+    Signed-off-by: Joe Smith <joe.smith@email.com>
 
 using your real name (sorry, no pseudonyms or anonymous contributions.) and an
 e-mail address under which you can be reached (sorry, no github noreply e-mail


### PR DESCRIPTION
To prevent the DCO check from failing, even if there is a valid sign-off-statement.

Signed-off-by: Jerome Luckenbach <github@luckenba.ch>