### PR TITLE
When using sendFrequency in Colorpicker, the value should not be in "…

### DIFF
--- a/configuration/sitemaps.md
+++ b/configuration/sitemaps.md
@@ -327,7 +327,7 @@ Slider item=KI_Temperature label="Kitchen"
 ### Element Type 'Colorpicker'
 
 ```perl
-Colorpicker item=<itemname> [label="<labelname>"] [icon="<iconname>"] [sendFrequency=""]
+Colorpicker item=<itemname> [label="<labelname>"] [icon="<iconname>"] [sendFrequency=<sendFrequency>]
 ```
 
 This element provides the ability to select a color.


### PR DESCRIPTION
…". If you do you will see this `warning: 2019-07-11 20:57:02.024 [WARN ] [el.core.internal.ModelRepositoryImpl] - Configuration model 'groundfloor.sitemap' has errors, therefore ignoring it: [31,91]: mismatched input '"20"' expecting RULE_INT`

Line 31 from groundfloor.sitemap:
```
Colorpicker item=cinema_led_strip_color label="Cinema LED Strip Color[]" sendFrequency="20"
```

Signed-off-by: Soren Thorsen <st@debian-linux.dk>