### PR TITLE
Added 'Number' item for possible type to use state options

### DIFF
--- a/developers/bindings/thing-xml.md
+++ b/developers/bindings/thing-xml.md
@@ -249,6 +249,9 @@ The following XML snippet shows the definition for a temperature actuator channe
 Some channels might have only a limited and countable set of states.
 These states can be specified as options.
 A `String` or `Number` item must be used as item type.
+In general `String` should be preferred with a meaningful option value.
+This prevents the user from having to guess what a value represents if a number is used as option value.
+`Number` is useful when the value represents a quantity (e.g. like in the system-wide channel type `signal-strength`).
 
 The following XML snippet defines a list of predefined state options:
 

--- a/developers/bindings/thing-xml.md
+++ b/developers/bindings/thing-xml.md
@@ -248,7 +248,7 @@ The following XML snippet shows the definition for a temperature actuator channe
 
 Some channels might have only a limited and countable set of states.
 These states can be specified as options.
-A `String` item must be used as item type.
+A `String` or `Number` item must be used as item type.
 
 The following XML snippet defines a list of predefined state options:
 


### PR DESCRIPTION
- Added 'Number' item for possible type to use state options

See https://github.com/openhab/openhab-addons/issues/8543#issuecomment-721684801

Signed-off-by: Christoph Weitkamp <github@christophweitkamp.de>