### PR TITLE
Add automatic pr labeling through github actions.

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,23 @@
+# Add 'priority: middle :soon::tm:' label to any file change
+"priority:: middle ::soon::::tm::":
+  - '**'
+  - '.*'
+  - '.*/**'
+
+"section:: add-ons":
+  - addons/*
+
+"section:: administration":
+  - administration/*
+
+"section:: configuration":
+  - configuration/*
+
+"section:: development":
+  - developers/*
+
+"section:: installation":
+  - installation/*
+
+"section:: tutorials":
+  - tutorials/*

--- a/.github/workflow/labeler.yml
+++ b/.github/workflow/labeler.yml
@@ -1,0 +1,14 @@
+name: Pull request labeler
+on:
+  schedule:
+    - cron: '0/15 * * * *'
+
+jobs:
+  labeler:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: paulfantom/periodic-labeler@v0.0.1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          LABEL_MAPPINGS_FILE: .github/labeler.yml


### PR DESCRIPTION
Adds automatic PR labeling through GitHub actions for our already existing section items.
Also a default priority will be set.

### Community reference
https://community.openhab.org/t/label-bot-for-github-prs/85881


@mueller-ma would be great if you would have a look at this.
I have introduced many labels including colons and have hopefully escaped them correct.