### PR TITLE
Make Subheadings Use Proper Subheading Syntax

### DIFF
--- a/developers/buildsystem.md
+++ b/developers/buildsystem.md
@@ -21,7 +21,7 @@ This section talks about some common buildsystem related topics and also some qu
 
 Generally all dependencies should be OSGi-bundles and available on JCenter.
 
-** External dependency **
+### External dependency
 In most cases they should be referenced in the project POM with scope `provided`:
 
 ```
@@ -48,7 +48,7 @@ If the bundle is not an OSGi-bundle, you need to wrap it and provide proper name
   <bundle dependency="true">wrap:mvn:foo.bar/baz/1.0.0$Bundle-Name=Foobar%20Baz%20Library&amp;Bundle-SymbolicName=foo.bar.baz&amp;Bundle-Version=1.0.0</bundle>
 ```
 
-** Internal dependency **
+### Internal dependency
 
 In two cases libraries can be added to the `/lib` directory:
 1. The bundle is not available for download


### PR DESCRIPTION
This way they render out as proper markdown and don't look weird on the website

Signed-off-by: Stefan Zabka <zabkaste@informatik.hu-berlin.de>