### PR TITLE
Ensure that UTF-8 is used as default for all text files on Windows

### DIFF
--- a/installation/windows.md
+++ b/installation/windows.md
@@ -156,6 +156,7 @@ By installing the openHAB process as a service in Windows, you can:
     wrapper.java.additional.17=-Dorg.osgi.service.http.port.secure=8443
     wrapper.java.additional.18=-Djava.util.logging.config.file="%KARAF_ETC%\java.util.logging.properties"
     wrapper.java.additional.19=-Dkaraf.logs="%OPENHAB_LOGDIR%"
+    wrapper.java.additional.20=-Dfile.encoding=UTF-8
     wrapper.java.maxmemory=512
 
     # Wrapper Logging Properties


### PR DESCRIPTION
Addition to [Ensure that UTF-8 is used as default for all text files on Windows #833](https://github.com/openhab/openhab-distro/pull/833/)

Signed-off-by: Patrik Germann <github@pgermann.de>