### PR TITLE
[persistence] Added 'evolutionRate', 'deviationSince' and 'varianceSince'

### DIFF
--- a/configuration/persistence.md
+++ b/configuration/persistence.md
@@ -171,20 +171,23 @@ You can easily imagine that you can implement very powerful rules using this fea
 
 Here is the full list of available persistence extensions:
 
-| Persistence Extension                   | Description                                                                                                                                                                |
-|-----------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `<item>.persist`                        | Persists the current State of the Item                                                                                                                                     |
-| `<item>.lastUpdate`                     | Queries for the last update timestamp of a given Item                                                                                                                      |
-| `<item>.historicState(AbstractInstant)` | Retrieves the State of an Item at a certain point in time (returns HistoricItem)                                                                                           |
-| `<item>.changedSince(AbstractInstant)`  | Checks if the State of the Item has (ever) changed since a certain point in time                                                                                           |
-| `<item>.updatedSince(AbstractInstant)`  | Checks if the state of the Item has been updated since a certain point in time                                                                                             |
-| `<item>.maximumSince(AbstractInstant)`  | Gets the maximum value of the State of a persisted Item since a certain point in time  (returns HistoricItem)                                                              |
-| `<item>.minimumSince(AbstractInstant)`  | Gets the minimum value of the State of a persisted Item since a certain point in time (returns HistoricItem)                                                               |
-| `<item>.averageSince(AbstractInstant)`  | Gets the average value of the State of a persisted Item since a certain point in time. This method uses a time-weighted average calculation (see example below)            |
-| `<item>.deltaSince(AbstractInstant)`    | Gets the difference in value of the State of a given Item since a certain point in time                                                                                    |
-| `<item>.previousState()`                | Gets the previous State of a persisted Item (returns HistoricItem)                                                                                                         |
-| `<item>.previousState(true)`            | Gets the previous State of a persisted Item, skips Items with equal State values and searches the first Item with State not equal the current State (returns HistoricItem) |
-| `<item>.sumSince(AbstractInstant)`      | Gets the sum of the previous States of a persisted Item since a certain point in time                                                                                      |
+| Persistence Extension                  | Description                                                                                                                                                                |
+|----------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `<item>.persist`                       | Persists the current State of the Item                                                                                                                                     |
+| `<item>.lastUpdate`                    | Queries for the last update timestamp of a given Item                                                                                                                      |
+| `<item>.historicState(ZonedDateTime)`  | Retrieves the State of an Item at a certain point in time (returns HistoricItem)                                                                                           |
+| `<item>.changedSince(ZonedDateTime)`   | Checks if the State of the Item has (ever) changed since a certain point in time                                                                                           |
+| `<item>.updatedSince(ZonedDateTime)`   | Checks if the state of the Item has been updated since a certain point in time                                                                                             |
+| `<item>.maximumSince(ZonedDateTime)`   | Gets the maximum value of the State of a persisted Item since a certain point in time (returns HistoricItem)                                                               |
+| `<item>.minimumSince(ZonedDateTime)`   | Gets the minimum value of the State of a persisted Item since a certain point in time (returns HistoricItem)                                                               |
+| `<item>.averageSince(ZonedDateTime)`   | Gets the average value of the State of a persisted Item since a certain point in time. This method uses a time-weighted average calculation (see example below)            |
+| `<item>.deltaSince(ZonedDateTime)`     | Gets the difference in value of the State of a given Item since a certain point in time                                                                                    |
+| `<item>.evolutionRate(ZonedDateTime)`  | Gets the evolution rate of the state of a given {@link Item} since a certain point in time (returns DecimalType)                                                           |
+| `<item>.deviationSince(ZonedDateTime)` | Gets the standard deviation of the state of the given Item since a certain point in time (returns DecimalType)                                                             |
+| `<item>.varianceSince(ZonedDateTime)`  | Gets the variance of the state of the given Item since a certain point in time (returns DecimalType)                                                                       |
+| `<item>.previousState()`               | Gets the previous State of a persisted Item (returns HistoricItem)                                                                                                         |
+| `<item>.previousState(true)`           | Gets the previous State of a persisted Item, skips Items with equal State values and searches the first Item with State not equal the current State (returns HistoricItem) |
+| `<item>.sumSince(ZonedDateTime)`       | Gets the sum of the previous States of a persisted Item since a certain point in time                                                                                      |
 
 These extensions use the default persistence service.
 (Refer to 'Default Persistence Service' above to configure this.)
@@ -214,19 +217,18 @@ Divide the value in Step 2 by the total weights in Step 3, to get an average of 
 
 ### Date and Time Extensions
 
-A number of date and time calculations have been made available in openHAB through incorporation of [Jodatime](http://joda-time.sourceforge.net/).
+A number of date and time calculations have been made available in openHAB through `ZonedDateTime`.
 This makes it very easy to perform actions based upon time.
 Here are some examples:
 
 ```java
 Lights.changedSince(now.minusMinutes(2).minusSeconds(30))
-Temperature.maximumSince(now.toDateMidnight)
+Temperature.maximumSince(now.truncatedTo(ChronoUnit.DAYS))
 Temperature.minimumSince(parse("2012-01-01"))
-PowerMeter.historicState(now.toDateMidnight.withDayOfMonth(1))
+PowerMeter.historicState(now.truncatedTo(ChronoUnit.DAYS).withDayOfMonth(1))
 ```
 
 The "now" variable can be used for relative time expressions, while "parse()" can define absolute dates and times.
-See the [Jodatime documentation](http://joda-time.sourceforge.net/api-release/org/joda/time/format/ISODateTimeFormat.html#dateTimeParser()) for information on accepted formats for string parsing.
 
 ## Startup Behavior
 


### PR DESCRIPTION
- Added 'evolutionRate', 'deviationSince' and 'varianceSince'
- Removed references to Joda and 'Instant'

See e.g. https://github.com/openhab/openhab-core/pull/1551

Signed-off-by: Christoph Weitkamp <github@christophweitkamp.de>