### PR TITLE
Replace local urls with inline code. CHange one occurence to openhabian.

### DIFF
--- a/configuration/restdocs.md
+++ b/configuration/restdocs.md
@@ -11,7 +11,7 @@ Through the openHAB [REST API](https://en.wikipedia.org/wiki/REST_API) most aspe
 This includes for example, the access to all data related to Items, Things and Bindings as well as the capabilities to invoke actions that can change the state of Items or influence the behavior of other elements of openHAB.
 Interactions with the REST API are based on the http protocol.
 Access over the Internet to the REST API is possible, but this represents a significant security risk.
-Users are encouraged to [ensure safe and secure connections](http://docs.openhab.org/installation/security.html).
+Users are encouraged to [ensure safe and secure connections](/docs/installation/security.html).
 Be aware that the documentation of the REST API may not be automatically installed, but once installed it is accessible through the openHAB dashboard.
 
 ## REST API Examples

--- a/configuration/rules-ng.md
+++ b/configuration/rules-ng.md
@@ -309,9 +309,9 @@ There are several ways to add new rules:
 
 ## REST API
 
-- http://<host:port>/rest/module-types - lists module types.
-- http://<host:port>/rest/templates" - lists rule templates.
-- http://<host:port>/rest/rules - lists rule instances.
+- `http://<host:port>/rest/module-types` - lists module types.
+- `http://<host:port>/rest/templates` - lists rule templates.
+- `http://<host:port>/rest/rules` - lists rule instances.
 
 ### /rest/templates
 

--- a/installation/macos.md
+++ b/installation/macos.md
@@ -94,7 +94,7 @@ To exit, use '<ctrl-d>' or 'logout'.
 openhab>
 ```
 
-Without closing the terminal, open your favorite web browser and type the following URL: [http://localhost:8080](http://localhost:8080), you should see the openHAB welcome screen, and you're all set to [using openHAB]({{base}}/tutorial/first_steps.html).
+Without closing the terminal, open your favorite web browser and type the following URL: `http://localhost:8080`, you should see the openHAB welcome screen, and you're all set to [using openHAB]({{base}}/tutorial/first_steps.html).
 If you installed openHAB on a different device, replace localhost with the IP address of the device.
 
 ## Updating openHAB

--- a/installation/security.md
+++ b/installation/security.md
@@ -604,7 +604,7 @@ Back in the GUI, go to Control Panel > Application Portal > Reverse Proxy, make 
 We do this 'double' redirect to take advantage of the GUI certificate handling in DSM - this is the equivalent of CertBot for a linux installation.
 :::
 
-Give it a try again - you should now get redirected to <https://your-hostname.com> from <http://your-hostname.com>, and should receive a username and password prompt before you see the openHAB landing page.
+Give it a try again - you should now get redirected to `https://your-hostname.com` from `http://your-hostname.com`, and should receive a username and password prompt before you see the openHAB landing page.
 
 If you need to troubleshoot the nginx server, SSH into your DiskStation, and check the NGINX error log:
 

--- a/tutorials/getting_started/first_steps.md
+++ b/tutorials/getting_started/first_steps.md
@@ -17,7 +17,7 @@ The following instructions will guide you through the initial steps after first 
 ## Create the Admin User
 
 Once openHAB is installed and started, launch the user interface by navigating to `http://localhost:8080` (if not running locally, replace localhost with the server's address or hostname accordingly).
-If you installed from the openHABian image, you can use `http://openhab:8080`.
+If you installed from the openHABian image, you can use `http://openhabianpi:8080`.
 
 By default, the administration pages can only be accessed if you are logged in with an administrator account.
 Since there are no users yet, openHAB will ask you to create an administrator account.


### PR DESCRIPTION
Replaces all example/local urls that were usable with inline code blocks.
Also Fixes #1272