### PR TITLE
Added var and VA units to UoM

### DIFF
--- a/concepts/units-of-measurement.md
+++ b/concepts/units-of-measurement.md
@@ -145,6 +145,8 @@ SI:
 | Energy                 | Watt Hour                        | Wh     |
 | Energy                 | Kilowatt Hour                    | kWh    |
 | Energy                 | Megawatt Hour                    | MWh    |
+| Energy                 | Volt-Ampere Hour                 | VAh    |
+| Energy                 | Volt-Ampere Reactive Hour        | varh   |
 | Energy                 | Kilovar Hour                     | kvarh  |
 | Force                  | Newton                           | N      |
 | Frequency              | Hertz                            | Hz     |
@@ -160,6 +162,8 @@ SI:
 | Mass                   | Kilogram                         | kg     |
 | Mass                   | Gram                             | g      |
 | Power                  | Watt                             | W      |
+| Power                  | Volt-Ampere                      | VA     |
+| Power                  | Volt-Ampere Reactive             | var    |
 | Power                  | Kilovar                          | kvar   |
 | Power                  | Decibel-Milliwatts               | dBm    |
 | Pressure               | Pascal                           | Pa     |


### PR DESCRIPTION
VA (Volt-Ampere - apparent power) and var (Volt-Ampere reactive) are used to measure power and energy consumption in AC circuits.

This is the documentation for [PR #1347](https://github.com/openhab/openhab-core/pull/1347)