### PR TITLE
Update JSR223 docs for renamed automation package

### DIFF
--- a/configuration/jsr223-jython.md
+++ b/configuration/jsr223-jython.md
@@ -58,7 +58,7 @@ To enable debug logging, use the [Karaf logging]({{base}}/administration/logging
 enable debug logging for the automation functionality:
 
 ```text
-log:set DEBUG org.eclipse.smarthome.automation
+log:set DEBUG org.openhab.core.automation
 ```
 
 ## Script Examples
@@ -72,15 +72,15 @@ The openHAB server uses the [SLFJ](https://www.slf4j.org/) library for logging.
 ```python
 from org.slf4j import LoggerFactory
 
-LoggerFactory.getLogger("org.eclipse.smarthome.automation.examples").info("Hello world!")
+LoggerFactory.getLogger("org.openhab.core.automation.examples").info("Hello world!")
 ```
 
 Jython can [import Java classes](http://www.jython.org/jythonbook/en/1.0/ModulesPackages.html). 
 Depending on the openHAB logging configuration, 
-you may need to prefix logger names with `org.eclipse.smarthome.automation` 
+you may need to prefix logger names with `org.openhab.core.automation` 
 for them to show up in the log file (or you modify the logging configuration).
 
-> NOTE: Be careful with using wildcards when importing Java packages (e.g., `import org.sl4j.*`). 
+> NOTE: Be careful with using wildcards when importing Java packages (e.g., `import org.sl4j.*`).
 > This will work in some cases, but it might not work in some situations. 
 > It's best to use explicit imports with Java packages. 
 > For more details, see the Jython documentation on 
@@ -90,7 +90,7 @@ The script then uses the [LoggerFactory](https://www.slf4j.org/apidocs/org/slf4j
 to obtain a named logger and then logs a message like:
 
 ```text
-    ... [INFO ] [.smarthome.automation.examples:-2   ] - Hello world!
+    ... [INFO ] [.openhab.core.automation.examples:-2   ] - Hello world!
 ```
 
 Notice that no rules were required for this simple script. 

--- a/configuration/jsr223.md
+++ b/configuration/jsr223.md
@@ -13,7 +13,7 @@ title: JSR223 Scripting
 
 ## Overview
 
-[JSR223](https://docs.oracle.com/javase/6/docs/technotes/guides/scripting/) ([spec](https://jcp.org/aboutJava/communityprocess/pr/jsr223/index.html)) is a standard scripting API for Java Virtual Machine (JVM) [languages](https://en.wikipedia.org/wiki/List_of_JVM_languages). 
+[JSR223](https://docs.oracle.com/javase/8/docs/technotes/guides/scripting/) ([spec](https://jcp.org/aboutJava/communityprocess/pr/jsr223/index.html)) is a standard scripting API for Java Virtual Machine (JVM) [languages](https://en.wikipedia.org/wiki/List_of_JVM_languages). 
 The JVM languages provide varying levels of support for the JSR223 API and interoperability with the Java runtime. 
 Currently the following languages are known to work well for openHAB scripting: 
 [**Jython**](https://jython.github.io/) (Python on the JVM), 
@@ -89,8 +89,8 @@ automationManager.addRule(sRule)
 
 ::: tab Groovy
 ```groovy
-import org.eclipse.smarthome.automation.*
-import org.eclipse.smarthome.automation.module.script.rulesupport.shared.simple.*
+import org.openhab.core.automation.*
+import org.openhab.core.automation.module.script.rulesupport.shared.simple.*
 import org.eclipse.smarthome.config.core.Configuration
 
 scriptExtension.importPreset("RuleSupport")
@@ -117,12 +117,12 @@ automationManager.addRule(sRule)
 
 ### Script Locations
 
-Scripts should be placed in the `${OPENHAB_CONF}/automation/jsr223/` directory. 
+Scripts should be placed in the `${OPENHAB_CONF}/automation/jsr223/` directory.
 This directory will vary, [based on the type of openHAB installation used](https://www.openhab.org/docs/installation/linux.html#installation).
 For example, Linux installations created with a package installer will use `/etc/openhab2/automation/jsr223/`, and manual installations will use `/opt/openhab2/conf/automation/jsr223/`.
 
-When openHAB starts, scripts will be loaded in an order based on their file name. 
-If the scripts have the same name, which should rarely happen, the parent directories will be considered in the sort. 
+When openHAB starts, scripts will be loaded in an order based on their file name.
+If the scripts have the same name, which should rarely happen, the parent directories will be considered in the sort.
 For example, with the following scripts and directory structure...
 
 ```text
@@ -144,7 +144,7 @@ For example, with the following scripts and directory structure...
 ### `ScriptExtension` Objects (all JSR223 languages)
 
 To faciliate JSR223 scripting, several openHAB-related variables are automatically predefined within `ScriptExtension` presets.
-They can be loaded into the script context using `scriptExtension.importPreset(String preset)`, e.g. `scriptExtension.importPreset("RuleSimple")`. 
+They can be loaded into the script context using `scriptExtension.importPreset(String preset)`, e.g. `scriptExtension.importPreset("RuleSimple")`.
 The Default preset is preloaded, so it does not require importing.
 
 - [`Default`](#default_presets)
@@ -206,7 +206,7 @@ The Default preset is preloaded, so it does not require importing.
 | `itemRegistry` | Instance of `org.eclipse.smarthome.core.items.ItemRegistry` |
 | `ir` | Alias for `itemRegistry` |
 | `things` | Instance of `org.eclipse.smarthome.core.thing.ThingRegistry` |
-| `rules` | Instance of `org.eclipse.smarthome.automation.RuleRegistry` |
+| `rules` | Instance of `org.openhab.core.automation.RuleRegistry` |
 | `scriptExtension` | (internal) For loading script presets. |
 | `se` | Alias for `scriptExtension` |
 | `events` | (internal) Used to send events, post commands, etc. [Details](#event_operations) below] |
@@ -236,7 +236,7 @@ These variables are loaded using:
 scriptExtension.importPreset("RuleSimple")
 ```
 
-The primary usage of this preset is for defining rule (`SimpleRule`) subclasses. 
+The primary usage of this preset is for defining rule (`SimpleRule`) subclasses.
 See language-specific documentation for examples.
 
 | Variable | Description |
@@ -282,14 +282,14 @@ scriptExtension.importPreset("RuleFactories")
 
 | Variable | Description |
 |----------|-------------|
-| `ActionHandlerFactory` | `org.openhab.core.automation.module.script.rulesupport.shared.factories.ActionHandlerFactory` |
-| `ConditionHandlerFactory` | `org.openhab.core.automation.module.script.rulesupport.shared.factories.ConditionHandlerFactory` | 
-| `TriggerHandlerFactory` | `org.openhab.core.automation.module.script.rulesupport.shared.factories.TriggerHandlerFactory` | 
+| `ActionHandlerFactory` | `org.openhab.core.automation.module.script.rulesupport.shared.factories.ScriptedActionHandlerFactory` |
+| `ConditionHandlerFactory` | `org.openhab.core.automation.module.script.rulesupport.shared.factories.ScriptedConditionHandlerFactory` |
+| `TriggerHandlerFactory` | `org.openhab.core.automation.module.script.rulesupport.shared.factories.ScriptedTriggerHandlerFactory` |
 | `TriggerType` | `org.openhab.core.automation.type.TriggerType` |
-| `ConfigDescriptionParameter` | `org.eclipse.smarthome.config.core.ConfigDescriptionParameter` | 
-| `ModuleType` | `org.openhab.core.automation.type.ModuleType` | 
-| `ActionType` | `org.openhab.core.automation.type.ActionType` | 
-| `Visibility` | `org.openhab.core.automation.Visibility` enum | 
+| `ConfigDescriptionParameter` | `org.eclipse.smarthome.config.core.ConfigDescriptionParameter` |
+| `ModuleType` | `org.openhab.core.automation.type.ModuleType` |
+| `ActionType` | `org.openhab.core.automation.type.ActionType` |
+| `Visibility` | `org.openhab.core.automation.Visibility` enum |
 
 
 <a name="trigger_types"></a>


### PR DESCRIPTION
All Java classes in the `org.eclipse.smarthome.automation` package have been moved to the `org.openhab.core.automation` package.