### PR TITLE
Remove bluetooth from Linux setup docs

### DIFF
--- a/installation/linux.md
+++ b/installation/linux.md
@@ -651,7 +651,7 @@ The need for these and the exact implementation on a specific system might diffe
 ### Privileges for Common Peripherals
 
 An openHAB setup will often rely on hardware like a modem, transceiver or adapter to interface with home automation hardware.
-Examples are a Bluetooth, Z-Wave, Enocean or RXFcom USB Stick or a Raspberry Pi add-on board connected to the serial port on its GPIOs.
+Examples are a Z-Wave, Enocean or RXFcom USB Stick or a Raspberry Pi add-on board connected to the serial port on its GPIOs.
 In order to allow openHAB to communicate with additional peripherals, it has to be added to corresponding Linux groups.
 The following example shows how to add Linux user `openhab` to the often needed groups `dialout` and `tty`.
 Additional groups may be needed, depending on your hardware and software setup.
@@ -659,7 +659,6 @@ Additional groups may be needed, depending on your hardware and software setup.
 ```shell
 sudo adduser openhab dialout
 sudo adduser openhab tty
-sudo adduser openhab bluetooth
 ```
 
 If you are looking to enable sound privileges for openHAB, it will also be necessary to add openHAB to the "audio" group.


### PR DESCRIPTION
The membership to the Bluetooth group is only necessary for the Bluez Binding, not for the BlueGiga Binding. So this step is only needed for this exact binding and for nothing else. As the Bluez Binding does only work on Linux anyway, I think this is a completely binding-specific documentation that does not have to be mentioned within the general setup.

Also, just adding the user to the bluetooth group is insufficient, more steps have to be done.

I added a more sufficient/correct documentation to the Bluez Binding docs (https://github.com/openhab/openhab-addons/pull/6475) and would suggest to remove it from the Linux setup docs.

Signed-off-by: Patrick Fink <mail@pfink.de>