### PR TITLE
Change description of System started description

### DIFF
--- a/configuration/rules-dsl.md
+++ b/configuration/rules-dsl.md
@@ -183,7 +183,7 @@ Two system-based triggers are provided as described in the table below:
 
 | Trigger           | Description                                                                                                                                                                                        |
 |-------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| System started    | System started is triggered upon openHAB startup, after the rule file containing the System started trigger is modified, or after item(s) related to that rule file are modified in a .items file. |
+| System started    | System started is triggered upon openHAB startup, after the rule file containing the System started trigger is modified, or after item(s) are modified in a .items file. |
 | System shuts down | Rules using the 'System shuts down' trigger execute when openHAB shuts down.                                                                                                                       |
 
 You may wish to use the 'System started' trigger to initialize values at startup if they are not already set.


### PR DESCRIPTION
Based on the discussion at https://community.openhab.org/t/systemstart-rule-trigger-if-i-change-any-item/74542 and after performing a few tests of my own including creating a brand new .items file with an Item not used by ANY Rule I have verified that all System started Rules trigger for any change to any .items file. The "related to that rule file" part of the description is misleading and incorrect and should be removed.

Sign off by Richard Koshak: rlkoshak@gmail.com