### PR TITLE
[exec-action] Clarify the use of @@ for executeCommandLine action

### DIFF
--- a/addons/actions.md
+++ b/addons/actions.md
@@ -60,9 +60,11 @@ One can configure whether specific log entries are logged out and where they get
 - `executeCommandLine(String commandLine)`: Executes a command on the command line without waiting for the command to complete
 - `executeCommandLine(String commandLine, int timeout)`: Executes a command on the command and waits timeout milliseconds for the command to complete, returning the output from the command as a String
 
-Note: Simple arguments that contain no spaces can be separated with spaces, for example `executeCommandLine("touch file.txt")`. 
+::: tip Note
+Simple arguments that contain no spaces can be separated with spaces, for example `executeCommandLine("touch file.txt")`. 
 When one or more arguments contain spaces, use `@@` instead of a space as the argument separator.
 For example the bash command `touch -t 01010000 "some file with space.txt"` will have to be written as `touch@@-t@@01010000@@some file with space.txt`.
+:::
 
 ### HTTP Actions
 

--- a/addons/actions.md
+++ b/addons/actions.md
@@ -61,8 +61,8 @@ One can configure whether specific log entries are logged out and where they get
 - `executeCommandLine(String commandLine, int timeout)`: Executes a command on the command and waits timeout milliseconds for the command to complete, returning the output from the command as a String
 
 Note: Simple arguments that contain no spaces can be separated with spaces, for example `executeCommandLine("touch file.txt")`. 
-
-When one or more arguments contain spaces, use `@@` instead of a space as the argument separator. For example the bash command `touch -t 01010000 "some file with space.txt"` will have to be written as `touch@@-t@@01010000@@some file with space.txt`.
+When one or more arguments contain spaces, use `@@` instead of a space as the argument separator.
+For example the bash command `touch -t 01010000 "some file with space.txt"` will have to be written as `touch@@-t@@01010000@@some file with space.txt`.
 
 ### HTTP Actions
 

--- a/addons/actions.md
+++ b/addons/actions.md
@@ -60,7 +60,7 @@ One can configure whether specific log entries are logged out and where they get
 - `executeCommandLine(String commandLine)`: Executes a command on the command line without waiting for the command to complete
 - `executeCommandLine(String commandLine, int timeout)`: Executes a command on the command and waits timeout milliseconds for the command to complete, returning the output from the command as a String
 
-Note: The commandLine variable often has to use a special format where @@ needs to be used in place of spaces. For example the bash command touch somefile will have to be written as touch@@somefile.
+Note: The commandLine variable has to use `@@` instead of a space to separate the command line arguments. For example the bash command `touch "some file with space.txt"` will have to be written as `touch@@some file with space.txt`.
 
 ### HTTP Actions
 

--- a/addons/actions.md
+++ b/addons/actions.md
@@ -60,7 +60,7 @@ One can configure whether specific log entries are logged out and where they get
 - `executeCommandLine(String commandLine)`: Executes a command on the command line without waiting for the command to complete
 - `executeCommandLine(String commandLine, int timeout)`: Executes a command on the command and waits timeout milliseconds for the command to complete, returning the output from the command as a String
 
-Note: The commandLine variable has to use `@@` instead of a space to separate the command line arguments. For example the bash command `touch "some file with space.txt"` will have to be written as `touch@@some file with space.txt`.
+Note: Simple arguments that contain no spaces can be separated with spaces, for example `executeCommandLine("touch file.txt")`. When one or more arguments contain spaces, use `@@` instead of a space as the argument separator. For example the bash command `touch -t 01010000 "some file with space.txt"` will have to be written as `touch@@-t@@01010000@@some file with space.txt`.
 
 ### HTTP Actions
 

--- a/addons/actions.md
+++ b/addons/actions.md
@@ -60,7 +60,9 @@ One can configure whether specific log entries are logged out and where they get
 - `executeCommandLine(String commandLine)`: Executes a command on the command line without waiting for the command to complete
 - `executeCommandLine(String commandLine, int timeout)`: Executes a command on the command and waits timeout milliseconds for the command to complete, returning the output from the command as a String
 
-Note: Simple arguments that contain no spaces can be separated with spaces, for example `executeCommandLine("touch file.txt")`. When one or more arguments contain spaces, use `@@` instead of a space as the argument separator. For example the bash command `touch -t 01010000 "some file with space.txt"` will have to be written as `touch@@-t@@01010000@@some file with space.txt`.
+Note: Simple arguments that contain no spaces can be separated with spaces, for example `executeCommandLine("touch file.txt")`. 
+
+When one or more arguments contain spaces, use `@@` instead of a space as the argument separator. For example the bash command `touch -t 01010000 "some file with space.txt"` will have to be written as `touch@@-t@@01010000@@some file with space.txt`.
 
 ### HTTP Actions
 


### PR DESCRIPTION
The current "Note" for the Exec command line is ambiguous and confused me at first. I am submitting a suggested revision to hopefully avoid confusion.