### PR TITLE
Extend types of Thing Configuration mappings

### DIFF
--- a/developers/bindings/index.md
+++ b/developers/bindings/index.md
@@ -183,7 +183,7 @@ Moreover the configuration class has a utility method `as(Class<T> configuration
 
 All configuration values will be mapped to properties of the class.
 The type of the property must match the type of the configuration.
-Only the following types are supported for configuration values: `Boolean`, `String` and `BigDecimal`.
+The following types are supported for configuration values: `Boolean`, `boolean`, `String`, `BigDecimal`, `int`, `long`, `float` and `double`.
 
 For example, the Yahoo Weather binding allows configuration of the location and the refresh frequency.
 


### PR DESCRIPTION
Available types: https://github.com/openhab/openhab-core/blob/master/bundles/org.openhab.core.config.core/src/main/java/org/openhab/core/config/core/internal/ConfigMapper.java#L128

Signed-off-by: Fabian Wolter <github@fabian-wolter.de>