### PR TITLE
Link to concepts section fixed.

### DIFF
--- a/tutorials/getting_started/things_simple.md
+++ b/tutorials/getting_started/things_simple.md
@@ -6,8 +6,7 @@ title:  Adding Things - Simple
 {% include base.html %}
 
 # Adding Things - Simple
-
-As covered in the [concepts section]({{base}}/docs/concepts/index.html) of the openHAB Docs, a binding is an add-on to openHAB that understands how to communicate with a specific home automation technology or API.
+As covered in the [concepts section]({{base}}/concepts/index.html) of the openHAB Docs, a binding is an add-on to openHAB that understands how to communicate with a specific home automation technology or API.
 A Thing represents a single device in openHAB.
 Each sensor (information provided by the device) or actuator (control on the device that causes it to do something) is represented by a Channel on the Thing.
 Things are the connection between openHAB and your external device or API using the binding.

--- a/tutorials/getting_started/things_simple.md
+++ b/tutorials/getting_started/things_simple.md
@@ -6,6 +6,7 @@ title:  Adding Things - Simple
 {% include base.html %}
 
 # Adding Things - Simple
+
 As covered in the [concepts section]({{base}}/concepts/index.html) of the openHAB Docs, a binding is an add-on to openHAB that understands how to communicate with a specific home automation technology or API.
 A Thing represents a single device in openHAB.
 Each sensor (information provided by the device) or actuator (control on the device that causes it to do something) is represented by a Channel on the Thing.


### PR DESCRIPTION
The {base} part of the link to 'Concepts' section seems to already include /doc in its path, thus directing the user to /docs/docs/... path (specifically https://www.openhab.org/docs/docs/concepts/index.html), whereas the proper link should be https://www.openhab.org/docs/concepts/.