### PR TITLE
Update transformations.md

### DIFF
--- a/addons/transformations.md
+++ b/addons/transformations.md
@@ -31,8 +31,8 @@ Transformation files need to be placed in the directory `$OPENHAB_CONF/transform
 
     ```java
     Contact Livingroom_Window        "Window [MAP(window_esp.map):%s]"               {/*Some Binding*/}
-    Number  Kitchen_Temperature_C    "Temperature [JSONPATH($.temperature):%.1f °C]" {/*Some Binding*/}
-    Number  Livingroom_Temperature_F "Temperature [JS(convert-C-to-F.js):%.1f °F]"   {/*Some Binding*/}
+    Number  Kitchen_Temperature_C    "Temperature [JSONPATH($.temperature):%s °C]" {/*Some Binding*/}
+    Number  Livingroom_Temperature_F "Temperature [JS(convert-C-to-F.js):%s °F]"   {/*Some Binding*/}
 
     ```
 


### PR DESCRIPTION
Small correction to replace formatter in Item label example, from %.1f to %s
Transform returns a string, not possible to format with %.1f

Signed-off-by: Ross Kennedy rossko@culzean.clara.co.uk