### PR TITLE
Update rasppi.md

### DIFF
--- a/installation/rasppi.md
+++ b/installation/rasppi.md
@@ -106,7 +106,7 @@ Now, to install Zulu 11, you need to download and install a tar.gz package for y
    ```
 4. Extract the archive
     ```shell
-   sudo tar -xzvf -zulu11.43.100-ca-jdk11.0.9.1-linux_aarch32hf
+   sudo tar -xzvf zulu11.43.100-ca-jdk11.0.9.1-linux_aarch32hf
    ```
 5. Install ```java``` and ```javac```
    ```shell


### PR DESCRIPTION
Removed the dash before the filename in sudo tar -xzvf -zulu11.43.100-ca-jdk11.0.9.1-linux_aarch32hf as it presumably is deprecated and leads to an error thrown when executed on raspbian stating:

tar (child): -zulu11.43.100-ca-jdk11.0.9.1-linux_aarch32hf.tar.gz: Cannot open: No such file or directory
tar (child): Error is not recoverable: exiting now
tar: Child returned status 2
tar: Error is not recoverable: exiting now