### PR TITLE
Update prerequisites

### DIFF
--- a/installation/index.md
+++ b/installation/index.md
@@ -37,10 +37,10 @@ Please check the menu to the left for all available options.
 
 ## Prerequisites
 
-Make sure that you have an up to date Java 8 platform installed on your host system.
+Make sure that you have an up to date **Java 8** platform installed on your host system.
 Zulu is currently the recommended Java platform for openHAB.
 [Download](https://www.azul.com/downloads/zulu-community/?&architecture=x86-64-bit&package=jdk#) and [installation](https://docs.azul.com/zulu/zuludocs/ZuluUserGuide/InstallingZulu/InstallationWindowsUsingZuluMSIFile.htm) instructions can be found on Azul Systems' Zulu website.
-Oracle Java is also suitable for most configurations but licencing restrictions may apply.
+Oracle Java is also suitable for most configurations but licensing restrictions may apply.
 OpenJDK may also be used, but it has some [known limitations](https://community.openhab.org/t/running-openhab-2-on-openjdk/21443/8?u=gatekeeper6838) with openHAB and is not recommended.
 
 | Java Platform                               | Advantages                                                                                                                                                                            | Disadvantages                                                                                                                                                                                                                                                                                                                        |
@@ -49,11 +49,13 @@ OpenJDK may also be used, but it has some [known limitations](https://community.
 | [Oracle Java](https://java.com/en/)         | Full openHAB support on all platforms                                                                                                                                                 | [Licensing restrictions](https://blog.takipi.com/running-java-on-docker-youre-breaking-the-law/), manual installation required on many Linux systems: [Ubuntu](https://help.ubuntu.com/community/Java), [Mint](https://community.linuxmint.com/tutorial/view/1091), and [Debian](https://wiki.debian.org/Java/Sun) are some examples |
 | [OpenJDK](http://openjdk.java.net)          | Supported by many Linux distributions, packages [typically available](http://openjdk.java.net/install/index.html)                                                                     | [Performance issues](https://github.com/openhab/openhab-distro/issues/10#issuecomment-223786506) on ARM platforms, [compatibility issues](https://community.openhab.org/t/openhab-is-offline-message-fixed/17441/8) with certain bindings and certificates                                                                           |
 
-Please download and install the Java 8 version of the JVM. 
-openHAB is known not to work on Java 9 and Java 10.
+Please download and install the **Java 8** version of the JVM.
+openHAB does not work well with newer Java versions such as Java 9 or Java 11.
 
-Please use the **32-bit version** of the JVM for ARM platforms, even on 64-bit operating systems.
-Serial connections won't work with a 64-bit JVM, preventing bindings like Z-Wave from functioning.
+The **64-bit version** of the JVM is recommended on platforms using a 64-bit OS and an Intel or AMD processor.
+
+The **32-bit version** of the JVM is recommended on ARM platforms such as the Raspberry Pi.
+The 32-bit JVM performs better on the ARM platform and some add-ons use libraries that do not work with a 64-bit JVM on the ARM platform.
 
 For best compatibility, namely with the openHAB Cloud service [myopenhab.org](http://www.myopenhab.org) and the [Eclipse IoT Marketplace]({{base}}/configuration/eclipseiotmarket.html), the minimum recommended Java 8 revision is "161".
 Attention: Most package managers serve an **older revision**.


### PR DESCRIPTION
* Emphasize that Java 8 should be used which hopefully makes users double check their Java version
* Add recommendation for using 64-bit JVM on Intel/AMD
* Update recommendation for ARM with Raspberry Pi example so users can easier relate to it
* Update reasons for using 32-bit JVM on ARM so users don't put effort into recompiling nrjavaserial on arm64 because it already works
* Fix typo

Fixes #932

---

See also this [community thread](https://community.openhab.org/t/wrapper-dll-error-cant-load-amd-64-bit-dll-on-a-ia-32-bit-platform/84251?u=wborn).