### PR TITLE
Add Alexa mapping along side a channel mapping

### DIFF
--- a/concepts/items.md
+++ b/concepts/items.md
@@ -133,6 +133,11 @@ There can be metadata attached to an Item for as many namespaces as desired, lik
 
     Switch MyFan "My Fan" { homekit="Fan.v2", alexa="Fan" [ type="oscillating", speedSteps=3 ] }
 
+The metdata can be included with the channel linking, here an Alexa metadata mapping is added after the channel linking separated with a comma. An example for a ZWave switch is given below.
+```
+Switch LightSwitch "Light Switch" {channel="zwave:device:22c99d1e:node3:switch_binary", alexa="PowerController.powerState"}
+``` 
+
 The metadata can be maintained via a dedicated REST endpoint and is included in the `EnrichedItemDTO` responses.
 
 Extensions which can infer some metadata automatically need to implement and register a `MetadataProvider` service in order to make them available to the system. 

--- a/concepts/items.md
+++ b/concepts/items.md
@@ -133,7 +133,7 @@ There can be metadata attached to an Item for as many namespaces as desired, lik
 
     Switch MyFan "My Fan" { homekit="Fan.v2", alexa="Fan" [ type="oscillating", speedSteps=3 ] }
 
-The metdata can be included with the channel linking, here an Alexa metadata mapping is added after the channel linking separated with a comma. An example for a ZWave switch is given below.
+The metdata can be included with the channel linking, an Alexa metadata mapping is added after the channel linking separated with a comma in the example for a ZWave switch below.
 ```
 Switch LightSwitch "Light Switch" {channel="zwave:device:22c99d1e:node3:switch_binary", alexa="PowerController.powerState"}
 ``` 


### PR DESCRIPTION
It took me a while to find this https://community.openhab.org/t/tagging-devices-for-alexa-support/98155/3 on the Forum and its not clearly documented in the openHAB Amazon Alexa Smart Home Skill or here in Item Metadata.
I originally suggested this as an update to the openHAB Amazon Alexa Smart Home Skill documentaion, but it fits better here, then other integrations using metadata (e.g. HomeKit or Google Assistant) could refer to it as well.