### PR TITLE
Revert #1428

### DIFF
--- a/configuration/restdocs.md
+++ b/configuration/restdocs.md
@@ -87,19 +87,6 @@ To authenticate with an API token, **apaddpend `-u '{API_TOKEN}:'` to the comman
 
 You can manage all access tokens in your profile settings in the Main UI.
 
-### Disable authentication
-
-It is possible to disable authentication.
-Stop openhab and add this part to ```$OPENHAB_USERDATA/etc/org.apache.karaf.features.xml``` before ```</featuresProcessing>```:
-
-```xml
-    <blacklistedFeatures>
-        <feature>openhab-*-auth</feature>
-    </blacklistedFeatures>
-```
-
-Once openhab is restarted authentication will be disabled.
-
 ## Additional Considerations
 
 The REST API also supports server-push supporting subscriptions on change notification for certain resources.


### PR DESCRIPTION
Reverting #1428 for now.

Based on openhab/openhab-core#2094 this should be considered as a workaround and seems also to break the UI.
We should not introduce docs to users that introduces content, that may break their installation in some way.
Especially in the context of unexperienced users reading articles like this.

When the auth topic is clarified in the corresponding core issues we can reintroduce a proper (and failsafe) documentation on how to disable auth.

Signed-off-by: Jerome Luckenbach <github@luckenba.ch>