### PR TITLE
Add missing serial configuration page to sidebar

### DIFF
--- a/.vuepress/docs-sidebar.js
+++ b/.vuepress/docs-sidebar.js
@@ -100,6 +100,7 @@ module.exports = [
       'administration/bundles',
       'administration/logging',
       'administration/jsondb',
+      'administration/serial'
     ]
   },
   {


### PR DESCRIPTION
I noticed that the serial port configuration guide is missing from the sidebar.
I hope that this change is sufficient to add it there.