### PR TITLE
Correct Apt-based stable repository url

### DIFF
--- a/installation/linux.md
+++ b/installation/linux.md
@@ -82,7 +82,7 @@ Then, you can choose between, *Official (Stable)*, *Beta* or *Snapshot* builds:
     Add the **openHAB 2 Stable Repository** to your systems apt sources list:
 
     ```shell
-    echo 'deb https://dl.bintray.com/openhab/apt-repo2 stable main' | sudo tee /etc/apt/sources.list.d/openhab2.list
+    echo 'deb https://openhab.jfrog.io/openhab/openhab-linuxpkg stable main' | sudo tee /etc/apt/sources.list.d/openhab2.list
     ```
 
 -   **Testing Release**


### PR DESCRIPTION
I am not sure if this applies also to the Yum/Dnf based links for stable or not, as I didn't investigate those.

Also, it's pretty late and I gave a quick look over the rest of the page, but nothing else jumped out. I figure an imperfect PR is better than none at all, even if I was almost too tired to do one.

This also closes https://github.com/openhab/openhab-linuxpkg/issues/150 but I didn't reference it, because it's actually in a different repository.