### PR TITLE
Correction of unit spellings Ampere hour

### DIFF
--- a/concepts/units-of-measurement.md
+++ b/concepts/units-of-measurement.md
@@ -133,7 +133,8 @@ SI:
 | ElectricPotential      | Volt                             | V      |
 | ElectricCapacitance    | Farad                            | F      |
 | ElectricCharge         | Coulomb                          | C      |
-| ElectricCharge         | Ampere Hour                      | A h    |
+| ElectricCharge         | Ampere Hour                      | Ah     |
+| ElectricCharge         | Milliampere Hour                 | mAh    |
 | ElectricConductance    | Siemens                          | S      |
 | ElectricConductivity   | Siemens per Metre                | S/m    |
 | ElectricCurrent        | Ampere                           | A      |


### PR DESCRIPTION
SI units are written without spaces.

Documentation updated due to:
https://github.com/openhab/openhab-core/pull/1316

Signed-off-by: Markus Schraufstetter <markus.schraufstetter@gmail.com>