### PR TITLE
Update linux.md for Samba install

### DIFF
--- a/installation/linux.md
+++ b/installation/linux.md
@@ -778,7 +778,7 @@ Make sure, the "openhab" user has ownership and/or write access to the openHAB c
 This can be accomplished by executing:
 
 ```shell
-sudo chown -hR openhab:openhab /etc/openhab2 /opt/openhab2/conf
+sudo chown -hR openhab:openhab /etc/openhab2
 ```
 
 Finally check the configuration file for correctness and restart Samba to load the new settings:


### PR DESCRIPTION
I have the openhabian (openhab v2.5.8-1) install on an RPi 4B and couldn't get network sharing working so went through this process to add Samba. At the end of it, my OPENHAB now shows up on network of my Mac. Anyway, when adding the openhab user (for Samba access) to the openhab folders, I couldn't find the /opt/openhab2/conf location. I think that the latter part of line 781 can be removed for this reason.

`[22:19:39] openhabian@openhab:/$ ls`
`bin  boot  dev  etc  home  lib  lost+found  media  mnt  opt  proc  root  run  sbin  srv  sys  tmp  usr  var`
`[22:19:39] openhabian@openhab:/$ cd opt`
`[22:19:41] openhabian@openhab:/opt$ ls`
`jdk  openhabian  openHABian-install-successful  vc`