### PR TITLE
Update links to zulu as it seams the redirect tries to redirect to yoursite.com

### DIFF
--- a/installation/linux.md
+++ b/installation/linux.md
@@ -29,12 +29,12 @@ Train your understanding of Linux permissions at [linuxjourney.com/lesson/file-p
 
 ## Meeting the Requirements: ##
 As a first step, please verify, that your system meets the [prerequisites](index.html#prerequisites).
-You may want to install Zulu, a fully certified Java build [as a package](http://zulu.org/zuludocs-folder/Content/ZuluUserGuide/PrepareZuluPlatform/AttachAzulPackageRepositories.htm) or [manually](http://zulu.org/zuludocs-folder/Content/ZuluUserGuide/InstallingZulu/InstallLinuxUsingZuluZIPFile.htm).
+You may want to install Zulu, a fully certified Java build [as a package](https://docs.azul.com/zulu/zuludocs/#ZuluUserGuide/InstallingZulu/InstallOnLinuxUsingAPTRepository.htm) or [manually](https://docs.azul.com/zulu/zuludocs/#ZuluUserGuide/InstallingZulu/InstallLinuxUsingZuluZIPFile.htm).
 
 Alternatively, Zulu Embedded can be installed for small systems either from the same package repository as above or [manually](http://www.azul.com/downloads/zulu-embedded/).
 If you're unsure which manual file you should download, using `dpkg --print-architecture` or `rpm -q --qf '%{ARCH}\n' rpm` in your Linux terminal should point you in the right direction (e.g. armhf means ARM Hard Float).
 
-When installing Zulu or Zulu Embedded from a .zip or .tar archive, make sure to [set Zulu as the main Java "alternative"](http://zulu.org/zuludocs-folder/Content/ZuluUserGuide/SwitchingBetweenJavaAlternatives/SwitchBetweenJavaAlts.htm).
+When installing Zulu or Zulu Embedded from a .zip or .tar archive, make sure to [set Zulu as the main Java "alternative"](https://docs.azul.com/zulu/zuludocs/#ZuluUserGuide/SwitchingBetweenJavaAlternatives/SwitchBetweenJavaAlts.htm).
 
 **Note:** Make sure to download Zulu or Java **8**, as openHAB is not yet compatible with Java 9. 
 


### PR DESCRIPTION
The link:

http://zulu.org/zuludocs-folder/Content/ZuluUserGuide/PrepareZuluPlatform/AttachAzulPackageRepositories.htm

redirects as of now to

https://www.yourdomain.com/folder/zuludocs-folder/Content/ZuluUserGuide/PrepareZuluPlatform/AttachAzulPackageRepositories.htm

which is not correct, this here is the correct page:

https://docs.azul.com/zulu/zuludocs/#ZuluUserGuide/InstallingZulu/InstallOnLinuxUsingAPTRepository.htm

This PR here also updates the other links to zulu to the correct version.