### PR TITLE
Update security.md

### DIFF
--- a/installation/security.md
+++ b/installation/security.md
@@ -220,7 +220,7 @@ Open the configuration file and **add** the following lines underneath the proxy
 ##### Add authorization and cookie directives in NGINX Configuration
 
 This is an important new requirment in openHAB 3.0 and later versions.
-This is not required prior to openHAB 3.0. In the `location /` block, you must add the following two directives underneath the `add_header` and `proxy_set_header` items respectively:
+This is not required prior to openHAB 3.0. You must add the following two directives underneath the `add_header` (in the `server` block) and `proxy_set_header` (in the `location /` block) items respectively:
 
 ```nginx
         add_header Set-Cookie X-OPENHAB-AUTH-HEADER=1;


### PR DESCRIPTION
It is incorrect that both additions are required to go into the `location\` block - one goes into the `server` block, the other into the `location` block. This is echoed by the final full configuration at the end of the page.