### PR TITLE
Update docs for openhab2-addons repo rename

### DIFF
--- a/.vuepress/process_file.rb
+++ b/.vuepress/process_file.rb
@@ -73,8 +73,8 @@ def process_file(indir, file, outdir, source)
                                 puts "    (add-on is from ESH)"
                                 source = "https://github.com/eclipse/smarthome/blob/master/extensions/#{addon_type}/org.eclipse.smarthome.#{addon_type}.#{addon}/README.md"
                             elsif !(file =~ /things/) then
-                                puts "    (add-on is from openhab2-addons)"
-                                source = "https://github.com/openhab/openhab2-addons/blob/master/addons/#{addon_type}/org.openhab.#{addon_type}.#{addon}/README.md"
+                                puts "    (add-on is from openhab-addons)"
+                                source = "https://github.com/openhab/openhab-addons/blob/master/addons/#{addon_type}/org.openhab.#{addon_type}.#{addon}/README.md"
                             end
 
                             out.puts "source: #{source}" if source != ""

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ You can read a bit more below about our external ressources and how we get them.
 ### Automatically Generated Parts
 
 Those parts include __all__ add-on documentation files, no matter if they are from the `openhab-core` repo, the
-`openhab1-addons` repo, the `openhab2-addons` repo or any special binding repo like *habmin*, *zwave* or the *alexa skill*.
+`openhab1-addons` repo, the `openhab-addons` repo or any special binding repo like *habmin*, *zwave* or the *alexa skill*.
 
 We are keeping all those files at their original location, because it simply doesn't make sense to keep them here.
 Imagine you want to do an improvement of the zwave binding and have to update the readme file in a completely different place.

--- a/developers/bindings/index.md
+++ b/developers/bindings/index.md
@@ -877,11 +877,11 @@ Various binding related questions are answered in our [Binding development FAQ](
 
 Once you are happy with your implementation, you need to integrate it in the Maven build and add it to the official distro.
 
-* Add a new line in the [bundle pom.xml](https://github.com/openhab/openhab2-addons/blob/master/bundles/pom.xml).
-* Add a new line in the [binding pom.xml](https://github.com/openhab/openhab2-addons/blob/master/bom/openhab-addons/pom.xml).
+* Add a new line in the [bundle pom.xml](https://github.com/openhab/openhab-addons/blob/master/bundles/pom.xml).
+* Add a new line in the [binding pom.xml](https://github.com/openhab/openhab-addons/blob/master/bom/openhab-addons/pom.xml).
 * If you have a dependency on a transport bundle (e.g. upnp, mdns or serial) or an external library,
   make sure to add a line for this dependency in the `/src/main/feature/feature.xml` file in your binding folder. See the other bindings as an example.
-* Add your binding to the [CODEOWNERS](https://github.com/openhab/openhab2-addons/blob/master/CODEOWNERS) file so that you get notified by Github when someone adds a pull request towards your binding.
+* Add your binding to the [CODEOWNERS](https://github.com/openhab/openhab-addons/blob/master/CODEOWNERS) file so that you get notified by Github when someone adds a pull request towards your binding.
 
 > Please make sure you add the above entries at their alphabetically correct position!
 

--- a/developers/contributing.md
+++ b/developers/contributing.md
@@ -12,7 +12,7 @@ title: Contribution
 The main parts of openHAB can be found in the following repositories:
 
 * [openHAB Core](https://github.com/openhab/openhab-core): This repo contains the core framework bundles of which the openHAB runtime is constructed.
-* [openHAB 2 Add-ons](https://github.com/openhab/openhab2-addons): Add-ons (such as bindings, voice services, etc.) of openHAB can be found within this repository. They cannot be used with an openHAB 1.x runtime, since they provide features that the old runtime does not support.
+* [openHAB Add-ons](https://github.com/openhab/openhab-addons): Add-ons (such as bindings, voice services, etc.) of openHAB can be found within this repository. They cannot be used with an openHAB 1.x runtime, since they provide features that the old runtime does not support.
 * [openHAB 1 Add-ons](https://github.com/openhab/openhab1-addons): Legacy add-ons that were developed for openHAB 1. Most of them are working smoothly on the openHAB 2 runtime and thus they are made available for backward compatibility reasons. They are not suggested for new users, though.
 * [openHAB Distro](https://github.com/openhab/openhab-distro): This repo contains all parts that are required for assembling the binary distribution of openHAB.
 

--- a/developers/ide/eclipse.md
+++ b/developers/ide/eclipse.md
@@ -31,7 +31,7 @@ This guide describes the steps to setup Eclipse and how to debug an add-on in Ec
 
     ![select](./images/ide_setup_eclipse_3_select_ide.png)
 
-1. Under `GitHub Projects > openHAB` select `openHAB Development` and any desired option from `openHAB Add-ons` (includes all add-ons from openhab2-addons repo), `openHAB ZigBee Binding` or `openHAB Z-Wave Binding`.
+1. Under `GitHub Projects > openHAB` select `openHAB Development` and any desired option from `openHAB Add-ons` (includes all add-ons from openhab-addons repo), `openHAB ZigBee Binding` or `openHAB Z-Wave Binding`.
 
    ![select projects](./images/ide_setup_eclipse_4_openhab.png)
 
@@ -46,12 +46,12 @@ This guide describes the steps to setup Eclipse and how to debug an add-on in Ec
     | openHAB Core Framework  | Core Framework Development            |
 
     ::: warning Attention
-    If you have selected `openHAB Add-ons` the installer will check out the [openHAB 2.x Add-ons](https://github.com/openhab/openhab2-addons/) repository and all add-on projects are imported in Eclipse.
+    If you have selected `openHAB Add-ons` the installer will check out the [openHAB 2.x Add-ons](https://github.com/openhab/openhab-addons/) repository and all add-on projects are imported in Eclipse.
 
     Select `OH2 Add-ons` and from right-click menu select "Close Projects": *this significantly speeds up the setup*.
     Re-open only the binding project(s) you would like to work on.
 
-    If you want to develop a new binding or a specific binding it is recommended to clone your own fork of [openHAB 2.x Add-ons](https://github.com/openhab/openhab2-addons/) and import only the projects you work on.
+    If you want to develop a new binding or a specific binding it is recommended to clone your own fork of [openHAB 2.x Add-ons](https://github.com/openhab/openhab-addons/) and import only the projects you work on.
     :::
 
 
@@ -77,7 +77,7 @@ This guide describes the steps to setup Eclipse and how to debug an add-on in Ec
     :::
 
     Setup tasks will personalize the IDE with openHAB code formatting tools, configurations and a demo app.
-    Setup tasks will also download openHAB latest projects you have selected during installation. Like `openhab-distro` and the add-ons `openhab2-addons` project if you have selected it.
+    Setup tasks will also download openHAB latest projects you have selected during installation. Like `openhab-distro` and the add-ons `openhab-addons` project if you have selected it.
 
     Click bottom right button in the IDE for Progress.
 

--- a/developers/ide/vscode.md
+++ b/developers/ide/vscode.md
@@ -13,7 +13,7 @@ The following steps will only need to be done once to setup both VSCode and your
 
 1. Install Java Extension Pack for VSCode (https://marketplace.visualstudio.com/items?itemName=vscjava.vscode-java-pack)
    
-2. Clone the addons (https://github.com/openhab/openhab2-addons.git or preferably your own fork) to %BASE%\openhab2-addons
+2. Clone the addons (https://github.com/openhab/openhab-addons.git or preferably your own fork) to %BASE%\openhab-addons
    
 3. If you want to setup openHAB code formatting guidelines, add the following to the VSCode settings:
          
@@ -26,17 +26,17 @@ The following steps will only need to be done once to setup both VSCode and your
 The following steps will show you how to setup a specific bundle for development with VSCode.  These steps will show how to setup the Russound bundle but are generic to any bundle in the system.
 
 1. Ensure the bundle builds correctly (natively with maven)
-   1. Open console to the bundle location (example: `%BASE%\openhab2-addons\bundles\org.openhab.binding.russound`)
+   1. Open console to the bundle location (example: `%BASE%\openhab-addons\bundles\org.openhab.binding.russound`)
    2. `mvn clean install -DskipChecks` in the console to build the bundle
-   3. Should produce a jar file in the 'target' directory of the bundle(example: `%BASE%\openhab2-addons\bundles\org.openhab.binding.russound\target\org.openhab.binding.russound-2.5.0-SNAPSHOT.jar`)
+   3. Should produce a jar file in the 'target' directory of the bundle(example: `%BASE%\openhab-addons\bundles\org.openhab.binding.russound\target\org.openhab.binding.russound-2.5.0-SNAPSHOT.jar`)
    
-2. Open VSCode and then open the folder of the bundle.  From VSCode - use `File->Open Folder->choose bundle directory` (example: `%BASE%\openhab2-addons\bundles\org.openhab.binding.russound`)
+2. Open VSCode and then open the folder of the bundle.  From VSCode - use `File->Open Folder->choose bundle directory` (example: `%BASE%\openhab-addons\bundles\org.openhab.binding.russound`)
    
-3. Create a ".vscode" directory under the bundle (example: `%BASE%\openhab2-addons\bundles\org.openhab.binding.russound\.vscode`)
+3. Create a ".vscode" directory under the bundle (example: `%BASE%\openhab-addons\bundles\org.openhab.binding.russound\.vscode`)
       
     ![define .vscode](images/ide_setup_vscode_folder.png)
 
-4. Download [tasks.json](https://raw.githubusercontent.com/openhab/openhab-docs/master/developers/ide/examples/vscode/tasks.json) to the .vscode directory (example: `%BASE%\openhab2-addons\bundles\org.openhab.binding.russound\.vscode\tasks.json`)
+4. Download [tasks.json](https://raw.githubusercontent.com/openhab/openhab-docs/master/developers/ide/examples/vscode/tasks.json) to the .vscode directory (example: `%BASE%\openhab-addons\bundles\org.openhab.binding.russound\.vscode\tasks.json`)
    
     ![define tasks.json](./images/ide_setup_vscode_folder_tasks.png)
    
@@ -53,7 +53,7 @@ The following steps will show you how to setup a specific bundle for development
 7.  Start the openHAB instance with the debug option - `start.bat debug` from a console in the openHAB home directory.  You should see the following line printed somewhere in the karaf console:
 	`Listening for transport dt_socket at address: xxxx` (where xxxx should be 5005)
 
-8.  Download [launch.json](https://raw.githubusercontent.com/openhab/openhab-docs/master/developers/ide/examples/vscode/launch.json) to the .vscode directory  (example: `%BASE%\openhab2-addons\bundles\org.openhab.binding.russound\.vscode\launch.json`)
+8.  Download [launch.json](https://raw.githubusercontent.com/openhab/openhab-docs/master/developers/ide/examples/vscode/launch.json) to the .vscode directory  (example: `%BASE%\openhab-addons\bundles\org.openhab.binding.russound\.vscode\launch.json`)
 
     ![define launch.json](./images/ide_setup_vscode_folder_launch.png)
 

--- a/developers/index.md
+++ b/developers/index.md
@@ -81,7 +81,7 @@ Not sure what to choose?: openHAB maintainers use [Eclipse IDE](https://wiki.ecl
 To start developing a new binding a script is available to generate the basis for your new binding.
 This script is specific for binding addons. Follow these steps to generate your binding:
 
-1. From the command line in `openhab2-addons/bundles` directory to create a skeleton of a new binding `mynewbinding` run:
+1. From the command line in `openhab-addons/bundles` directory to create a skeleton of a new binding `mynewbinding` run:
 
    On Linux:
     ```
@@ -97,14 +97,14 @@ This script is specific for binding addons. Follow these steps to generate your 
 
 1. Accept with `Y` when the skeleton configuration asks for it.
 
-1. From `openhab2-addons` root you can build only your binding with maven using the `-pl` option:
+1. From `openhab-addons` root you can build only your binding with maven using the `-pl` option:
     ```
     mvn clean install -pl :org.openhab.binding.mynewbinding
     ```
    Where `mynewbinding` is the name of your new binding.
    Some additional maven options that may help:
    * `-U`: Forces all dependencies to be downloaded again.
-   * `-am`: Builds all projects in openhab2-addons your project dependends on.
+   * `-am`: Builds all projects in openhab-addons your project dependends on.
    * `-o`: Won't update any dependencies.
    * `-DskipChecks`: Skips the static analysis checks
    * `-DskipTests`: Skips the unit tests

--- a/developers/legacy/ide.md
+++ b/developers/legacy/ide.md
@@ -38,9 +38,9 @@ Both are currently based on different build systems and thus require separate ID
 [![deprecated](https://badges.github.io/stability-badges/dist/deprecated.svg)](http://github.com/badges/stability-badges)
 
 Warning: The following step by step guide is only for the old build-system.
-* **A binding created via this old way will not be accepted in the official openhab2-addons repository!**
+* **A binding created via this old way will not be accepted in the official openhab-addons repository!**
 * The migration to the new build-system is a work in progress. Migrated bindings will not be accessible in the IDE.
-* We are working on a new step by step guide after the migration is done. Watch [Issue 5005](https://github.com/openhab/openhab2-addons/issues/5005) for further information and progress.
+* We are working on a new step by step guide after the migration is done. Watch [Issue 5005](https://github.com/openhab/openhab-addons/issues/5005) for further information and progress.
 
 1. Select (double-click) the "openHAB Add-on Development" item and any other entries (apart from "openHAB Core Development") that you want to have available in your workspace (you can select multiple/all of them). Click "Next" when you are finished.
 2. Now provide an installation folder (don't use spaces in the path on Windows!) and your Github id (used to push your changesets to) and select "Next".


### PR DESCRIPTION
Updates the documentation for the rename of the openhab2-addons GitHub repository to openhab-addons.