### PR TITLE
update security.md

### DIFF
--- a/installation/security.md
+++ b/installation/security.md
@@ -414,8 +414,8 @@ server {
         proxy_set_header X-Real-IP              $remote_addr;
         proxy_set_header X-Forwarded-For        $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto      $scheme;
-        proxy_set_header Upgrade $http_upgrade;
-        proxy_set_header Connection "Upgrade";
+        proxy_set_header Upgrade                $http_upgrade;
+        proxy_set_header Connection             "Upgrade";
         satisfy                                 any;
         allow                                   192.168.0.1/24;
         allow                                   127.0.0.1;

--- a/installation/security.md
+++ b/installation/security.md
@@ -414,6 +414,8 @@ server {
         proxy_set_header X-Real-IP              $remote_addr;
         proxy_set_header X-Forwarded-For        $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto      $scheme;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection "Upgrade";
         satisfy                                 any;
         allow                                   192.168.0.1/24;
         allow                                   127.0.0.1;


### PR DESCRIPTION
added some reverse proxy setting in order make websocket's working again see [NGINX as a WebSocket Proxy](https://www.nginx.com/blog/websocket-nginx/).

...
        proxy_set_header Upgrade $http_upgrade;
        proxy_set_header Connection "Upgrade";
...

After doing this - local openhab installation was able to talk to my private openhab cloud services again (docker:opehab --> internet --> myserver --> docker:nginx proxy --> docker:myopenhab-cloud-service)

Finest Regards,
Sven

Signed-off-by: Kekspackung <github.sven@kekspackung.de>