### PR TITLE
Update things.md

### DIFF
--- a/configuration/things.md
+++ b/configuration/things.md
@@ -123,7 +123,7 @@ The resulting UID of the thing is `hue:0210:mybridge:bulb1`.
 Bridges that are defined somewhere else can also be referenced in the DSL:
 
 ```xtend
-Thing hue:0210:mybridge:bulb (hue:bridge:mybridge) [lightId="3"]
+Thing hue:0210:mybridge:bulb "Label" (hue:bridge:mybridge) @ "Location" [lightId="3"]
 ```
 
 The referenced bridge is specified in the parentheses.


### PR DESCRIPTION
Amended example code to include using label and location when defining a Thing with a bridge that is defined elsewhere.

Signed-off-by: Justin Clark <justin@2906.co.uk>