### PR TITLE
Remove unnecessary isCancelled() from code example

### DIFF
--- a/developers/bindings/index.md
+++ b/developers/bindings/index.md
@@ -725,7 +725,7 @@ The following example shows the implementation of the above mentioned methods in
     @Override
     protected void stopBackgroundDiscovery() {
         logger.debug("Stop WeMo device background discovery");
-        if (wemoDiscoveryJob != null && !wemoDiscoveryJob.isCancelled()) {
+        if (wemoDiscoveryJob != null) {
             wemoDiscoveryJob.cancel(true);
             wemoDiscoveryJob = null;
         }


### PR DESCRIPTION
Cancelling an already canceled task has no effect. IMHO this check is not necesssary and removal would simplify the code. I came to this because I saw this pattern in many bindings during reviewing.

Signed-off-by: Fabian Wolter <github@fabian-wolter.de>