### PR TITLE
Add crypto_policy unlimited as environment variable

### DIFF
--- a/installation/docker.md
+++ b/installation/docker.md
@@ -94,6 +94,7 @@ docker run \
         -d \
         -e USER_ID=<uid> \
         -e GROUP_ID=<gid> \
+        -e CRYPTO_POLICY=unlimited \
         --restart=always \
         openhab/openhab:<version>-<distribution>
 ```
@@ -146,6 +147,7 @@ ExecStart=/usr/bin/docker run --name=%n --net=host \
   --device=/dev/ttyUSB0 \
   -e USER_ID=<uid_of_openhab> \
   -e GROUP_ID=<gid_of_openhab> \
+  -e CRYPTO_POLICY=unlimited \
   openhab/openhab:<version>-<distribution>
 ExecStop=/usr/bin/docker stop -t 2 %n ; /usr/bin/docker rm -f %n
 


### PR DESCRIPTION
Fix for integrating the Loxone binding. Ref: https://gitter.im/openhab/openhab-docker?at=5e4e52723ca8a67fb807eb87