### PR TITLE
Additional step in new binding creation

### DIFF
--- a/developers/index.md
+++ b/developers/index.md
@@ -97,6 +97,12 @@ This script is specific for binding addons. Follow these steps to generate your 
 
 1. Accept with `Y` when the skeleton configuration asks for it.
 
+1. Check the content of `openhab-addons/bundles/pom.xml` file and eventually add the following entry under `<modules>` tag, to let maven find your new binding project in the reactor:
+
+    ```
+    <module>org.openhab.binding.mynewbinding</module>
+    ```
+
 1. From `openhab2-addons` root you can build only your binding with maven using the `-pl` option:
     ```
     mvn clean install -pl :org.openhab.binding.mynewbinding


### PR DESCRIPTION
At least on Windows, this solved me the `Could not find the selected project in the reactor` issue I had at step #3, when maven building the newly created binding.