### PR TITLE
Add automated markdown linting

### DIFF
--- a/.github/markdownStyle.rb
+++ b/.github/markdownStyle.rb
@@ -1,0 +1,13 @@
+all
+
+# Expect dash usage for unorderd lists
+rule 'MD004', :style => :dash
+
+# Allow long line lengths
+exclude_rule 'MD013'
+
+# Allow Multiple top level headers in the same document
+exclude_rule 'MD025'
+
+# Allow inline HTML
+exclude_rule 'MD033'

--- a/.github/workflows/markdownlint.yml
+++ b/.github/workflows/markdownlint.yml
@@ -7,10 +7,10 @@ on:
       - '2.5.x'
     tags-ignore:
       - '**'
-  pull_request:
-    branches:
-      - main
-    types: [open,synchronize,reopen]
+#  pull_request:
+#    branches:
+#      - main
+#    types: [open,synchronize,reopen]
 
 jobs:
   markdownlint:

--- a/.github/workflows/markdownlint.yml
+++ b/.github/workflows/markdownlint.yml
@@ -13,7 +13,7 @@ jobs:
     steps:
 
       - name: Check out code
-          uses: actions/checkout@v2
+        uses: actions/checkout@v2
 
       - name: Run markdownlint (mdl)
         uses: bewuethr/mdl-action@v1.0.12

--- a/.github/workflows/markdownlint.yml
+++ b/.github/workflows/markdownlint.yml
@@ -1,0 +1,4 @@
+- name: Run markdownlint (mdl)
+  uses: bewuethr/mdl-action@v1.0.12
+  with:
+  style-file: .github/markdownStyle.rb

--- a/.github/workflows/markdownlint.yml
+++ b/.github/workflows/markdownlint.yml
@@ -3,9 +3,14 @@ name: Linting
 on:
   push:
     branches:
-      - '**'
+      - 'main'
+      - '2.5.x'
     tags-ignore:
       - '**'
+  pull_request:
+    branches:
+      - main
+    types: [open,synchronize,reopen]
 
 jobs:
   markdownlint:

--- a/.github/workflows/markdownlint.yml
+++ b/.github/workflows/markdownlint.yml
@@ -9,7 +9,12 @@ on:
 
 jobs:
   markdownlint:
+    runs-on: ubuntu-latest
     steps:
+
+      - name: Check out code
+          uses: actions/checkout@v2
+
       - name: Run markdownlint (mdl)
         uses: bewuethr/mdl-action@v1.0.12
         with:

--- a/.github/workflows/markdownlint.yml
+++ b/.github/workflows/markdownlint.yml
@@ -1,4 +1,16 @@
-- name: Run markdownlint (mdl)
-  uses: bewuethr/mdl-action@v1.0.12
-  with:
-  style-file: .github/markdownStyle.rb
+name: Linting
+
+on:
+  push:
+    branches:
+      - '**'
+    tags-ignore:
+      - '**'
+
+jobs:
+  markdownlint:
+    steps:
+      - name: Run markdownlint (mdl)
+        uses: bewuethr/mdl-action@v1.0.12
+        with:
+          style-file: .github/markdownStyle.rb

--- a/styleguide.md
+++ b/styleguide.md
@@ -16,7 +16,7 @@ First and foremost we are following the recommendations given at: [https://www.c
 An ordered list:
 
 1. Some text
-2. Some more text
+1. Some more text
 
 An unordered list:
 
@@ -25,9 +25,9 @@ An unordered list:
 
 An unordered loose list (applied if bigger or with nested lists):
 
--   Some text
-    - An indented item, making the list "loose"
+- Some text
+  - An indented item, making the list "loose"
 
--   Some more text
+- Some more text
 
--   And even more text that could also strech over multiple lines
+- And even more text that could also strech over multiple lines


### PR DESCRIPTION
This will add an action that automatically checks our markdown files for errors according to our configured style.

Fixes #50
Fixes #196
