### PR TITLE
Updated the paths to the json schemas

### DIFF
--- a/configuration/rules-ng.md
+++ b/configuration/rules-ng.md
@@ -109,9 +109,9 @@ The types in the **Configuration** object are restricted to the following:
 
 **JSON schemas for:**
 
- * [module types](../development/rules/ModuleTypes_schema.json)
- * [rule templates](../development/rules/Templates_schema.json)
- * [rule instances](../development/rules/Rules_schema.json)
+ * [module types](../../schemas/ModuleTypes_schema.json)
+ * [rule templates](../../schemas/Templates_schema.json)
+ * [rule instances](../../schemas/Rules_schema.json)
 
 ### Sample Rules
 


### PR DESCRIPTION
I believe I got the URL correct.  The root path to the schemas is https://openhab.org/schemas which is at the same level as the root `docs`. I don't know for sure that the relative path used here will work or not.

Solves #1081 

Signed-off-by: Rich Koshak <rlkoshak@gmail.com>