### PR TITLE
Update items.md

### DIFF
--- a/configuration/items.md
+++ b/configuration/items.md
@@ -752,5 +752,5 @@ Switch Outdoor_Temperature_Low_Alert { channel="openweathermap:weather-and-forec
 
 // Indicates a battery low alarm if battery level drops below 15
 Number Battery_Level { channel="serialbutton:button:mybutton:battery-level" }
-Switch Low_Battery { channel="serialbutton:button:mybutton:battery-level", [profile="hysteresis", lower=15, inverted=true] }
+Switch Low_Battery { channel="serialbutton:button:mybutton:battery-level" [profile="hysteresis", lower=15, inverted=true] }
 ```


### PR DESCRIPTION
There is one comma too much in the sample for profile hysteresis. The profile must be related to the channel. The comma will lead also to an error message in log.
Switch Low_Battery { channel="serialbutton:button:mybutton:battery-level" [profile="hysteresis", lower=15, inverted=true] }

fyi: That's my first pull request. I hope, doing it correctly without screwing anything. 