### PR TITLE
Update demo URL and add demo.rules URL

### DIFF
--- a/configuration/rules-dsl.md
+++ b/configuration/rules-dsl.md
@@ -22,7 +22,7 @@ On this page you will learn how to leverage its functionality to do *real* home 
 ### File Location
 
 Rules are placed in the folder `$OPENHAB_CONF/rules`.
-The [demo setup]({{base}}/tutorials/demo.html) already comes with a demo file called `demo.rules`, which has a couple of examples that can be a good starting point.
+The [demo setup](http://demo.openhab.org:8080/) already comes with a demo file called [`demo.rules`](https://github.com/openhab/openhab-distro/blob/master/features/distro-resources/src/main/resources/rules/demo.rules), which has a couple of examples that can be a good starting point.
 
 A rule file can contain multiple rules.
 All rules of a file share a common execution context, i.e. they can access and exchange variables with each other.


### PR DESCRIPTION
Based on: https://community.openhab.org/t/demo-setup-missing/94850
Old Link is broken leading to 404.
The link to the demo.rules on github is an extra :)