### PR TITLE
jsr223: correct pathes still pointing to OH2

### DIFF
--- a/configuration/jsr223.md
+++ b/configuration/jsr223.md
@@ -113,7 +113,7 @@ automationManager.addRule(sRule)
 
 Scripts should be placed in the `${OPENHAB_CONF}/automation/jsr223/` directory.
 This directory will vary, [based on the type of openHAB installation used](https://www.openhab.org/docs/installation/linux.html#installation).
-For example, Linux installations created with a package installer will use `/etc/openhab2/automation/jsr223/`, and manual installations will use `/opt/openhab2/conf/automation/jsr223/`.
+For example, Linux installations created with a package installer will use `/etc/openhab/automation/jsr223/`, and manual installations will use `/opt/openhab/conf/automation/jsr223/`.
 
 When openHAB starts, scripts will be loaded in an order based on their file name.
 If the scripts have the same name, which should rarely happen, the parent directories will be considered in the sort.


### PR DESCRIPTION
Signed-off-by: Michael Roßner <Schrott.Micha@web.de>