### PR TITLE
Sitemaps: Fix links

### DIFF
--- a/configuration/sitemaps.md
+++ b/configuration/sitemaps.md
@@ -8,7 +8,7 @@ title: Sitemaps
 # Sitemaps
 
 In openHAB a collection of [Things]({{base}}/concepts/things.html) and [Items]({{base}}/concepts/items.html) represent physical or logical objects in the user's home automation setup.
-Sitemaps are used to select and prepare these elements in order to compose a user-oriented presentation of this setup for various User Interfaces (UIs), including [BasicUI]({{base}}/configuration/ui/basic.html), the [openHAB app for Android]({{base}}/apps/android.html) and others.
+Sitemaps are used to select and prepare these elements in order to compose a user-oriented presentation of this setup for various User Interfaces (UIs), including [BasicUI]({{base}}/configuration/ui/basic/), the [openHAB app for Android]({{base}}/apps/android.html) and others.
 
 This page is structured as follows:
 

--- a/configuration/sitemaps.md
+++ b/configuration/sitemaps.md
@@ -8,9 +8,7 @@ title: Sitemaps
 # Sitemaps
 
 In openHAB a collection of [Things]({{base}}/concepts/things.html) and [Items]({{base}}/concepts/items.html) represent physical or logical objects in the user's home automation setup.
-Sitemaps are used to select and prepare these elements in order to compose a user-oriented presentation of this setup for various User Interfaces (UIs),
-including [BasicUI](/configuration/ui/basic/),
-the [Android openHAB app](https://play.google.com/store/apps/details?id=org.openhab.habdroid) and others.
+Sitemaps are used to select and prepare these elements in order to compose a user-oriented presentation of this setup for various User Interfaces (UIs), including [BasicUI]({{base}}/configuration/ui/basic.html), the [openHAB app for Android]({{base}}/apps/android.html) and others.
 
 This page is structured as follows:
 


### PR DESCRIPTION
And change "openHAB Android App" to "openHAB App for Android"

> "Android", or anything confusingly similar to "Android", cannot be used in names of applications or accessory products, including phones, tablets, TVs, speakers, headphones, watches, and other devices. Instead, use "for Android".

from https://developer.android.com/distribute/marketing-tools/brand-guidelines?hl=en