### PR TITLE
Update available script variables

### DIFF
--- a/configuration/jsr223.md
+++ b/configuration/jsr223.md
@@ -160,15 +160,13 @@ The `default` preset is preloaded, so it does not require importing.
 
 | Variable | Description |
 |----------|-------------|
-| `DateTime` | `org.joda.time.DateTime` (if Jodatime is available) |
-| `LocalTime` | `org.joda.time.LocalTime` (if Jodatime is available) |
 | `State` | `org.openhab.core.types.State` |
 | `Command` | `org.openhab.core.types.State` |
-| `StringUtils` | `org.apache.commons.lang.StringUtils` |
 | `URLEncoder` | `java.net.URLEncoder` |
-| `FileUtils` | `org.apache.commons.io.FileUtils` |
-| `FilenameUtils` | `org.apache.commons.io.FilenameUtils` |
 | `File` | `java.io.File` |
+| `Files` | `java.nio.file.Files` |
+| `Path` | `java.nio.file.Path` |
+| `Paths` | `java.nio.file.Paths` |
 | `IncreaseDecreaseType` | `org.openhab.core.library.types.IncreaseDecreaseType` |
 | `DECREASE` | `IncreaseDecreaseType` enum item |
 | `INCREASE` | `IncreaseDecreaseType` enum item |


### PR DESCRIPTION
Updates the variables based on [org.openhab.core.automation.module.script.internal.defaultscope.DefaultScriptScopeProvider](https://github.com/openhab/openhab-core/blob/090b889dbb29073c0b22d2d02db5a5630b066891/bundles/org.openhab.core.automation.module.script/src/main/java/org/openhab/core/automation/module/script/internal/defaultscope/DefaultScriptScopeProvider.java#L92-L163)

Fixes #1162

---

All other Joda-Time related updates were done in #1294