### PR TITLE
Additional Information

### DIFF
--- a/installation/windows.md
+++ b/installation/windows.md
@@ -101,6 +101,7 @@ By installing the openHAB process as a service in Windows, you can:
     set.default.KARAF_DATA=%OPENHAB_USERDATA%
     set.default.KARAF_ETC=%OPENHAB_USERDATA%\etc
     set.default.PATH=%PATH%;%KARAF_BASE%\lib;%KARAF_HOME%\lib
+    set.default.JAVA_HOME=C:\Program Files\Zulu\zulu-11
 
     # Java Application
     wrapper.working.dir=%KARAF_BASE%


### PR DESCRIPTION
After line 103 it would appear many (including myself) have had to add a line indicating the location of the JAVA installation.

This is not too difficult to find through the excellent Forum contributions, but it would be nice to see it here instead of having the Service installation fail, then having to look elsewhere for the answer.

In my case the new line 104 is 'set.default.JAVA_HOME=C:\Program Files\Zulu\zulu-11', followed by a new blank line.