### PR TITLE
Update items.md

### DIFF
--- a/configuration/items.md
+++ b/configuration/items.md
@@ -69,7 +69,7 @@ itemtype itemname "labeltext [stateformat]" <iconname> (group1, group2, ...) ["t
 **Examples:**
 
 ```java
-Switch Kitchen_Light "Kitchen Light" {mqtt="<[...], >[...]" }
+Switch Kitchen_Light "Kitchen Light" {channel="mqtt:topic:..." }
 String Bedroom_Sonos_CurrentTitle "Title [%s]" (gBedRoom) {channel="sonos:..."}
 Number Bathroom_WashingMachine_Power "Power [%.0f W]" <energy> (gPower) {channel="homematic:..."}
 


### PR DESCRIPTION
Example with item Switch Kitchen_Light in the example is not correct for current binding version.