### PR TITLE
buildsystem / external dependecy instructions fixed

### DIFF
--- a/developers/buildsystem.md
+++ b/developers/buildsystem.md
@@ -21,7 +21,7 @@ Generally all dependencies should be OSGi-bundles and available on JCenter.
 
 ### External dependency
 
-In most cases they should be referenced in the project POM with scope `provided`:
+In most cases they should be referenced in the project POM with scope `compile`:
 
 ```xml
   <dependencies>


### PR DESCRIPTION
The example (showing `compile`) and sentence (advising use of `provided`) are in conflict.

This documentation issue was caused by merge https://github.com/openhab/openhab-docs/pull/1266/ . @J-N-K contributed the original piece of documentation in https://github.com/openhab/openhab-docs/pull/1199, having both the sentence and code using `compile` scope for dependencies.

This also matches with the wisdom shared in the community forum: https://community.openhab.org/t/3rd-party-maven-dependencies-in-openhab-core/113722/2

To my knowledge, actual code reference how this works out is in openhab-addons/bundles/pom.xml: 

https://github.com/openhab/openhab-addons/blob/c709f52d662ff216c3954f8930438c605ac0b0b7/bundles/pom.xml#L504-L526

(highlighting lines of interest with `!`)

```xml
!      <!-- embed compile time dependencies by unpacking -->
      <plugin>
        <groupId>org.apache.maven.plugins</groupId>
        <artifactId>maven-dependency-plugin</artifactId>
        <version>3.1.1</version>
        <executions>
          <execution>
            <id>embed-dependencies</id>
            <goals>
              <goal>unpack-dependencies</goal>
            </goals>
            <configuration>
!              <includeScope>runtime</includeScope>
              <includeTypes>jar</includeTypes>
              <excludeGroupIds>javax.activation,org.apache.karaf.features,org.lastnpe.eea</excludeGroupIds>
              <excludeArtifactIds>${dep.noembedding}</excludeArtifactIds>
              <outputDirectory>${project.build.directory}/classes</outputDirectory>
              <overWriteReleases>true</overWriteReleases>
              <overWriteSnapshots>true</overWriteSnapshots>
              <excludeTransitive>true</excludeTransitive>
              <type>jar</type>
            </configuration>
          </execution>
```


Signed-off-by: Sami Salonen <ssalonen@gmail.com>