### PR TITLE
[docs] Cover naming of Channel ID

### DIFF
--- a/developers/guidelines.md
+++ b/developers/guidelines.md
@@ -88,7 +88,10 @@ The rules are defined at <https://github.com/openhab/static-code-analysis/tree/m
 
 ### Java Coding Style
 
-- The [Java naming conventions](https://java.about.com/od/javasyntax/a/nameconventions.htm) should be used for source files.
+- The [Java naming conventions](https://java.about.com/od/javasyntax/a/nameconventions.htm) should always be used and are descibed in detail at the link, a quick summary is:
+    * Channel IDs: `lowerCamelCase`
+    * Variables: `lowerCamelCase`
+    * Constants: `ALL_UPPER_CASE`
 - Generics must be used where applicable. See example below:
 
 ```java


### PR DESCRIPTION
Make the Java naming convention more clear, as 100% of the new binding submissions that I have looked in the last week have all failed to know this. In most cases it is the Channel ID that they get wrong as:

1. Some merged bindings do it "differently".
2. The linked url does not cover what to do for channel IDs.

Signed-off-by: Matthew Skinner <matt@pcmus.com>