### PR TITLE
Update sitemap.md section charts

### DIFF
--- a/configuration/sitemaps.md
+++ b/configuration/sitemaps.md
@@ -467,7 +467,7 @@ See this [Tutorial](https://community.openhab.org/t/13761/1) for more details.
 
 - When using rrd4j persistence, the strategy `everyMinute` (60 seconds) has to be used. Otherwise no data will be persisted (stored) and the chart will not be drawn properly (see [rrd4j Persistence](/addons/persistence/rrd4j)).
 - The visibility of multiple Chart objects may be toggled to simulate changing the Chart period; non-visible Chart widgets are NOT generated behind the scenes until they become visible.
-- When charting a group of item, make sure that every label is unique. If the label contains spaces, the first word of the label must be unique. Identical labels result in an empty chart.
+- When charting a group of item, make sure that every label is unique.
 
 ## Mappings
 


### PR DESCRIPTION
I observed that the unique first word in the labels of items charted in a group isn't causing an empty chart anymore. I'm on openHAB 2.5.1.

Signed-off-by: Jürgen Baginski opus42@gmx.de