### PR TITLE
Changed from "RPi 2 or newer" to "RPi 2 or better"

### DIFF
--- a/installation/rasppi.md
+++ b/installation/rasppi.md
@@ -17,7 +17,7 @@ These including the official [raspberrypi.org help articles](https://www.raspber
 
 Recommendations for a ["headless"](https://en.wikipedia.org/wiki/Headless_computer) hardware setup:
 
-- [Raspberry Pi 2 or newer](https://en.wikipedia.org/wiki/Raspberry_Pi#Specifications), compare your existing device [here](https://en.wikipedia.org/wiki/Raspberry_Pi#Connectors) if you are unsure.
+- [Raspberry Pi 2 or better](https://en.wikipedia.org/wiki/Raspberry_Pi#Specifications), compare your existing device [here](https://en.wikipedia.org/wiki/Raspberry_Pi#Connectors) if you are unsure.
 - SD card (16GB or more to support [wear-leveling](https://en.wikipedia.org/wiki/Wear_leveling))
 - Steady power supply
 - Ethernet connection


### PR DESCRIPTION
The RPi 0 and RPi 0W are both "newer" than the RPi 2. The important thing isn't when the RPi came out, it's the hardware specs. By saying "newer" it is a little misleading to some users.

Signed off: Richard Koshak <rlkoshak@gmail.com>

I messed up the commit and forgot to sign off, but it's only a one word change so hopefully it can sneak in.