### PR TITLE
Fix start.sh debug command

### DIFF
--- a/developers/ide/examples/vscode/tasks.json
+++ b/developers/ide/examples/vscode/tasks.json
@@ -14,7 +14,7 @@
             "label": "Start openHAB (Debug)",
             "type": "shell",
             "isBackground": true,
-            "command": "$openhab_home/start.sh",
+            "command": "$openhab_home/start.sh debug",
             "windows": {
                 "command": "& $env:openhab_home/start.bat debug"
             },


### PR DESCRIPTION
Added missing "debug" from start.sh command

Signed-off-by: Tim Roberts <troberts@bigfoot.com>