### PR TITLE
Markdown linting bulk fix

### DIFF
--- a/.github/markdownStyle.rb
+++ b/.github/markdownStyle.rb
@@ -14,3 +14,6 @@ exclude_rule 'MD025'
 
 # Allow inline HTML
 exclude_rule 'MD033'
+
+# Allow Frontmatter and exclude top level header on first line rule
+exclude_rule 'MD041'

--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -1,8 +1,7 @@
 {
     "default": true,
-    "MD004": {
-        "style": "dash"
-    },
+    "MD004": { "style": "dash" },
     "MD013": false,
-    "MD025": false
+    "MD025": false,
+    "MD029": { "style": "one" }
 }

--- a/administration/jsondb.md
+++ b/administration/jsondb.md
@@ -55,6 +55,7 @@ The JSON DB does NOT store information for manually configured _**Items, Links, 
 ## Storage Purpose
 
 JSON DB Storage can be used for:
+
 - Backup: Maintains a copy of your configurations in the `OPENHAB_USERDATA/jsondb/backup` directory
 - Troubleshooting: Allows the user to interact with the configurations that were automatically generated via the UIs
 - Advanced administration: Gives the possibility to manually define configuration parameters within the `*.json` files
@@ -69,7 +70,7 @@ The parameters for the two mechanisms may be modified in Paper UI :arrow_right: 
 
 1. _Write delay_ (defaults to 500 ms): Sets the time to wait before writing changes to disk.
 This can reduce the number of writes when many changes are being introduced within a short period, and
-2. _Maximum write delay_ (defaults to 30000 ms): Sets the maximum period the service will wait to write data in cases where changes are happening continually.
+1. _Maximum write delay_ (defaults to 30000 ms): Sets the maximum period the service will wait to write data in cases where changes are happening continually.
 
 The service keeps up to five backups of each table.
 The outdated file is copied to the backup folder and then that file is overwritten with the new content.
@@ -78,6 +79,7 @@ The outdated file is copied to the backup folder and then that file is overwritt
 
 The JsonDB Storage resides in the `OPENHAB_USERDATA/jsondb/` directory.
 The full directory path depends on the installation method:
+
 - Linux Repository Installation: `/var/lib/openhab/jsondb/`
 - Linux Manual Installation: `/opt/openhab/userdata/jsondb/`
 - Windows (Manual) Installation: `C:\openHAB\userdata\jsondb\`
@@ -92,7 +94,6 @@ Within the `OPENHAB_USERDATA/jsondb/` directory, you will find the following fil
 | org.openhab.core.thing.link.**ItemThingLink.json**    | _Item to Thing Link configurations_   |
 | org.openhab.core.thing.**Thing.json**                 | _Things configurations_               |
 
-
 ## Example Use
 
 In this example, we will use the Network Binding (2.0) to Search for Things, add a new Thing to openHAB and then modify its parameters to check the information that is stored in the JsonDB.
@@ -103,7 +104,7 @@ Step 1. Add new Thing (name: `ISP_Gateway`) from UI:
 
 Step 2. Check the contents of the `OPENHAB_USERDATA/jsondb/org.openhab.core.thing.Thing.json` file:
 
-```
+```json
 root@rpi3:~# more /var/lib/openhab/jsondb/org.openhab.core.thing.Thing.json
 {
   "network:device:172_16_13_254": {
@@ -189,6 +190,7 @@ root@rpi3:~# more /var/lib/openhab/jsondb/org.openhab.core.thing.Thing.json
 ```
 
 Step 3. Using Paper UI :arrow_right: Configuration :arrow_right: Things, edit the new `ISP_Gateway` Thing and modify the following parameters:
+
 - Location (from unset to `MyHome`)
 - Retry (from 1 to 3)
 - Timeout (from 5000 to 10000)

--- a/administration/jsondb.md
+++ b/administration/jsondb.md
@@ -46,7 +46,7 @@ openHAB stores configuration information in JSON (JavaScript Object Notation) fo
 
 ## Storage Scope
 
-All configuration information regarding _**Items, Links, and Things**_ are defined via the User Interfaces (Paper UI, HABmin, REST) or via internal openHAB services.
+All configuration information regarding _**Items, Links, and Things**_ are defined via the User Interfaces (UI, REST) or via internal openHAB services.
 
 ::: tip Note
 The JSON DB does NOT store information for manually configured _**Items, Links, or Things**_, since these are already stored in files within the `OPENHAB_CONF` sub-directories (e.g. `/etc/openhab/items/`).
@@ -66,7 +66,7 @@ openHAB writes the `*.json` files every time a change is made via the User Inter
 openHAB _**reads the `*.json` files only once at startup**_.  So, if you edit them manually, you should restart openHAB.
 
 The system employs two write mechanisms to improve performance where there are multiple writes in a short time. When the service is closed, all open services are written to disk.
-The parameters for the two mechanisms may be modified in Paper UI :arrow_right: Configuration :arrow_right: System :arrow_right: Json Storage
+The parameters for the two mechanisms may be modified in UI :arrow_right: Settings :arrow_right: Json Storage
 
 1. _Write delay_ (defaults to 500 ms): Sets the time to wait before writing changes to disk.
 This can reduce the number of writes when many changes are being introduced within a short period, and
@@ -88,7 +88,7 @@ Within the `OPENHAB_USERDATA/jsondb/` directory, you will find the following fil
 
 | Filename                                                        | _Contents_                            |
 |-----------------------------------------------------------------|---------------------------------------|
-| org.openhab.config.discovery.**DiscoveryResult.json** | _Results of Paper UI Discovery_       |
+| org.openhab.config.discovery.**DiscoveryResult.json** | _Results of UI Discovery_       |
 | org.openhab.core.items.**Item.json**                  | _Items configurations_                |
 | org.openhab.core.thing.link.**ItemChannelLink.json**  | _Item to Channel Link configurations_ |
 | org.openhab.core.thing.link.**ItemThingLink.json**    | _Item to Thing Link configurations_   |
@@ -189,7 +189,7 @@ root@rpi3:~# more /var/lib/openhab/jsondb/org.openhab.core.thing.Thing.json
 }
 ```
 
-Step 3. Using Paper UI :arrow_right: Configuration :arrow_right: Things, edit the new `ISP_Gateway` Thing and modify the following parameters:
+Step 3. Using UI :arrow_right: Settings :arrow_right: Things, edit the new `ISP_Gateway` Thing and modify the following parameters:
 
 - Location (from unset to `MyHome`)
 - Retry (from 1 to 3)

--- a/administration/logging.md
+++ b/administration/logging.md
@@ -13,7 +13,7 @@ This includes how to access logging information and configure logging for user-d
 There are two ways to check log entries:
 
 1. Through files stored on the **file system**
-2. During runtime in the **Karaf Console**
+1. During runtime in the **Karaf Console**
 
 ## Filesystem
 
@@ -41,7 +41,7 @@ The log shell provides the following commands:
 
 For example, the following command enables real-time monitoring of the default log:
 
-```
+```shell
 openhab> log:tail
 20:38:00.031 [DEBUG] [sistence.rrd4j.internal.RRD4jService] - Stored 'Temperature_FF_Child' with state '19.1' in rrd4j database
 20:38:00.032 [DEBUG] [sistence.rrd4j.internal.RRD4jService] - Stored 'Temperature_FF_Bed' with state '19.5' in rrd4j database
@@ -51,7 +51,7 @@ openhab> log:tail
 
 A useful feature is that filters can be applied:
 
-```
+```shell
 openhab> log:tail org.openhab.io.rest.core.item.ItemResource
 20:36:52.879 [DEBUG] [thome.io.rest.core.item.ItemResource] - Received HTTP POST request at 'items/Light_FF_Bath_Ceiling' with value 'ON'.
 20:36:53.545 [DEBUG] [thome.io.rest.core.item.ItemResource] - Received HTTP POST request at 'items/Light_FF_Bath_Ceiling' with value 'OFF'.
@@ -98,10 +98,13 @@ The levels build a hierarchy with **ERROR** logging critical messages only and *
 Setting the log level to **DEFAULT** will log to the level defined in the package.subpackage (in most cases a binding).
 
 If the name of `package.subpackage` is not known, the name can be found out in the console:
+
 ```text
 list -s
 ```
+
 returns a list of all modules and the last column contains the information about the symbolic name of the bundle:
+
 ```text
 openhab> list -s
 START LEVEL 100 , List Threshold: 50
@@ -115,8 +118,10 @@ START LEVEL 100 , List Threshold: 50
  24 │ Active │  80 │ 3.0.0.v201312141243     │ com.google.inject
 
 ```
+
 The list can be also filtered with grep. To find out the Z-Wave binding the following command can be used
-```Text
+
+```shell
 openhab> list -s | grep zwave
 253 x Active x  80 x 2.5.5                   x org.openhab.binding.zwave
 
@@ -124,7 +129,7 @@ openhab> list -s | grep zwave
 
 The following example sets the logging for the Z-Wave binding to **DEBUG**
 
-```text
+```shell
 log:set DEBUG org.openhab.binding.zwave
 ```
 
@@ -153,13 +158,14 @@ For example you can use `log:set info org.openhab.core.model.script` and `log:se
 
 An example output of the last log statement above is:
 
-```
+```shell
 2016-06-04 16:28:39.482 [DEBUG] [org.openhab.core.model.script.heating] Bedroom: Temperature 21.3°C, Mode NORMAL
 ```
 
 Note that, in the last example above, inclusion and formatting of values is done using [Java Formatter String Syntax](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/util/Formatter.html).
 
 ## Log4j configuration and logging into separate files
+
 By default, all log entries are saved in the file `openhab.log` and event-specific entries are saved in `events.log`.
 Additional log files can be defined in order to write specifics logs to a separate place.
 

--- a/concepts/items.md
+++ b/concepts/items.md
@@ -11,7 +11,7 @@ openHAB has a strict separation between the physical world (the "Things", see be
 
 Items represent functionality that is used by the application (mainly user interfaces or automation logic).
 Items have a state and are used through events.
-  
+
 The following Item types are currently available (alphabetical order):
 
 | Item Name          | Description                                                        | Command Types                              |
@@ -38,11 +38,12 @@ Cyclic membership is not forbidden but strongly not recommended.
 User interfaces might display Group Items as single entries and provide navigation to its members.
 
 Example for a Group Item as a simple collection of other Items:
-```
+
+```shell
     Group groundFloor
     Switch kitchenLight (groundFloor)
     Switch livingroomLight (groundFloor)
-``` 
+```
 
 ### Derive Group State from Member Items
 
@@ -64,10 +65,10 @@ For available Group functions and examples see [Configuration Guide](../configur
 `DateTimeType` objects are parsed using Java's `SimpleDateFormat.parse()` using the first matching pattern:
 
 1. `yyyy-MM-dd'T'HH:mm:ss.SSSZ`
-2. `yyyy-MM-dd'T'HH:mm:ss.SSSz`
-3. `yyyy-MM-dd'T'HH:mm:ss.SSSX`
-4. `yyyy-MM-dd'T'HH:mm:ssz`
-5. `yyyy-MM-dd'T'HH:mm:ss`
+1. `yyyy-MM-dd'T'HH:mm:ss.SSSz`
+1. `yyyy-MM-dd'T'HH:mm:ss.SSSX`
+1. `yyyy-MM-dd'T'HH:mm:ssz`
+1. `yyyy-MM-dd'T'HH:mm:ss`
 
 | Literal | Standard           | Example                               |
 |---------|--------------------|---------------------------------------|
@@ -124,25 +125,26 @@ Here is a short table demonstrating conversions for the examples above:
 
 ## Item Metadata
 
-Sometimes additional information is required to be attached to Items for certain use-cases. 
+Sometimes additional information is required to be attached to Items for certain use-cases.
 This could be an application which needs some hints in order to render the Items in a generic way, or an integration with voice controlled assistants, or any other services which access the Items and need to understand their "meaning".
 
-Such metadata can be attached to Items using disjunct namespaces so they won't conflict with each other. 
-Each metadata entry has a main value and optionally additional key/value pairs. 
-There can be metadata attached to an Item for as many namespaces as desired, like in the following example: 
+Such metadata can be attached to Items using disjunct namespaces so they won't conflict with each other.
+Each metadata entry has a main value and optionally additional key/value pairs.
+There can be metadata attached to an Item for as many namespaces as desired, like in the following example:
 
-    Switch MyFan "My Fan" { homekit="Fan.v2", alexa="Fan" [ type="oscillating", speedSteps=3 ] }
+Switch MyFan "My Fan" { homekit="Fan.v2", alexa="Fan" [ type="oscillating", speedSteps=3 ] }
 
 The metdata can be included with the channel linking, an Alexa metadata mapping is added after the channel linking separated with a comma in the example for a ZWave switch below.
-```
+
+```shell
 Switch LightSwitch "Light Switch" {channel="zwave:device:22c99d1e:node3:switch_binary", alexa="PowerController.powerState"}
-``` 
+```
 
 The metadata can be maintained via a dedicated REST endpoint and is included in the `EnrichedItemDTO` responses.
 
-Extensions which can infer some metadata automatically need to implement and register a `MetadataProvider` service in order to make them available to the system. 
-They may provision them from any source they like and also dynamically remove or add data. 
+Extensions which can infer some metadata automatically need to implement and register a `MetadataProvider` service in order to make them available to the system.
+They may provision them from any source they like and also dynamically remove or add data.
 They are also not restricted to a single namespace.
 
-The `MetadataRegistry` provides access for all extensions which need to read the Item metadata programmatically. 
+The `MetadataRegistry` provides access for all extensions which need to read the Item metadata programmatically.
 It is the central place where additional information about Items is kept.

--- a/developers/ide/vscode.md
+++ b/developers/ide/vscode.md
@@ -16,7 +16,8 @@ The following steps will only need to be done once to setup both VSCode and your
 1. Clone the addons (<https://github.com/openhab/openhab-addons.git> or preferably your own fork) to %BASE%\openhab-addons
 
 1. On Windows, VSCode should be configured to use powershell instead of the classic command line.
-If not configured already, add the following to the VSCode settings:
+
+    If not configured already, add the following to the VSCode settings:
 
      ```"terminal.integrated.automationShell.windows": "C:\\Windows\\sysnative\\WindowsPowerShell\\v1.0\\powershell.exe"```
 
@@ -36,77 +37,77 @@ The following steps will show you how to setup a specific bundle for development
 
 1. Ensure the bundle builds correctly (natively with maven)
    1. Open console to the bundle location (example: `%BASE%\openhab-addons\bundles\org.openhab.binding.russound`)
-   2. `mvn clean install -DskipChecks` in the console to build the bundle
-   3. Should produce a jar file in the 'target' directory of the bundle(example: `%BASE%\openhab-addons\bundles\org.openhab.binding.russound\target\org.openhab.binding.russound-2.5.0-SNAPSHOT.jar`)
+   1. `mvn clean install -DskipChecks` in the console to build the bundle
+   1. Should produce a jar file in the 'target' directory of the bundle(example: `%BASE%\openhab-addons\bundles\org.openhab.binding.russound\target\org.openhab.binding.russound-2.5.0-SNAPSHOT.jar`)
 
-2. Open VSCode and then open the folder of the bundle.  From VSCode - use `File->Open Folder->choose bundle directory` (example: `%BASE%\openhab-addons\bundles\org.openhab.binding.russound`)
+1. Open VSCode and then open the folder of the bundle.  From VSCode - use `File->Open Folder->choose bundle directory` (example: `%BASE%\openhab-addons\bundles\org.openhab.binding.russound`)
 
-3. Create a ".vscode" directory under the bundle (example: `%BASE%\openhab-addons\bundles\org.openhab.binding.russound\.vscode`)
+1. Create a ".vscode" directory under the bundle (example: `%BASE%\openhab-addons\bundles\org.openhab.binding.russound\.vscode`)
 
     ![define .vscode](images/ide_setup_vscode_folder.png)
 
-4. Download [tasks.json](https://raw.githubusercontent.com/openhab/openhab-docs/master/developers/ide/examples/vscode/tasks.json) to the .vscode directory (example: `%BASE%\openhab-addons\bundles\org.openhab.binding.russound\.vscode\tasks.json`)
+1. Download [tasks.json](https://raw.githubusercontent.com/openhab/openhab-docs/master/developers/ide/examples/vscode/tasks.json) to the .vscode directory (example: `%BASE%\openhab-addons\bundles\org.openhab.binding.russound\.vscode\tasks.json`)
 
     ![define tasks.json](./images/ide_setup_vscode_folder_tasks.png)
 
-5. Edit tasks.json and ...
+1. Edit tasks.json and ...
 
     ![tasks.json changes](./images/ide_setup_vscode_tasks.png)
 
    1. Set `openhab_*` to the directories for your openHAB installation
-   2. Set `dist` to the name of the JAR file maven is producing in the target directory
-   3. Save and close tasks.json
+   1. Set `dist` to the name of the JAR file maven is producing in the target directory
+   1. Save and close tasks.json
 
-6. Stop any openHAB instance (if it's running).
+1. Stop any openHAB instance (if it's running).
 
-7. Start the openHAB instance with the debug option - `start.bat debug` from a console in the openHAB home directory.  You should see the following line printed somewhere in the karaf console:
+1. Start the openHAB instance with the debug option - `start.bat debug` from a console in the openHAB home directory.  You should see the following line printed somewhere in the karaf console:
  `Listening for transport dt_socket at address: xxxx` (where xxxx should be 5005)
 
-8. Download [launch.json](https://raw.githubusercontent.com/openhab/openhab-docs/master/developers/ide/examples/vscode/launch.json) to the .vscode directory  (example: `%BASE%\openhab-addons\bundles\org.openhab.binding.russound\.vscode\launch.json`)
+1. Download [launch.json](https://raw.githubusercontent.com/openhab/openhab-docs/master/developers/ide/examples/vscode/launch.json) to the .vscode directory  (example: `%BASE%\openhab-addons\bundles\org.openhab.binding.russound\.vscode\launch.json`)
 
     ![define launch.json](./images/ide_setup_vscode_folder_launch.png)
 
-9. Edit launch.json and ...
+1. Edit launch.json and ...
 
     ![launch.json changes](./images/ide_setup_vscode_launch.png)
 
     1. Set the `port` to xxxx (from step 7).  This can be skipped if xxxx was 5005 from step 7.
-    2. Set the `hostName` to the hostname running openHAB.  This can be skipped if running locally (localhost)
-    3. Save and close launch.json
+    1. Set the `hostName` to the hostname running openHAB.  This can be skipped if running locally (localhost)
+    1. Save and close launch.json
 
-10. Verify that VSCode can build the system and connect to a debug instance of openHAB:
+1. Verify that VSCode can build the system and connect to a debug instance of openHAB:
 
     1. Shutdown any instances of openHAB
-    2. Press `CTRL-SHIFT-P -> Tasks: Run Task -> Start openHAB (Debug)` to start an openHAB instance in debug mode.  You should see openHAB startup in a new VSCode terminal.
-    3. Press F5 (or bring up debug in VSCode and choose the "Debug (Attach) - openHAB" configuration) and the following should occur in the VSCode terminal
+    1. Press `CTRL-SHIFT-P -> Tasks: Run Task -> Start openHAB (Debug)` to start an openHAB instance in debug mode.  You should see openHAB startup in a new VSCode terminal.
+    1. Press F5 (or bring up debug in VSCode and choose the "Debug (Attach) - openHAB" configuration) and the following should occur in the VSCode terminal
 
         1. The maven compile occuring (successfully)
-        2. The resulting JAR is copied to the openHAB addons directory (`openhab_addons`)
-        3. Connecting to the openHAB instance (the debug call stack should show a bunch of openHAB type threads running)
+        1. The resulting JAR is copied to the openHAB addons directory (`openhab_addons`)
+        1. Connecting to the openHAB instance (the debug call stack should show a bunch of openHAB type threads running)
 
 You can now make changes, set breakpoints, etc.
 
 ## Notes
 
 1. May take openHAB a few seconds to realize there is a new bundle and to reinitilize it after it's been copied.  Be a little bit patient.
-2. You must run the `mvn Compile (Online)` task atleast once to allow the offline compile to occur.  You should use the `mvn Compile (Offline)` task for most of your development as it's quicker since it uses the cache files.  When you are ready to commit (or release a test bundle) - you should run the `mvn Compile (Release)` task to include code checks (and resolve them).
-3. Win10+ allows forward slashes as part of its path.  If you use backward slashes instead - you will need to double up on them since tasks.json uses a backward slash as a delimiter.  Example: `c:\\\\openhab`
+1. You must run the `mvn Compile (Online)` task atleast once to allow the offline compile to occur.  You should use the `mvn Compile (Offline)` task for most of your development as it's quicker since it uses the cache files.  When you are ready to commit (or release a test bundle) - you should run the `mvn Compile (Release)` task to include code checks (and resolve them).
+1. Win10+ allows forward slashes as part of its path.  If you use backward slashes instead - you will need to double up on them since tasks.json uses a backward slash as a delimiter.  Example: `c:\\\\openhab`
 
 ## Tasks
 
 The [tasks.json](examples/vscode/tasks.json) defines the following tasks that you may use withing VSCode (`CTRL-SHIFT-P > Tasks: Run Task`):
 
 1. **Start openHAB (Debug)** - this task will start a new instance of openHAB in debug mode (allowing VSCode to connect to it).  Please shut down any other instances of openHAB prior to running this (see next task).  This will open a **new** terminal for openHAB to run in.  Formally, this will call `start.bat debug` (or `start.sh debug` on osx/linux) in the `openhab_home` directory.
-2. **Stop openHAB** - this task will stop any running instance.  Please note this will stop an instance started outside of VSCode as well on the same machine.  Formally, this will call `stop.bat` (or `stop.sh` on osx/linux) in the `openhab_runtime/bin` directory.
-3. **mvn Compile (Online)** - this task will run a online maven compile skipping code checks.  Formally, will run `mvn clean install -DskipChecks`
-4. **mvn Compile (Offline)** - this task will run a offline maven compile skipping code checks (assumes you have run a online compile atleast once).  Formally, will run `mvn -o clean install -DskipChecks`
-5. **mvn Compile (Release)** - this task will run a online maven compile with code checks.  Formally, will run `mvn clean install`
-6. **Copy Distribution to Addons** - this task will run the 'mvn Compile (Offline)' task and then copy the resulting target file (as defined by `dist`) to your openHAB addons directory (defined by `openhab_addons`)
-7. **Build** - this is an alias for `Copy Distribution to Addons` task.
-8. **Tail events.log** - this will tail the events.log in a new terminal.
-9. **Tail openhab.log** - this will tail the openhab.log in a new terminal.
+1. **Stop openHAB** - this task will stop any running instance.  Please note this will stop an instance started outside of VSCode as well on the same machine.  Formally, this will call `stop.bat` (or `stop.sh` on osx/linux) in the `openhab_runtime/bin` directory.
+1. **mvn Compile (Online)** - this task will run a online maven compile skipping code checks.  Formally, will run `mvn clean install -DskipChecks`
+1. **mvn Compile (Offline)** - this task will run a offline maven compile skipping code checks (assumes you have run a online compile atleast once).  Formally, will run `mvn -o clean install -DskipChecks`
+1. **mvn Compile (Release)** - this task will run a online maven compile with code checks.  Formally, will run `mvn clean install`
+1. **Copy Distribution to Addons** - this task will run the 'mvn Compile (Offline)' task and then copy the resulting target file (as defined by `dist`) to your openHAB addons directory (defined by `openhab_addons`)
+1. **Build** - this is an alias for `Copy Distribution to Addons` task.
+1. **Tail events.log** - this will tail the events.log in a new terminal.
+1. **Tail openhab.log** - this will tail the openhab.log in a new terminal.
 
 ## Additional References
 
 1. [VSCode with Java](https://code.visualstudio.com/docs/languages/java)
-2. [VSCode with Java debugging](https://code.visualstudio.com/docs/java/java-debugging)
+1. [VSCode with Java debugging](https://code.visualstudio.com/docs/java/java-debugging)

--- a/installation/index.md
+++ b/installation/index.md
@@ -79,7 +79,7 @@ Before you can start, two decisions have to be made:
     - **Package setup:** Install from a package repository, using a package manager such as apt or yum.
     This option is only available for certain Linux distributions such as Debian or Ubuntu derivatives, but allows you to take advantage of automatic updates and is the recommended choice: [Linux (apt/deb)](linux.html#package-repository-installation)
 
-2. Stable release or cutting edge:
+1. Stable release or cutting edge:
     - **Stable:** Use the latest official release [hosted on Bintray](https://bintray.com/openhab/mvn/openhab-distro) (recommended for new users).
     - **Snapshot:** Benefit from the latest changes in the daily created snapshot ([hosted on openhab.org](https://ci.openhab.org/)).
 
@@ -95,8 +95,8 @@ To find out where these locations are, e.g. where `$OPENHAB_CONF` points to, use
 ```shell
 openhab-cli info
 ```
- will result in e.g. for an [openHABian](https://www.openhab.org/docs/installation/openhabian.html) installation
 
+will result in e.g. for an [openHABian](https://www.openhab.org/docs/installation/openhabian.html) installation
 
 ```shell
 Version:     3.0.0 (Build)
@@ -115,8 +115,6 @@ Directories: Folder Name      | Path                        | User:Group
 URLs:        http://169.254.63.209:8080
              https://169.254.63.209:8443
 ```
-
-
 
 ## Additional Steps
 

--- a/installation/qnap.md
+++ b/installation/qnap.md
@@ -19,32 +19,32 @@ Follow the instructions shown if a new version is announced when opening the adm
 
 1. Download the QPKG from the [releases section over on GitHub](https://github.com/openhab/openhab-qnap-qpkg/releases).
 
-2. Create a directory for your addons, configurations and userdata, by either
+1. Create a directory for your addons, configurations and userdata, by either
     - Creating a share called "openHAB" (recommended)
     - Creating a folder called "openHAB" inside the "Public" share
     - Not creating any of them and therefore using `.qpkg/openHAB2/distribution` for all data (for testing or demonstration)
 
-3. Go to your NAS's App Center and make sure you have got "JRE" (for x86-CPU based NAS) or "JRE_ARM" (for ARM-CPU based NAS) installed.
+1. Go to your NAS's App Center and make sure you have got "JRE" (for x86-CPU based NAS) or "JRE_ARM" (for ARM-CPU based NAS) installed.
     If that is not the case, go to the "Developer-Tools" section of the App Center, install the appropriate version and wait for a while until the Java installation has finished.
 
-4. Open the "Install manually" dialog in the App Center by clicking the gear-wheel on the upper-right corner of the App Center and choose the `qpkg` you have downloaded.
+1. Open the "Install manually" dialog in the App Center by clicking the gear-wheel on the upper-right corner of the App Center and choose the `qpkg` you have downloaded.
 
     ![AppCenter choose](https://github.com/openhab/openhab-qnap-qpkg/raw/master/docs/QTS_4.2.0_AppCenter%20choose.png)
 
-5. Confirm the installation
+1. Confirm the installation
 
     ![AppCenter confirm](https://github.com/openhab/openhab-qnap-qpkg/raw/master/docs/QTS_4.2.0_AppCenter%20confirm.png)
 
-6. Wait while the package is being installed
+1. Wait while the package is being installed
 
     ![AppCenter installing](https://github.com/openhab/openhab-qnap-qpkg/raw/master/docs/QTS_4.2.0_AppCenter%20installing.png)
 
-7. When finished just close the dialog and wait for a while until openHAB has completely started.
+1. When finished just close the dialog and wait for a while until openHAB has completely started.
     This may take several minutes.
 
     ![AppCenter finished](https://github.com/openhab/openhab-qnap-qpkg/raw/master/docs/QTS_4.2.0_AppCenter%20finished.png)
 
-8. Access openHAB via `http://NAS_IP_or_DNS_address:8090`.
+1. Access openHAB via `http://NAS_IP_or_DNS_address:8090`.
     If the interface does not start, retry after another minute.
     The initial startup takes some time.
 
@@ -54,7 +54,7 @@ If you want to keep configuration files, copy them to a save place outside of th
 
 1. Go to the "App Center" and remove the app like any other.
 
-2. Additionally if wanted or needed, please remove the folders "addons", "conf" and "userdata" from the your directory, eg. "openHAB2" share or "Public"/openHAB2
+1. Additionally if wanted or needed, please remove the folders "addons", "conf" and "userdata" from the your directory, eg. "openHAB2" share or "Public"/openHAB2
    If you have installed openHAB2 to `.qpkg` (see "How to install", third option) then all files get removed automatically.
 
 ## Known issues

--- a/installation/rasppi.md
+++ b/installation/rasppi.md
@@ -47,7 +47,7 @@ As of the November 2016 release, Raspbian has the SSH server disabled by default
 You will have to enable it manually.
 For headless setup, SSH can be enabled by placing a file named "ssh", without any extension, onto the boot partition of the SD card.
 
-### Connecting: 
+### Connecting
 
 Get your SD card and network cable plugged in and power up.
 Booting up takes up to 10 minutes.
@@ -55,7 +55,7 @@ To connect with an SSH client (like [Putty](https://www.raspberrypi.org/document
 A standard Raspbian setup should be reachable either by the hostname "raspberrypi" or though the local domain name "raspberrypi.local".
 If you are not able to connect, check your routers web frontend for newly connected devices.
 
-### First Steps:
+### First Steps
 
 Connected via SSH, execute the Raspbian configuration menu by running `sudo raspi-config`.
 Go through the following steps:
@@ -80,57 +80,68 @@ Raspbian in the latest full version already includes Oracle Java 11.
 However, at the time of this writing, the installed revision is lower than the [recommended](index.html#prerequisites).
 Raspbian Lite comes without Java to begin with.
 
- ### Manual setup of Zulu 11
- 
+### Manual setup of Zulu 11
+
 The following steps refer specifically to Raspberry Pi devices. For a more general overview. please refer to the Linux article for instructions on [how to install the latest Java 11 revision](linux.html).
 
 1. create a folder for Zulu 11 and make it the current folder. For instance, ``/opt/jdk``. You can use the commands
+
    ```shell
    sudo mkdir /opt/jdk
    cd /opt/jdk
    ```
-2. verify the architecture of your device. You perform this issuing the command:
+
+1. verify the architecture of your device. You perform this issuing the command:
+
    ```shell
    dpkg --print-architecture
    ```
-   this will show whether you need files for  Soft Float (```armsf```) or Hard Float (```armhf```) .
-Raspberry Pi 4 runs on ARM32-bit HF architecture (```armhf```), for instance. 
 
+   this will show whether you need files for  Soft Float (```armsf```) or Hard Float (```armhf```) .
+Raspberry Pi 4 runs on ARM32-bit HF architecture (```armhf```), for instance.
 
 Now, to install Zulu 11, you need to download and install a tar.gz package for your architecture following the steps described below (```armhf``` architecture assumed for reference):
 
+1. Download the latest Zulu 11 build from [the Azul download page](https://www.azul.com/downloads/zulu-community/?version=java-11-lts&architecture=arm-32-bit-hf&package=jdk) - at the time of writing, it's `` zulu11.43.100-ca-jdk11.0.9.1-linux_aarch32hf ``. You can use the command:
 
-3. Download the latest Zulu 11 build from [the Azul download page](https://www.azul.com/downloads/zulu-community/?version=java-11-lts&architecture=arm-32-bit-hf&package=jdk) - at the time of writing, it's `` zulu11.43.100-ca-jdk11.0.9.1-linux_aarch32hf ``. You can use the command:
    ```shell
    sudo wget http://cdn.azul.com/zulu-embedded/bin/zulu11.43.100-ca-jdk11.0.9.1-linux_aarch32hf.tar.gz
    ```
-4. Extract the archive
+
+1. Extract the archive
+
     ```shell
    sudo tar -xzvf zulu11.43.100-ca-jdk11.0.9.1-linux_aarch32hf.tar.gz
    ```
-5. Install ```java``` and ```javac```
+
+1. Install ```java``` and ```javac```
+
    ```shell
     sudo update-alternatives --install /usr/bin/java java /opt/jdk/zulu11.43.100-ca-jdk11.0.9.1-linux_aarch32hf/bin/java 1
     sudo update-alternatives --install /usr/bin/javac javac /opt/jdk/zulu11.43.100-ca-jdk11.0.9.1-linux_aarch32hf/bin/javac 1
    ```
-6. change the current alternative:
+
+1. change the current alternative:
+
     ```shell
     sudo update-alternatives --config java
     ```
+
    You'll be prompted to select the alternative, pick the zulu11 you installed.
 
-7. If you wish so, you can now delete the downloaded tar file
+1. If you wish so, you can now delete the downloaded tar file
+
     ```shell
     sudo rm *.tar.gz
     ```
 
-### Installation of openHAB:
+### Installation of openHAB
 
-This section describes the steps required to install openHAB on the Raspberry device, after you completed the above mentioned *prerequisites* steps. 
+This section describes the steps required to install openHAB on the Raspberry device, after you completed the above mentioned *prerequisites* steps.
 
 It is a selection of the general Linux installation steps described in  [Package Repository based Installation on Linux](linux.html#package-repository-installation) .
 
-Refer to that page if you wish to view a comprehensive guide to every possible Linux installation environments instead. 
+Refer to that page if you wish to view a comprehensive guide to every possible Linux installation environments instead.
 
 1. First, add the openHAB Bintray repository key to your package manager and allow Apt to use the HTTPS Protocol:
 
@@ -139,16 +150,16 @@ Refer to that page if you wish to view a comprehensive guide to every possible L
    sudo apt-get install apt-transport-https
    ```
 
-2. choose the openHAB package to install. 
+1. choose the openHAB package to install.
 
     You can choose between *Official (Stable)*, *Beta* or *Snapshot* builds.
 
-    If you are new to openHAB and don't know what to pick, you likely need the *Stable* version. 
+    If you are new to openHAB and don't know what to pick, you likely need the *Stable* version.
     Expand the section of your choice for the details of the installation step.
 
     <details>
      <summary>Official (Stable)</summary>
-  
+
      The stable builds contain the latest official release with tested features.
 
     Add the **openHAB Stable Repository** to your systems apt sources list:
@@ -156,11 +167,12 @@ Refer to that page if you wish to view a comprehensive guide to every possible L
     ```shell
     echo 'deb https://dl.bintray.com/openhab/apt-repo2 stable main' | sudo tee /etc/apt/sources.list.d/openhab.list
     ```
+
     </details>
 
     <details>
      <summary >Testing Release</summary>
-  
+
      The beta and release candidate builds come out less frequently, but will contain new features that are currently in the testing phase.
 
     Add the **openHAB Beta Repository** to your systems apt sources list:
@@ -172,7 +184,7 @@ Refer to that page if you wish to view a comprehensive guide to every possible L
     </details>
      <details>
        <summary >Snapshot Release</summary>
-  
+
      The snapshot build is created [almost daily](https://ci.openhab.org/job/openhab-linuxpkg/), and include the latest changes to the openHAB core and add-ons.
     These changes are often unstable, so you should use this branch only for testing or development purposes.
 
@@ -182,45 +194,50 @@ Refer to that page if you wish to view a comprehensive guide to every possible L
     ```shell
     echo 'deb https://openhab.jfrog.io/artifactory/openhab-linuxpkg unstable main' | sudo tee /etc/apt/sources.list.d/openhab.list
     ```
+
 </details>
 
-3. re-synchronize the package index:
+1. re-synchronize the package index:
 
     ```shell
     sudo apt-get update
     ```
 
-4. Install openHAB with the following command:
+1. Install openHAB with the following command:
 
     ```shell
     sudo apt-get install openhab
     ```
 
-5. *(optional)* When you choose to install an add-on, openHAB will download it from the internet on request.
+1. *(optional)* When you choose to install an add-on, openHAB will download it from the internet on request.
 
    If you plan on working off-line, you might consider installing the add-ons package.
 
     ```shell
     sudo apt-get install openhab-addons
     ```
+
 ---
-If everything went well, the installation is complete. 
+If everything went well, the installation is complete.
 
 You can now start openHAB and test it as described in the following points
 
-6. Start openHAB
- ```shell
+1. Start openHAB
+
+```shell
 sudo systemctl start openhab.service
 sudo systemctl status openhab.service
 ```
-7. test that openHAB is running fine. 
 
-    You can try to reach the openHAB dashboard, using the link:  `http://openhab-device:8080` (replace localhost or your device IP address to *openhab-device*). You should get the *create new admin* screen 
+1. test that openHAB is running fine.
+
+    You can try to reach the openHAB dashboard, using the link:  `http://openhab-device:8080` (replace localhost or your device IP address to *openhab-device*). You should get the *create new admin* screen
 
    ![The openHAB Dashboard page](images/Home_Openhab_4.png)
 
-8. Install openHAB as a service. This will allow openHAB to run without need for a manual start as described above.
- ```shell
+1. Install openHAB as a service. This will allow openHAB to run without need for a manual start as described above.
+
+```shell
 sudo systemctl daemon-reload
 sudo systemctl enable openhab.service
 ```
@@ -240,7 +257,7 @@ You can:
 
 This is the location of folders of  interest for the user:
 
-|                               | Repository Installation      
+|                               | Repository Installation      |
 |:-----------------------------|------------------------------|------------------------------------------------------------------|
 |      openHAB application      | `/usr/share/openhab`                                                        |
 |    Additional add-on files    | `/usr/share/openhab/addons` |                                         |
@@ -249,7 +266,6 @@ This is the location of folders of  interest for the user:
 | Userdata like rrd4j databases | `/var/lib/openhab`          |                               |
 |         Backups folder        | `/var/lib/openhab/backups`  |                      |
 |     Service configuration     | `/etc/default/openhab`      | (                                 |
-
 
 ### Utilities
 
@@ -296,8 +312,6 @@ Possible commands:
   info                -- Displays distribution information.
 ```
 
-
-
 ## Viewing Log Messages
 
 You can learn more about openHAB and how it works by looking at your log files.
@@ -305,18 +319,19 @@ These will tell you everything you might need to know.
 
 To access the current log of openHAB, execute the following command in one session or have both files separated in sessions side by side:
 
-
-
   ```shell
   tail -f /var/log/openhab/openhab.log -f /var/log/openhab/events.log
   ```
-  - if you wish to filter the results, please notice that there is an utility to support you, named *grep*. A quick example below:
-      ```
-      tail -f /var/log/openhab/openhab.log -f /var/log/openhab/events.log | grep "theStringYourLookingForGoesHere"
-      ```
-      Refer to its help for details.
 
-   - if you wish to modify the level of detail of logging, you'll need to interact with the [openHAB console](#command-line-interface), as described int the [Administration-Logging]({{base}}/administration/logging.md) page.
+- if you wish to filter the results, please notice that there is an utility to support you, named *grep*. A quick example below:
+
+   ```bash
+   tail -f /var/log/openhab/openhab.log -f /var/log/openhab/events.log | grep "theStringYourLookingForGoesHere"
+   ```
+
+   Refer to its help for details.
+
+- if you wish to modify the level of detail of logging, you'll need to interact with the [openHAB console](#command-line-interface), as described int the [Administration-Logging]({{base}}/administration/logging.md) page.
 
 ## Backup and Restore
 
@@ -342,6 +357,7 @@ If you're unsure how to use the above files, just use `--help` or `-h`:
 ```shell
 $OPENHAB_RUNTIME/bin/backup --help
 ```
+
 ### Upgrade
 
 To stay up to date with new releases, you should do regular upgrades.
@@ -373,6 +389,7 @@ Once you know which version you want, you can upgrade/downgrade to it by using t
 ```shell
 sudo apt-get install openhab=3.0.0-1
 ```
+
 ### Uninstallation
 
 To uninstall openHAB and get rid of all related files managed by the package manager, make a backup as described above, then uninstall openHAB and remove the repository:
@@ -383,4 +400,5 @@ sudo rm /etc/apt/sources.list.d/openhab.list
 ```
 
 ### Additional Setup steps
+
 Please refer to the [Recommended Additional Setup Steps]({{base}}/installation/linux.md#Recommended-Additional-Setup-Steps) in the Linux installation guide.

--- a/installation/security.md
+++ b/installation/security.md
@@ -10,7 +10,7 @@ title: Securing Communication and Access
 openHAB has mainly two ways to be accessed:
 
 1. Through the command line console, which is done through SSH and thus always authenticated and encrypted. You will find all details about this in the [Console documentation](/docs/administration/console.html).
-2. Through HTTP(S), which we will look at in the following.
+1. Through HTTP(S), which we will look at in the following.
 
 {::options toc_levels="2..3"/}
 

--- a/installation/synology.md
+++ b/installation/synology.md
@@ -41,12 +41,12 @@ Download the latest SPK package: [Releases](https://github.com/openhab/openhab-s
 The SPK is a wrapper to download the latest openHAB release and does not contain openHAB itself.
 
 1. Login and open the DiskStation Manager.
-2. Go to Control Panel → User → Advanced → User Home and check 'Enable user home service'
-3. Go to Main Menu → Package Center.
-4. Click on the Manual Install button.
-5. Click "Choose File" and select the previously downloaded openHAB `.spk` file.
-6. On the confirmation page: If you would like the package to run immediately after installation, make sure the box next to "Run after Installation" is ticked.
-7. Click Apply to start installation.
+1. Go to Control Panel → User → Advanced → User Home and check 'Enable user home service'
+1. Go to Main Menu → Package Center.
+1. Click on the Manual Install button.
+1. Click "Choose File" and select the previously downloaded openHAB `.spk` file.
+1. On the confirmation page: If you would like the package to run immediately after installation, make sure the box next to "Run after Installation" is ticked.
+1. Click Apply to start installation.
 
 If your NAS cannot connect to the internet, the installer will tell you to download and place the ZIP file into your NAS public folder.
 

--- a/installation/windows.md
+++ b/installation/windows.md
@@ -42,15 +42,15 @@ To install it, follow these simple steps:
 
 1. Download the latest Windows Stable or Snapshot ZIP archive file for manual installation from the [Download](https://www.openhab.org/download/) page.
 
-2. Unzip the file in your chosen directory (e.g. `C:\openHAB`)
+1. Unzip the file in your chosen directory (e.g. `C:\openHAB`)
 
     ![openHAB Folders](images/openHAB_Folders.png)
 
-3. Start the server: Launch the runtime by executing the script `C:\openHAB\start.bat` and wait a while for it to start and complete.
+1. Start the server: Launch the runtime by executing the script `C:\openHAB\start.bat` and wait a while for it to start and complete.
 
     ![Karaf_Windows](images/Karaf_Windows.png)
 
-4. Point your browser to `http://localhost:8080`.
+1. Point your browser to `http://localhost:8080`.
     You should be looking at the openHAB page requesting you to set up an administrator username and password:
 
 ![Home_OH_adminCreate](images/Home_OH_adminCreate.png)
@@ -69,7 +69,7 @@ By installing the openHAB process as a service in Windows, you can:
 #### Windows Service Installation Steps
 
 1. Complete the [prerequisites](#prerequisites) and regular [installation](#installation) steps.
-2. Issue the following two commands in your openHAB console:
+1. Issue the following two commands in your openHAB console:
 
     ```shell
     feature:install service-wrapper
@@ -78,9 +78,9 @@ By installing the openHAB process as a service in Windows, you can:
 
     ![Wrapper Install_Windows](images/Wrapper_Install_Windows.jpg)
 
-3. Shutdown the openHAB instance by typing `logout` in the currently running console.
+1. Shutdown the openHAB instance by typing `logout` in the currently running console.
 
-4. Update the newly created `C:\openHAB\userdata\etc\openHAB-wrapper.conf` to include all necessary parameters:
+1. Update the newly created `C:\openHAB\userdata\etc\openHAB-wrapper.conf` to include all necessary parameters:
 
     - Copy all the config text from the below section and paste it in your `openHAB-wrapper.conf`, replacing all existing content.
     - Adapt the first entry (`OPENHAB_HOME`) to match your openHAB installation directory.
@@ -154,7 +154,7 @@ By installing the openHAB process as a service in Windows, you can:
     wrapper.ntservice.interactive=false
     ```
 
-5. Open an elevated command prompt and type the following commands:
+1. Open an elevated command prompt and type the following commands:
 
     ```text
     C:\openHAB\userdata\bin\openHAB-service.bat install
@@ -165,7 +165,7 @@ By installing the openHAB process as a service in Windows, you can:
 
     ![Wrapper_Start_Windows](images/Wrapper_Start_Windows.jpg)
 
-6. Your openHAB Windows service is now installed and running.
+1. Your openHAB Windows service is now installed and running.
     Validate proper operations by:
 
     - Browsing to [http://localhost:8080](http://localhost:8080)

--- a/introduction.md
+++ b/introduction.md
@@ -38,10 +38,10 @@ Some of openHAB's strengths are:
 Home automation is fascinating and requires a considerable investment of your time.
 Here are some key considerations especially for new users. To be successful, you will need to:
 
-* Start slowly and proceed one step at a time
-* Be prepared to learn
-* Remain flexible in how you want to achieve your goal
-* Celebrate all the small successes
+- Start slowly and proceed one step at a time
+- Be prepared to learn
+- Remain flexible in how you want to achieve your goal
+- Celebrate all the small successes
 
 Remember, openHAB is just a computer program.
 The computer will only do what *you* tell it to do.
@@ -51,9 +51,9 @@ openHAB is fully customizable, but doing so will require substantial effort on y
 
 After you have read the documentation for openHAB, you will have:
 
-* Identified a computer on which to run openHAB
-* Learned how to install openHAB, as well as all other software that is needed to run openHAB (e.g. Java)
-* Learned how your smart devices communicate with openHAB; how to make openHAB give commands to your smart devices; and how you can interact with openHAB
+- Identified a computer on which to run openHAB
+- Learned how to install openHAB, as well as all other software that is needed to run openHAB (e.g. Java)
+- Learned how your smart devices communicate with openHAB; how to make openHAB give commands to your smart devices; and how you can interact with openHAB
 
 Keep your focus.
 For almost everything, there is more than one way in openHAB to achieve a goal or perform a task.
@@ -163,13 +163,13 @@ Once you have got a first overview, it is time to practice.
 Here a short list of the steps that you will need to consider to get openHAB up and running as your home automation system:
 
 1. Install openHAB
-2. If you already own a smart device, search the addons for the brand or technology used by that device (or simply browse the list of [add-ons](/addons/) for any technologies or services you may recognize)
-3. Install a binding (in openHAB)
-4. Define a “thing”
-5. Add a “channel” to the “thing” if not created by the binding
-6. Define an “item”
-7. Link the “channel” to your “item”
-8. Establish a sitemap
+1. If you already own a smart device, search the addons for the brand or technology used by that device (or simply browse the list of [add-ons](/addons/) for any technologies or services you may recognize)
+1. Install a binding (in openHAB)
+1. Define a “thing”
+1. Add a “channel” to the “thing” if not created by the binding
+1. Define an “item”
+1. Link the “channel” to your “item”
+1. Establish a sitemap
 
 Most of the above can be done in openHAB through point-and-click processes in a graphical user interface.
 But remember, there is always more than one way to achieve your goal in openHAB.

--- a/tutorials/getting_started/first_steps.md
+++ b/tutorials/getting_started/first_steps.md
@@ -15,22 +15,23 @@ The following instructions will guide you through the initial steps after first 
 {:toc}
 
 ## Create the Admin User
-Once openHAB is installed and started, launch the user interface by navigating to [http://localhost:8080]() (if not running locally, replace localhost with the server's address or hostname accordingly).
-If you installed from the openHABian image, you can use [http://openhab:8080]().
+
+Once openHAB is installed and started, launch the user interface by navigating to `http://localhost:8080` (if not running locally, replace localhost with the server's address or hostname accordingly).
+If you installed from the openHABian image, you can use `http://openhab:8080`.
 
 By default, the administration pages can only be accessed if you are logged in with an administrator account.
 Since there are no users yet, openHAB will ask you to create an administrator account.
 
-![](images/create_user.png)
+![create user](images/create_user.png)
 
 ### Add geographic information
 
 After creating an admin user, you will be guided through a first-time setup wizard.
 Start by setting your language, region, and time zone. You can also set your location, or skip this step and complete it later.
 
-![](images/wizard_geo.png)
+![geo wizard](images/wizard_geo.png)
 
-![](images/wizard_location.png)
+![location wizard](images/wizard_location.png)
 
 ### Install add-ons
 
@@ -38,11 +39,11 @@ You now have the option to install openHAB add-ons.
 Do this if you already know that you'll need specific add-ons (e.g. if you're upgrading from an older openHAB system), or skip this step if you prefer to install add-ons individually.
 You can always install/remove add-ons in the future, enabling you to modify and improve your system over time.
 
-![](images/wizard_addons.png)
+![addons wizard](images/wizard_addons.png)
 
 After finishing the wizard you will get a welcome message and be redirected to your dashboard.
-![](images/wizard_welcome.png)
-![](images/welcome_page.png)
+![welcome wizard](images/wizard_welcome.png)
+![welcome page](images/welcome_page.png)
 
 ### Log into the dashboard
 
@@ -60,18 +61,19 @@ You can also set your preferred measurement system (openHAB defaults to the Metr
 ### Set your geographic location (latitude and longitude) and measurement system
 
 1. In the left-hand menu under Administration, select Settings to open the Settings page.
-![](images/initial_settings.png)
+![initial settings](images/initial_settings.png)
 
-2. Under System Settings, select Regional Settings.
-![](images/regional_settings.png)
+1. Under System Settings, select Regional Settings.
+![regional settings](images/regional_settings.png)
 
-3. Under Location, click the Map button to add your geographic coordinates.
+1. Under Location, click the Map button to add your geographic coordinates.
 
-4. If you also want to set your measurement system, click "Show advanced" and choose between Metric and Imperial.
+1. If you also want to set your measurement system, click "Show advanced" and choose between Metric and Imperial.
 
-![](images/units_settings.png)
+![unit settings](images/units_settings.png)
 
 ## Additional Settings
+
 The following settings are available but not covered by this tutorial.
 
 Setting | Purpose


### PR DESCRIPTION
Another run of fixing several markdown errors.

Also excluded rule `MD041` which checks for a top level heading on line 1.
We are using Frontmatter and won't be able to fulfill this rule.