### PR TITLE
Update guidelines.md

### DIFF
--- a/developers/development/guidelines.md
+++ b/developers/development/guidelines.md
@@ -38,7 +38,7 @@ The following directory and file layout must be respected:
 1. Every Java file must have a license header. You can run ```mvn license:format``` on the root of the repo to automatically add missing headers.
 1. Code must be formatted using the "ESH" code formatter (in Eclipse).
    - This is set up automatically by the official [IDE setup](ide.html)
-   - You can manually import [ESH.xml](ESH.xml) via Eclipse Preferences -> Java -> Code Style -> Formatter.
+   - You can manually import [ESH.xml]({base}/developer/contributing/ESH.xml) via Eclipse Preferences -> Java -> Code Style -> Formatter.
 
 ## B. Code Style
 

--- a/developers/development/guidelines.md
+++ b/developers/development/guidelines.md
@@ -22,15 +22,16 @@ The following directory and file layout must be respected:
 .
 +-- pom.xml  The buildsystem (maven) file that contains the version and name of your extension
 |
-+-- NOTICE   license information
++-- NOTICE   License information
 |            3rd party content has to be given in the NOTICE file.
 |
-+-- lib      3rd party jar files - Avoid to use those, use maven dependencies instead
++-- lib      3rd party jar files - Avoid those, use maven dependencies instead
 |
 +-- src      Your source code
-|   +-- main/jave/...      The java sources
-|   +-- main/resources/... Other resource files like the binding.xml
-|   +-- test/jave/...      Your test code
+|   +-- main/jave/...            The java sources
+|   +-- main/resources/ESH_INF/  Binding and config xml description files like binding.xml
+|   +-- main/resources/...       Other resource files
+|   +-- test/jave/...            Your test code
 ```
 
 1. The [Java naming conventions](http://java.about.com/od/javasyntax/a/nameconventions.htm) should be used for source files.
@@ -41,33 +42,54 @@ The following directory and file layout must be respected:
 
 ## B. Code Style
 
-1. Generics must be used where applicable.
-1. Code MUST not show any warnings. Warnings that cannot be circumvented should be suppressed by using the `@SuppressWarnings` annotation.
-1. Packages that contain classes that are not meant to be used by other bundles MUST have "internal" in their package name.
-1. Every class, except data-transfer-objects (DTO), must be annotated with `@NonNullByDefault`.
-and `@Nullable` should be used, for details see [Null annotation](#null-annotations).
-1. OSGi Declarative Services should be declared using annotations. 
+* Generics must be used where applicable. See example below:
+
+```java
+public static <T> boolean isEqual(GenericsType<T> g1, GenericsType<T> g2){
+		return g1.get().equals(g2.get());
+}
+```
+
+* Code MUST not show any warnings. Warnings that cannot be circumvented should be suppressed by using the `@SuppressWarnings` annotation.
+* Your classes are generally organised within an internal package
+
+```
+org.openhab.binding.coolbinding.internal
+org.openhab.binding.coolbinding.internal.handler
+org.openhab.binding.coolbinding.internal.discovery
+```
+
+Remember that classes that are meant to be used by scripts or other bindings must be non internal.
+
+* Every class, except data-transfer-objects (DTO), must be annotated with `@NonNullByDefault`.
+  For details see [Null annotation](#null-annotations).
+* OSGi Declarative Services annotations are to be used
+
+```java
+@Component(service=MyCoolService.class)
+public class MyCoolService {
+   @Reference
+   private @NonNullByDefault({}) ItemRegistry itemRegistry;
+}
+```
 
 ## C. Documentation
 
-The following is valid for every class, interface and enumeration (except inner classes and enums):
+JavaDoc is required to describe the purpose and usage of every:
 
-1. JavaDoc is required, describing the elements purpose and usage.
-   Data-transfer-objects (DTOs map from Json/XML to Java classes) do not need JavaDoc.
-1. An `@author` tag within the JavaDoc for every author that wrote a substantial part of the file is required.
+* class,
+* interface,
+* enumeration (except inner classes and enums),
+* constant, field and method with visibility of default, protected or public.
 
-We also require JavaDoc for
-
-* every constant,
-* field and
-* method with default, protected or public visibility.
+An @author tag is required within the JavaDoc for every author who made a substantial contribution to the file. New @author tags should be placed below the older ones. Data-transfer-objects (DTOs map from Json/XML to Java classes) do not require JavaDoc.
 
 ## D. Language Levels and Libraries
 
 1. openHAB generally targets the long time supported Java 8 and Java 11 releases with the following restrictions:
- * To allow optimized runtimes, the set of Java packages to be used is furthermore restricted to [Compact Profile 2](http://www.oracle.com/technetwork/java/embedded/resources/tech/compact-profiles-overview-2157132.html)
-2. The [OSGi R5](http://www.osgi.org/Download/Release5) release is targeted, no newer features should be used.
-3. slf4j is used for logging
+ * To allow optimized runtimes, the set of Java packages to be used is further restricted to [Compact Profile 2](http://www.oracle.com/technetwork/java/embedded/resources/tech/compact-profiles-overview-2157132.html)
+2. The [OSGi R5](http://www.osgi.org/Download/Release5) release is targeted, and newer features should not be used.
+3. slf4j is used for logging.
 4. Some utility libraries are available which can be used throughout the code:
  - Apache Commons IO
  - Apache Commons Lang
@@ -82,8 +104,8 @@ We also require JavaDoc for
 ## F. Logging
 
 This section explains some logging usage patterns.
-The used logger allows to log to different severity levels (trace, info, debug, warn, error).
-Most of the time you want to use `warn` or `debug`. 
+The logger that is used allows logging at multiple severity levels (trace, info, debug, warn, error).
+Most of the time, a level of `warn` or `debug` will be used.
 Please remember that every logging statement adds to code size and runtime cost.
 
 * Loggers should be [non-static](http://slf4j.org/faq.html#declared_static), when ever possible and have the name ```logger```.
@@ -136,11 +158,16 @@ void myFun() {
 }
 ```
 
-Please keep the user informated via those `update*` methods if a connection drops etc and not abuse the logger.
+Please keep the user informed through those `update*` methods, when a connection drops, device is not accessible, etc.
+Do not over use the logger.
 
-* `warn` logging should only be used to inform the user that something seems to be wrong in his overall setup, but the system can nonetheless function as normal, while possibly ignoring some faulty configuration/situation. It can also be used in situations, where a code section is reached, which is not expected by the implementation under normal circumstances (while being able to automatically recover from it).
+* `warn` logging should only be used
+  - to inform the user that something seems to be wrong in his overall setup, but the system can nonetheless function as normal,
+  - in recoverable situations when a section of code that is not accessed under normal operating conditions is reached.
 
-* `error` logging is not allowed in extensions and is purely reserved to the framework. Except if something is going really, really wrong in your extension and you are going to affect the framework stability.
+* `error` logging is not allowed in extensions and is purely reserved to the framework.
+   The only exception would be if something is going really, really wrong in your extension,
+   and there is a possibility that the stability of the framework could be affected.
 
 ## Guideline details
 

--- a/developers/development/guidelines.md
+++ b/developers/development/guidelines.md
@@ -14,65 +14,139 @@ Exceptions can certainly be made, but they should be discussed and approved by a
 Note that this list also serves as a checklist for code reviews on pull requests.
 To speed up the contribution process, we therefore advice to go through this checklist yourself before creating a pull request.
 
-## A. Code Style
+## A. Directory and file layout
 
-1. The [Java naming conventions](http://java.about.com/od/javasyntax/a/nameconventions.htm) should be used.
+The following directory and file layout must be respected:
+
+```
+.
++-- pom.xml  The buildsystem (maven) file that contains the version and name of your extension
+|
++-- NOTICE   license information
+|            3rd party content has to be given in the NOTICE file.
+|
++-- lib      3rd party jar files - Avoid to use those, use maven dependencies instead
+|
++-- src      Your source code
+|   +-- main/jave/...      The java sources
+|   +-- main/resources/... Other resource files like the binding.xml
+|   +-- test/jave/...      Your test code
+```
+
+1. The [Java naming conventions](http://java.about.com/od/javasyntax/a/nameconventions.htm) should be used for source files.
 1. Every Java file must have a license header. You can run ```mvn license:format``` on the root of the repo to automatically add missing headers.
-1. Every class, interface and enumeration should have JavaDoc describing its purpose and usage.
-1. Every class, interface and enumeration must have an `@author` tag in its JavaDoc for every author that wrote a substantial part of the file.
-1. Every constant, field and method with default, protected or public visibility should have JavaDoc (optional, but encouraged for private visibility as well).
-1. Code must be formatted using the provided code formatter and clean up settings. They are set up automatically by the official [IDE setup](ide.html).
+1. Code must be formatted using the "ESH" code formatter (in Eclipse).
+   - This is set up automatically by the official [IDE setup](ide.html)
+   - You can manually import [ESH.xml](ESH.xml) via Eclipse Preferences -> Java -> Code Style -> Formatter.
+
+## B. Code Style
+
 1. Generics must be used where applicable.
-1. Code should not show any warnings. Warnings that cannot be circumvented should be suppressed by using the `@SuppressWarnings` annotation.
-1. For dependency injection, OSGi Declarative Services should be used.
-1. OSGi Declarative Services should be declared using annotations. The IDE will take care of the service `*.xml` file creation. See the official OSGi documentation for an [example here](http://enroute.osgi.org/services/org.osgi.service.component.html).
-1. Packages that contain classes that are not meant to be used by other bundles should have "internal" in their package name.
-[Null annotations](https://wiki.eclipse.org/JDT_Core/Null_Analysis) are used from the Eclipse JDT project. `@NonNullByDefault` and `@Nullable` should be used, for details see [Null annotation conventions](conventions.html#null-annotations).
+1. Code MUST not show any warnings. Warnings that cannot be circumvented should be suppressed by using the `@SuppressWarnings` annotation.
+1. Packages that contain classes that are not meant to be used by other bundles MUST have "internal" in their package name.
+1. Every class, except data-transfer-objects (DTO), must be annotated with `@NonNullByDefault`.
+and `@Nullable` should be used, for details see [Null annotation](#null-annotations).
+1. OSGi Declarative Services should be declared using annotations. 
 
-## B. OSGi Bundles
+## C. Documentation
 
-7. Every bundle must contain a Maven pom.xml with a version and artifact name that is in sync with the manifest entry. The pom.xml must reference the correct parent pom (which is usually in the parent folder).
-1. Every bundle must contain an about.html file, providing license information. If there is a third-party software in the bundle, its licence information must be added to the bundle's about.html file and the date in the about.html files must be changed to the current. You can look at and use these two examples: [about.html without 3rd party licence information](https://github.com/openhab/openhab2-addons/blob/master/addons/ui/org.openhab.ui.cometvisu.php/about.html) and [about.html with 3rd party licence information](https://github.com/openhab/openhab2-addons/blob/master/addons/binding/org.openhab.binding.avmfritz/about.html).
-1. Every bundle must contain a build.properties file, which lists all resources that should end up in the binary under `bin.includes`.
-1. The manifest must not contain any "Require-Bundle" entries. Instead, "Import-Package" must be used.
-1. The manifest must not export any internal package.
-1. The manifest must not have any version constraint on package imports, unless this is thoughtfully added. Note that Eclipse automatically adds these constraints based on the version in the target platform, which might be too high in many cases.
-1. The manifest must include all services in the Service-Component entry. A good approach is to put `OSGI-INF/*.xml` in there.
-1. Every exported package of a bundle must be imported by the bundle itself again.
-1. Any 3rd party content has to be added thoughtfully and version/license information has to be given in the NOTICE file.
+The following is valid for every class, interface and enumeration (except inner classes and enums):
 
-## C. Language Levels and Libraries
+1. JavaDoc is required, describing the elements purpose and usage.
+   Data-transfer-objects (DTOs map from Json/XML to Java classes) do not need JavaDoc.
+1. An `@author` tag within the JavaDoc for every author that wrote a substantial part of the file is required.
 
-1. Eclipse SmartHome generally targets JavaSE 8 with the following restrictions:
- * To allow optimized JavaSE 8 runtimes, the set of Java packages to be used is furthermore restricted to [Compact Profile 2](http://www.oracle.com/technetwork/java/embedded/resources/tech/compact-profiles-overview-2157132.html)
-1. The minimum OSGi framework version supported is [OSGi R4.2](http://www.osgi.org/Download/Release4V42), no newer features must be used.
-1. For logging, slf4j (v1.7.2) is used.
-1. A few common utility libraries are available that every Eclipse SmartHome based solution has to provide and which can be used throughout the code (and which are made available in the target platform):
- - Apache Commons IO (v2.2)
- - Apache Commons Lang (v2.6)
-- ~~Google Guava (v10.0.1)~~ (historically allowed, to be avoided in new contributions)
+We also require JavaDoc for
 
-## D. Runtime Behavior
+* every constant,
+* field and
+* method with default, protected or public visibility.
+
+## D. Language Levels and Libraries
+
+1. openHAB generally targets the long time supported Java 8 and Java 11 releases with the following restrictions:
+ * To allow optimized runtimes, the set of Java packages to be used is furthermore restricted to [Compact Profile 2](http://www.oracle.com/technetwork/java/embedded/resources/tech/compact-profiles-overview-2157132.html)
+2. The [OSGi R5](http://www.osgi.org/Download/Release5) release is targeted, no newer features should be used.
+3. slf4j is used for logging
+4. Some utility libraries are available which can be used throughout the code:
+ - Apache Commons IO
+ - Apache Commons Lang
+
+## E. Runtime Behavior
 
 1. Overridden methods from abstract classes or interfaces are expected to return fast unless otherwise stated in their JavaDoc. Expensive operations should therefore rather be scheduled as a job.
 1. Creation of threads must be avoided. Instead, resort into using existing schedulers which use pre-configured thread pools. If there is no suitable scheduler available, start a discussion in the forum about it rather than creating a thread by yourself. For periodically executed jobs that do not require a fixed rate [scheduleWithFixedDelay](http://docs.oracle.com/javase/7/docs/api/java/util/concurrent/ScheduledExecutorService.html#scheduleWithFixedDelay(java.lang.Runnable,%20long,%20long,%20java.util.concurrent.TimeUnit)) should be preferred over [scheduleAtFixedRate](http://docs.oracle.com/javase/7/docs/api/java/util/concurrent/ScheduledExecutorService.html#scheduleAtFixedRate(java.lang.Runnable,%20long,%20long,%20java.util.concurrent.TimeUnit)).
 1. Bundles need to cleanly start and stop without throwing exceptions or malfunctioning. This can be tested by manually starting and stopping the bundle from the console (```stop <bundle-id>``` resp. ```start <bundle-id>```).
 1. Bundles must not require any substantial CPU time. Test this e.g. using "top" or VisualVM and compare CPU utilization with your bundle stopped vs. started.
 
-## E. Logging
+## F. Logging
 
-1. As we are in a dynamic OSGi environment, loggers should be [non-static](http://slf4j.org/faq.html#declared_static), when ever possible and have the name ```logger```.
-1. Parametrized logging must be used (instead of string concatenation).
-1. Where ever unchecked exceptions are caught and logged, the exception should be added as a last parameter to the logging. For checked exceptions, this is normally not recommended, unless it can be considered an error situation and the stacktrace would hold additional important information for the analysis.
-1. Logging levels should focus on the system itself and describe its state. As every bundle is only one out of many, logging should be done very scarce. It should be up to the user to increase the logging level for specific bundles, packages or classes if necessary. This means in detail:
- - Most logging should be done in `debug` level. `trace` can be used for even more details, where necessary.
- - Only few important things should be logged in `info` level, e.g. a newly started component or a user file that has been loaded.
- - `warn` logging should only be used to inform the user that something seems to be wrong in his overall setup, but the system can nonetheless function as normal, while possibly ignoring some faulty configuration/situation. It can also be used in situations, where a code section is reached, which is not expected by the implementation under normal circumstances (while being able to automatically recover from it).
- - `error` logging should only be used to inform the user that something is tremendously wrong in his setup, the system cannot function normally anymore, and there is a need for immediate action. It should also be used if some code fails irrecoverably and the user should report it as a severe bug.
-1. For bindings, you should NOT log errors, if e.g. connections are dropped - this is considered to be an external problem and from a system perspective to be a normal and expected situation. The correct way to inform users about such events is to update the Thing status accordingly. Note that all events (including Thing status events) are anyhow already logged.
-1. Likewise, bundles that accept external requests (such as servlets) must not log errors or warnings if incoming requests are incorrect. Instead, appropriate error responses should be returned to the caller.
+This section explains some logging usage patterns.
+The used logger allows to log to different severity levels (trace, info, debug, warn, error).
+Most of the time you want to use `warn` or `debug`. 
+Please remember that every logging statement adds to code size and runtime cost.
 
-## Static Code Analysis
+* Loggers should be [non-static](http://slf4j.org/faq.html#declared_static), when ever possible and have the name ```logger```.
+
+```java
+class MyCoolClass {
+   private final Logger logger = LoggerFactory.getLogger(MyCoolClass.class);
+}
+```
+
+* Parametrized logging must be used (instead of string concatenation).
+
+```java
+void myFun() {
+  String someValue = "abc";
+  int someInt = 12;
+  
+  logger.log("Current value is {} and int is {}", someValue, someInt);
+}
+```
+
+* Where ever exceptions are caught and logged, the exception should be added as a last parameter to the logging. 
+
+```java
+void myFun() {
+  try {
+    doSomething();
+  } catch (IOException e) {
+    logger.warn("Explain where we are in the code", e);  
+  }
+}
+```
+
+* Logging is not a replacement for using the debugger.
+
+```java
+void myFun() {
+  logger.trace("Enter myfun"); // DONT, DONT, really DONT do that
+  doSomething();
+  logger.trace("Leave myfun"); // DONT, DONT, really DONT do that
+}
+```
+
+* Logging is not a replacement to use respective `update*` methods of the framework
+
+```java
+void myFun() {
+  logger.debug("And now the thing goes online"); // DONT, DONT, really DONT do that
+  updateState(ThingState.ONLINE);
+}
+```
+
+Please keep the user informated via those `update*` methods if a connection drops etc and not abuse the logger.
+
+* `warn` logging should only be used to inform the user that something seems to be wrong in his overall setup, but the system can nonetheless function as normal, while possibly ignoring some faulty configuration/situation. It can also be used in situations, where a code section is reached, which is not expected by the implementation under normal circumstances (while being able to automatically recover from it).
+
+* `error` logging is not allowed in extensions and is purely reserved to the framework. Except if something is going really, really wrong in your extension and you are going to affect the framework stability.
+
+## Guideline details
+
+This sections provides some background and more detailed information about parts of the guideline.
+
+### Static Code Analysis
 
 The openHAB Maven build includes [tooling for static code analysis](https://github.com/openhab/static-code-analysis) that will validate your code against the Coding Guidelines and some additional best practices.
 Information about the checks can be found [here](https://github.com/openhab/static-code-analysis/blob/master/docs/included-checks.md).
@@ -80,7 +154,51 @@ Information about the checks can be found [here](https://github.com/openhab/stat
 The tool will generate an individual report for each bundle that you can find in `path/to/bundle/target/code-analysis/report.html` file and a report for the whole build that contains links to the individual reports in the `target/summary_report.html`.
 The tool categorizes the found issues by priority: 1(error),2(warning) or 3(info).
 If any error is found within your code the Maven build will end with failure.
-You will receive detailed information (path to the file, line and message) listing all problems with Priority 1 on the console.
 
-Please fix all the priority 1 issues and all issues with priority 2 and 3 that are relevant (if you have any doubt don't hesitate to ask).
-Re-run the build to confirm that the checks are passing.
+You will receive detailed information (path to the file, line and message) listing all problems with Priority 1 and 2 on the console.
+
+### Null Annotations
+
+[Null annotations](https://wiki.eclipse.org/JDT_Core/Null_Analysis) are used from the Eclipse JDT project.
+
+Those annotations help the compiler and our static code analyser to figure out if a potential null pointer access would happen in your code.
+
+Classes (except data transfer objects (DTO)) must be annotated with `@NonNullByDefault`:
+
+```java
+@NonNullByDefault
+public class MyClass(){}
+```
+
+This forces you to think about every field in your class if it can be null at any point, or should rather be default initialized. If you have fields that are neither marked as nullable, nor are initialized, the code will not compile.
+
+Fields that can be null are to be annotated like this:
+
+```java
+private @Nullable MyType myField;
+```
+
+The compiler will force you to check if `myField` is null, before using it:
+
+```java
+private void myFunction() {
+  final MyType myField = this.myField; // You need a local copy of the field for thread safety.
+  if (myField != null) {
+    myField.soSomething();
+  }
+}
+```
+
+Methods should be annotated as follows:
+
+```java
+private @Nullable MyReturnType myMethod(){};
+```
+
+If you reference an OSGi service, OSGi will already make sure that the field is non-null.
+The compiler doesn't know about that fact though. You must therefore disable null-checks for such references:
+
+```java
+@Reference
+private @NonNullByDefault({}) MyService injectedService;
+```

--- a/developers/development/guidelines.md
+++ b/developers/development/guidelines.md
@@ -50,7 +50,8 @@ public static <T> boolean isEqual(GenericsType<T> g1, GenericsType<T> g2){
 }
 ```
 
-* Code MUST not show any warnings. Warnings that cannot be circumvented should be suppressed by using the `@SuppressWarnings` annotation.
+* Code MUST not show any warnings.
+  Warnings that cannot be circumvented should be suppressed by using the `@SuppressWarnings` annotation.
 * Your classes are generally organised within an internal package
 
 ```
@@ -82,7 +83,9 @@ JavaDoc is required to describe the purpose and usage of every:
 * enumeration (except inner classes and enums),
 * constant, field and method with visibility of default, protected or public.
 
-An @author tag is required within the JavaDoc for every author who made a substantial contribution to the file. New @author tags should be placed below the older ones. Data-transfer-objects (DTOs map from Json/XML to Java classes) do not require JavaDoc.
+An @author tag is required within the JavaDoc for every author who made a substantial contribution to the file.
+New @author tags should be placed below the older ones.
+Data-transfer-objects (DTOs map from Json/XML to Java classes) do not require JavaDoc.
 
 ## D. Language Levels and Libraries
 
@@ -197,7 +200,8 @@ Classes (except data transfer objects (DTO)) must be annotated with `@NonNullByD
 public class MyClass(){}
 ```
 
-This forces you to think about every field in your class if it can be null at any point, or should rather be default initialized. If you have fields that are neither marked as nullable, nor are initialized, the code will not compile.
+This forces you to think about every field in your class if it can be null at any point, or should rather be default initialized.
+If you have fields that are neither marked as nullable, nor are initialized, the code will not compile.
 
 Fields that can be null are to be annotated like this:
 
@@ -223,7 +227,8 @@ private @Nullable MyReturnType myMethod(){};
 ```
 
 If you reference an OSGi service, OSGi will already make sure that the field is non-null.
-The compiler doesn't know about that fact though. You must therefore disable null-checks for such references:
+The compiler doesn't know about that fact though.
+You must therefore disable null-checks for such references:
 
 ```java
 @Reference


### PR DESCRIPTION
* Remove eclipse smarthome references.
* More concise
* Add examples for logging
* Merge null annotations part into this file
* Use MUST instead of SHOULD in many places, where we nowadays enforce such rules
* OSGi framework level R5

This was one big blob of text. I have added some life to it with examples and an extension directory layout etc.

The most controversial point is OSGi R5, but I think it is about to be time. We are running openHAB on R6 already and DS 1.3 is just to helpful to ignore it.

Signed-off-by: David Graeff <david.graeff@web.de>