### PR TITLE
VSCode tasks.json example: use tail -F instead of -f to keep tailing after OpenHAB restart.

### DIFF
--- a/developers/ide/examples/vscode/tasks.json
+++ b/developers/ide/examples/vscode/tasks.json
@@ -100,7 +100,7 @@
             "args": [
                 "-n",
                 "50",
-                "-f",
+                "-F",
                 "$openhab_logs/events.log"
             ],
             "windows": {
@@ -126,7 +126,7 @@
             "args": [
                 "-n",
                 "50",
-                "-f",
+                "-F",
                 "$openhab_logs/openhab.log"
             ],
             "windows": {


### PR DESCRIPTION
With -f you need to restart the task each time you restarted the local OpenHAB instance.