### PR TITLE
Get openhab2-addons feature files from jfrog

### DIFF
--- a/process_addons.groovy
+++ b/process_addons.groovy
@@ -9,7 +9,7 @@ def collect_feature_xml = { features, xml, attrs ->
 
 def collect_features = { features ->
     collect_feature_xml(features, '.external-resources/openhab-distro/features/addons/src/main/feature/feature.xml',                  ['install': 'auto',   'since': '2x'])
-    collect_feature_xml(features, '.external-resources/openhab2-addons/features/karaf/openhab-addons/src/main/feature/feature.xml',         ['install': 'auto',   'since': '2x'])
+    collect_feature_xml(features, '.external-resources/jfrog-files/feature.xml',         ['install': 'auto',   'since': '2x'])
     collect_feature_xml(features, '.external-resources/openhab1-addons/features/openhab-addons/src/main/feature/feature.xml',         ['install': 'auto',   'since': '1x'])
     collect_feature_xml(features, '.external-resources/openhab1-addons/features/openhab-addons-legacy/src/main/feature/feature.xml',  ['install': 'legacy', 'since': '1x'])
 }

--- a/update-external-resources.sh
+++ b/update-external-resources.sh
@@ -59,6 +59,11 @@ pull_or_clone_repo "openhab-webui" "openhab/openhab-webui.git"
 echo_process "Updating submodules of the 'openhab-bundles' repo... "
 git -C "$resourcefolder/openhab-bundles" submodule update --recursive --remote --init
 
+echo_process "Fetching feature.xml file from the snapshot repository..."
+wget -r -l 1 -npdH -A '*.xml' -P "$resourcefolder/jfrog-files" "https://openhab.jfrog.io/openhab/libs-snapshot/org/openhab/distro/openhab-addons/2.5.0-SNAPSHOT/"
+# Copy the lates feature file into the finally used feature.xml
+cp `ls .external-resources/jfrog-files/openhab-addons-2.5.0-*-features.xml | sort | tail -1` .external-resources/jfrog-files/feature.xml
+
 echo_process "Running Maven Clean Plugin... "
 mvn clean
 echo_process "Running Maven Package Plugin... "


### PR DESCRIPTION
This is a hotfix for #973, which will fix the gather external docs build for now.