### PR TITLE
Fix website build and introduce 2.5.x based docs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -153,7 +153,7 @@
               <outputDirectory>${basedir}/_addons_persistences/oh2</outputDirectory>
               <resources>
                 <resource>
-                  <directory>${basedir}/.external-resources/openhab2-addons/bundles</directory>
+                  <directory>${basedir}/.external-resources/openhab-addons/bundles</directory>
                   <includes>
                     <include>org.openhab.persistence.*/**/README.md</include>
                     <include>org.openhab.persistence.*/**/doc/**</include>
@@ -173,7 +173,7 @@
               <outputDirectory>${basedir}/_addons_bindings/oh2</outputDirectory>
               <resources>
                 <resource>
-                  <directory>${basedir}/.external-resources/openhab2-addons/addons/binding</directory>
+                  <directory>${basedir}/.external-resources/openhab-addons/addons/binding</directory>
                   <includes>
                     <include>**/README.md</include>
                     <include>**/doc/**</include>
@@ -181,7 +181,7 @@
                   </includes>
                 </resource>
                 <resource>
-                  <directory>${basedir}/.external-resources/openhab2-addons/bundles</directory>
+                  <directory>${basedir}/.external-resources/openhab-addons/bundles</directory>
                   <includes>
                     <include>org.openhab.binding.*/**/README.md</include>
                     <include>org.openhab.binding.*/**/doc/**</include>
@@ -214,7 +214,7 @@
               <outputDirectory>${basedir}/_addons_transformations/oh2</outputDirectory>
               <resources>
                 <resource>
-                  <directory>${basedir}/.external-resources/openhab2-addons/addons/transform</directory>
+                  <directory>${basedir}/.external-resources/openhab-addons/addons/transform</directory>
                   <includes>
                     <include>**/README.md</include>
                     <include>**/doc/**</include>
@@ -222,7 +222,7 @@
                   </includes>
                 </resource>
                 <resource>
-                  <directory>${basedir}/.external-resources/openhab2-addons/bundles</directory>
+                  <directory>${basedir}/.external-resources/openhab-addons/bundles</directory>
                   <includes>
                     <include>org.openhab.transform.*/**/README.md</include>
                     <include>org.openhab.transform.*/**/doc/**</include>
@@ -287,7 +287,7 @@
               <outputDirectory>${basedir}/_addons_voices/oh2</outputDirectory>
               <resources>
                 <resource>
-                  <directory>${basedir}/.external-resources/openhab2-addons/addons/voice</directory>
+                  <directory>${basedir}/.external-resources/openhab-addons/addons/voice</directory>
                   <includes>
                     <include>**/README.md</include>
                     <include>**/doc/**</include>
@@ -295,7 +295,7 @@
                   </includes>
                 </resource>
                 <resource>
-                  <directory>${basedir}/.external-resources/openhab2-addons/bundles</directory>
+                  <directory>${basedir}/.external-resources/openhab-addons/bundles</directory>
                   <includes>
                     <include>org.openhab.voice.*/**/README.md</include>
                     <include>org.openhab.voice.*/**/doc/**</include>
@@ -338,7 +338,7 @@
               <outputDirectory>${basedir}/_addons_ios/oh2</outputDirectory>
               <resources>
                 <resource>
-                  <directory>${basedir}/.external-resources/openhab2-addons/addons/io</directory>
+                  <directory>${basedir}/.external-resources/openhab-addons/addons/io</directory>
                   <includes>
                     <include>**/README.md</include>
                     <include>**/doc/**</include>
@@ -346,7 +346,7 @@
                   </includes>
                 </resource>
                 <resource>
-                  <directory>${basedir}/.external-resources/openhab2-addons/bundles</directory>
+                  <directory>${basedir}/.external-resources/openhab-addons/bundles</directory>
                   <includes>
                     <include>org.openhab.io.*/**/README.md</include>
                     <include>org.openhab.io.*/**/doc/**</include>

--- a/update-external-resources.sh
+++ b/update-external-resources.sh
@@ -40,7 +40,7 @@ pull_or_clone_repo() {
   else
     echo_process "Cloning the '$1' repo... "
     mkdir "$resourcefolder/$1"
-    git clone "https://github.com/$2" "$resourcefolder/$1"
+    git clone --branch $3 "https://github.com/$2" "$resourcefolder/$1"
   fi
 }
 

--- a/update-external-resources.sh
+++ b/update-external-resources.sh
@@ -44,17 +44,17 @@ pull_or_clone_repo() {
   fi
 }
 
-pull_or_clone_repo "smarthome" "eclipse/smarthome.git" "master"
-pull_or_clone_repo "openhab-distro" "openhab/openhab-distro.git" "2.5.x"
-pull_or_clone_repo "openhab1-addons" "openhab/openhab1-addons.git" "master"
-pull_or_clone_repo "openhab-addons" "openhab/openhab-addons.git" "2.5.x"
-pull_or_clone_repo "openhab-bundles" "openhab/openhab-bundles.git" "2.5.x"
-pull_or_clone_repo "openhabian" "openhab/openhabian.git" "master"
-pull_or_clone_repo "openhab-alexa" "openhab/openhab-alexa.git" "master"
-pull_or_clone_repo "openhab-mycroft" "openhab/openhab-mycroft.git" "master"
-pull_or_clone_repo "openhab-android" "openhab/openhab-android.git" "master"
-pull_or_clone_repo "openhab-google-assistant" "openhab/openhab-google-assistant.git" "master"
-pull_or_clone_repo "openhab-webui" "openhab/openhab-webui.git" "2.5.x"
+pull_or_clone_repo "smarthome" "eclipse/smarthome.git" master
+pull_or_clone_repo "openhab-distro" "openhab/openhab-distro.git" 2.5.x
+pull_or_clone_repo "openhab1-addons" "openhab/openhab1-addons.git" master
+pull_or_clone_repo "openhab-addons" "openhab/openhab-addons.git" 2.5.x
+pull_or_clone_repo "openhab-bundles" "openhab/openhab-bundles.git" 2.5.x
+pull_or_clone_repo "openhabian" "openhab/openhabian.git" master
+pull_or_clone_repo "openhab-alexa" "openhab/openhab-alexa.git" master
+pull_or_clone_repo "openhab-mycroft" "openhab/openhab-mycroft.git" master
+pull_or_clone_repo "openhab-android" "openhab/openhab-android.git" master
+pull_or_clone_repo "openhab-google-assistant" "openhab/openhab-google-assistant.git" master
+pull_or_clone_repo "openhab-webui" "openhab/openhab-webui.git" 2.5.x
 
 echo_process "Updating submodules of the 'openhab-bundles' repo... "
 git -C "$resourcefolder/openhab-bundles" submodule update --recursive --remote --init

--- a/update-external-resources.sh
+++ b/update-external-resources.sh
@@ -35,7 +35,7 @@ echo_process "Updating the base openhab-docs repo... (skipping)"
 pull_or_clone_repo() {
   if [ -d "$resourcefolder/$1" ]; then
     echo_process "Updating the '$1' repo... "
-    git -C "$resourcefolder/$1" checkout $3
+    git -C "$resourcefolder/$1" checkout $(echo "${3//[$'\t\r\n ']}")
     git -C "$resourcefolder/$1" pull
   else
     echo_process "Cloning the '$1' repo... "

--- a/update-external-resources.sh
+++ b/update-external-resources.sh
@@ -34,8 +34,11 @@ echo_process "Updating the base openhab-docs repo... (skipping)"
 # Parameters: $1=name, $2=GitHub project
 pull_or_clone_repo() {
   if [ -d "$resourcefolder/$1" ]; then
+    # Make sure to get all available branches in case of future script adaptions
+    git -C "$resourcefolder/$1" fetch origin -v
+
     echo_process "Updating the '$1' repo... "
-    git -C "$resourcefolder/$1" checkout $(echo "${3//[$'\t\r\n ']}")
+    git -C "$resourcefolder/$1" checkout $3
     git -C "$resourcefolder/$1" pull
   else
     echo_process "Cloning the '$1' repo... "
@@ -44,6 +47,7 @@ pull_or_clone_repo() {
   fi
 }
 
+# Pull or clone the repo with a specified branch into the given folder
 pull_or_clone_repo "smarthome" "eclipse/smarthome.git" master
 pull_or_clone_repo "openhab-distro" "openhab/openhab-distro.git" 2.5.x
 pull_or_clone_repo "openhab1-addons" "openhab/openhab1-addons.git" master
@@ -60,7 +64,7 @@ echo_process "Updating submodules of the 'openhab-bundles' repo... "
 git -C "$resourcefolder/openhab-bundles" submodule update --recursive --remote --init
 
 echo_process "Fetching feature.xml file from the snapshot repository..."
-wget -r -l 1 -npdH -A '*.xml' -P "$resourcefolder/jfrog-files" "https://openhab.jfrog.io/openhab/libs-snapshot/org/openhab/distro/openhab-addons/2.5.0-SNAPSHOT/"
+wget -r -l 1 -npdH -A '*.xml' -P "$resourcefolder/jfrog-files" "https://openhab.jfrog.io/openhab/libs-snapshot/org/openhab/distro/openhab-addons/2.5.1-SNAPSHOT/"
 # Copy the lates feature file into the finally used feature.xml
 cp `ls .external-resources/jfrog-files/openhab-addons-2.5.0-*-features.xml | sort | tail -1` .external-resources/jfrog-files/feature.xml
 

--- a/update-external-resources.sh
+++ b/update-external-resources.sh
@@ -35,7 +35,7 @@ echo_process "Updating the base openhab-docs repo... (skipping)"
 pull_or_clone_repo() {
   if [ -d "$resourcefolder/$1" ]; then
     echo_process "Updating the '$1' repo... "
-    git -C "$resourcefolder/$1" checkout master
+    git -C "$resourcefolder/$1" checkout $3
     git -C "$resourcefolder/$1" pull
   else
     echo_process "Cloning the '$1' repo... "
@@ -44,17 +44,17 @@ pull_or_clone_repo() {
   fi
 }
 
-pull_or_clone_repo "smarthome" "eclipse/smarthome.git"
-pull_or_clone_repo "openhab-distro" "openhab/openhab-distro.git"
-pull_or_clone_repo "openhab1-addons" "openhab/openhab1-addons.git"
-pull_or_clone_repo "openhab2-addons" "openhab/openhab2-addons.git"
-pull_or_clone_repo "openhab-bundles" "openhab/openhab-bundles.git"
-pull_or_clone_repo "openhabian" "openhab/openhabian.git"
-pull_or_clone_repo "openhab-alexa" "openhab/openhab-alexa.git"
-pull_or_clone_repo "openhab-mycroft" "openhab/openhab-mycroft.git"
-pull_or_clone_repo "openhab-android" "openhab/openhab-android.git"
-pull_or_clone_repo "openhab-google-assistant" "openhab/openhab-google-assistant.git"
-pull_or_clone_repo "openhab-webui" "openhab/openhab-webui.git"
+pull_or_clone_repo "smarthome" "eclipse/smarthome.git" "master"
+pull_or_clone_repo "openhab-distro" "openhab/openhab-distro.git" "2.5.x"
+pull_or_clone_repo "openhab1-addons" "openhab/openhab1-addons.git" "master"
+pull_or_clone_repo "openhab-addons" "openhab/openhab-addons.git" "2.5.x"
+pull_or_clone_repo "openhab-bundles" "openhab/openhab-bundles.git" "2.5.x"
+pull_or_clone_repo "openhabian" "openhab/openhabian.git" "master"
+pull_or_clone_repo "openhab-alexa" "openhab/openhab-alexa.git" "master"
+pull_or_clone_repo "openhab-mycroft" "openhab/openhab-mycroft.git" "master"
+pull_or_clone_repo "openhab-android" "openhab/openhab-android.git" "master"
+pull_or_clone_repo "openhab-google-assistant" "openhab/openhab-google-assistant.git" "master"
+pull_or_clone_repo "openhab-webui" "openhab/openhab-webui.git" "2.5.x"
 
 echo_process "Updating submodules of the 'openhab-bundles' repo... "
 git -C "$resourcefolder/openhab-bundles" submodule update --recursive --remote --init


### PR DESCRIPTION
This will change the fetching of external docs to a build that is based on 2.5.x branches (where available).
I have also added some small improvements to the bash script and increased the version of the pulled feature xml.

Docs will now be build based on the 2.5.1-Snapshot artifacts.

Maven Build succeeded locally already.

cc @kaikreuzer 
This should solve https://github.com/openhab/website/issues/221 too.