### PR TITLE
[Sitemaps] Update switchSupport Slider parameter

### DIFF
--- a/configuration/sitemaps.md
+++ b/configuration/sitemaps.md
@@ -310,8 +310,10 @@ This type presents a value as a user-adjustable control which slides from left (
 -   `sendFrequency` is used to distinguish between long and short button presses in the classic (web) frontend.
     This parameter defines the interval in milliseconds for sending increase/decrease requests.
 
--   `switchSupport` is a parameter without an assignment (Classic UI only!).
-    If specified, a short press on the "up" or "down" button switches the item "on" or "off" (0 or 100) respectively.
+-   `switchSupport` is a parameter without an assignment
+    - Classic UI: If specified, a short press on the "up" or "down" button switches the item "on" or "off" (0 or 100) respectively.
+    - Android app: If specified, a short press on the item row (except the slider itself) switches the item "on" or "off".
+    - This has no effect in other UIs.
 
 -   `minValue` (defaults to 0) and `maxValue` (defaults to 100) limit the possible range of the value (both included in the range).
 -   `step` (defaults to 1) defines the distance between two possible/selectable datapoints on the slider.


### PR DESCRIPTION
The Android app sends `ON` or `OFF`. Depending on the binding, `ON` can stand for "latest non-zero brightness" or for `100`.

Signed-off-by: mueller-ma <mueller-ma@users.noreply.github.com>