### PR TITLE
[ide] Moved skeleton description to overview

### DIFF
--- a/developers/ide/eclipse.md
+++ b/developers/ide/eclipse.md
@@ -22,7 +22,7 @@ This guide focuses on existing Add-on (binding) development.
 Ensure that you select the Eclipse version to use to "2019-03" as version `2019-06` currently does not support bndtools. Finally select `Next >`.
 
 1. Under `Github Projects > openHAB` select `openHAB Development` and any desired option from `openHAB Add-ons` (includes all add-ons from openhab2-addons repo), `openHAB ZigBee Binding` or `openHAB Z-Wave Binding`.
-    
+
    ![select projects](./images/ide_setup_eclipse_projects.png)
 
 1. Click `Next>`, verify/modify Root and install folder name, click `Next>` and `Finish` to start installation. 
@@ -67,34 +67,3 @@ Now the IDE is ready to start openHAB with a minimum set of the openHAB core bin
 1. You can check openHAB is running going with your browser to: http://localhost:8080/paperui/ (the last `/` is important!)
 
 1. Check the chosen binding is active in `Paper UI > Configuration > Bindings`
-
-## Develop a NEW binding with the Eclipse IDE
-
-To start developing a new binding follow these steps:
-
-1. Close Eclipse
-1. From the command line in `openhab2-addons/bundles` directory run:
-
-    `$ ./create_openhab_binding_skeleton.sh  MyNewBinding <Author> <GitHubUsername>`
-
-    to create a skeleton of a new binding `mynewbinding`.
-    Accept with `Y` the skeleton configuration.
-
-1. Edit file `openhab2-addons/bom/openhab-addons/pom.xml` and add your new binding to the list (adapt the artifactid to your binding name!):
-    ```
-    <dependency>
-        <groupId>org.openhab.addons.bundles</groupId>
-        <artifactId>org.openhab.binding.mynewbinding</artifactId>
-        <version>${project.version}</version>
-    </dependency>
-    ```
-
-1. From the `git\openhab2-addons\bom\openhab-addons` directory run: `mvn -DskipChecks -DskipTests clean install` to rebuild the list of bindings in the BOM (Bill Of Material) and make your new binding visible from the IDE launch configuration
-
-1. Open Eclipse and import your new binding project 
-
-1. Follow from previous step 7. to select and run/debug your new binding in the Eclipse IDE
-
-Now you can start developing your NEW binding.
-
-In case the new binding has dependencies to other bundles/libraries see [Adding Dependencies](../buildsystem.html#adding-dependencies) for more information.

--- a/developers/index.md
+++ b/developers/index.md
@@ -75,3 +75,53 @@ We have prepared some step-by-step guides for the following IDEs:
 </table>
 
 Not sure what to choose?: openHAB maintainers use [Eclipse IDE](https://wiki.eclipse.org/Eclipse_Installer).
+
+## Develop a NEW binding
+
+To start developing a new binding a script is available to generate the basis for your new binding.
+This script is specific for binding addons. Folllow these steps to generate your binding:
+
+1. From the command line in `openhab2-addons/bundles` directory to create a skeleton of a new binding `mynewbinding` run:
+
+   On Linux:
+    ```
+    ./create_openhab_binding_skeleton.sh  MyNewBinding "<Author>" <GitHubUsername>
+    ```
+
+   On Windows:
+    ```
+    create_openhab_binding_skeleton.cmd MyNewBinding "<Author>" <GitHubUsername>
+    ```
+
+    _Use your full name for `<Author>`_.
+
+1. Accept with `Y` when the skeleton configuration asks for it.
+
+1. From the `/openhab2-addons/bom/openhab-addons` directory run:
+   ```
+   mvn -DskipChecks -DskipTests clean install
+   ```
+   to rebuild the list of bindings in the BOM (Bill Of Material) and make your new binding visible from the IDE launch configuration
+
+1. From `openhab2-addons` root you can build your binding with maven:
+    ```
+    mvn clean install -pl :org.openhab.binding.mynewbinding
+    ```
+   Where `mynewbinding` is the name of your new binding.
+   Some additional maven options that may help:
+   * `-U`: Forces all dependencies to be downloaded again.
+   * `-am`: Builds all projects in openhab2-addons your project dependends on.
+   * `-o`: Won't update any dependencies.
+   * `-DskipChecks`: Skips the static analysis checks
+   * `skipTests`: Skips the unit tests
+
+1. To start your new binding it's a good practise to commit your code on a new git branch:
+   ```
+   git checkout -b <mynewbranch>
+   ```
+
+1. Open Eclipse or your favorite editor and import your new binding project
+
+Now you can start developing your NEW binding. We're looking forward to your pull request!
+
+In case the new binding has dependencies to other bundles/libraries see [Adding Dependencies](../buildsystem.html#adding-dependencies) for more information.


### PR DESCRIPTION
Moved the skeleton description from the eclipse page to the overview page as it's not specific for eclipse.

Signed-off-by: Hilbrand Bouwkamp <hilbrand@h72.nl>