### PR TITLE
Add frontmatter to building-pages.md

### DIFF
--- a/ui/building-pages.md
+++ b/ui/building-pages.md
@@ -1,3 +1,7 @@
+---
+title: Building Pages - Components & Widgets
+---
+
 # Building Pages: Components & Widgets
 
 [[toc]]


### PR DESCRIPTION
If there's no frontmatter at all for a page, the processing script
will not add a "source" and therefore the Edit on GitHub link
will be missing.

Signed-off-by: Yannick Schaus <github@schaus.net>