### PR TITLE
tutorial: Fix description of sitemap 'type'

### DIFF
--- a/tutorials/beginner/sitemap.md
+++ b/tutorials/beginner/sitemap.md
@@ -107,10 +107,12 @@ Next comes the block with the actual items you want to show on your sitemap. Her
 The syntax is again pretty straight:
 
 ```bash
-ItemType item=ItemName label="Description of the item shown on the webpage"
+ElementType item=ItemName label="Description of the item shown on the webpage"
 ```
 
-where ItemType and ItemName must be the same as defined in default.items
+where ItemName must be the same as defined in default.items
+
+You can find a detailed overview of the different element types [here]({{base}}/configuration/configuration/sitemaps.html#element-types)
 
 One last thing to do is setting the default sitemap for the "Basic UI" via "Paper UI".
 Browse to "Configuration -> Services" in Paper UI and click the "Configure" button of Basic UI


### PR DESCRIPTION
In the tutorial, the generic sitemap description says that ItemType has to be the same as the type defined in default.items. Looking at https://www.openhab.org/docs/configuration/items.html#type and https://www.openhab.org/docs/configuration/sitemaps.html#element-types this is incorrect as they take different values. The example is even mislading as `Switch` is one of the only types which is common between items and sitemaps. Might be better to describe `Default` instead.