### PR TITLE
Corrected bad name to use hyphen (which is not allowed)

### DIFF
--- a/configuration/items.md
+++ b/configuration/items.md
@@ -322,7 +322,7 @@ The following guidelines apply to user-added icon files:
 - Hyphens (`-`) are reserved for [Dynamic Icons](#dynamic-icons) (see below)
 - Example filenames:
   - Good: `myswitch.svg`, `power_meter.png`, `error23.svg`
-  - Bad: `PC_Display.svg`, `power-meter.png`, `tür⇔.svg`
+  - Bad: `PC-Display.svg`, `power-meter.png`, `tür⇔.svg`
 
 **Bitmaps or Vector Graphics:**
 openHAB can work with either Bitmap (`png`) or Vector (`svg`) icon files.


### PR DESCRIPTION
Bad image filename was correct (with underscore) - corrected bad name to use hyphen (which is not allowed)