### PR TITLE
Make all openhabian docs available on the homepage.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -245,9 +245,12 @@
                 <resource>
                   <directory>${basedir}/.external-resources/openhabian/docs</directory>
                   <includes>
-                    <include>openhabian.md</include>
+                    <include>*.md</include>
                     <include>images/*.png</include>
                   </includes>
+                  <excludes>
+                    <exclude>NEWSLOG.md</exclude>
+                  </excludes>
                 </resource>
               </resources>
             </configuration>


### PR DESCRIPTION
This will make all openhabian docs available during external content gathering.

@mstormi 
I have excluded the `NEWSLOG.md` file for now.
I don't think that one is necessary for now.
`READNEWS` will get sorted out because it has no markdown ending.

What about `exim.md`?
Should it be tranferred or is it not relevant for the website?

Fixes #1201

Signed-off-by: Jerome Luckenbach <github@luckenba.ch>