### PR TITLE
Corrected and updated logging example

### DIFF
--- a/administration/logging.md
+++ b/administration/logging.md
@@ -124,8 +124,8 @@ Examples for typical logging lines found in rules:
 
 ```text
 logInfo("heating-control.rules", "Heating mode set to normal")
-logError("heating-control.rules", "Heating control failed while in mode " + Heating_Mode.state)
-logDebug("heating-control.rules", "Bedroom: Temperature: %1$.1f°C, Mode %2$s", Bedroom_Temp.state, Bedroom_Heater_Mode.state)
+logWarn("heating-control.rules", "Heating control failed while in mode {}", Heating_Mode.state)
+logDebug("heating-control.rules", "Bedroom: Temperature: {}, Mode: {}", Bedroom_Temp.state, Bedroom_Heater_Mode.state)
 ```
 
 An example output of the last log statement above is:


### PR DESCRIPTION
Removed example using the + operator for string concatenation, since we should only be recommending parameterized logging. I also removed the string formatting example, since this could cause confusion when using Items with UoM.

Signed-off-by: Scott Rushworth <openhab@5iver.com>