### PR TITLE
Update security.md

### DIFF
--- a/installation/security.md
+++ b/installation/security.md
@@ -20,7 +20,7 @@ openHAB has mainly two ways to be accessed:
 ### Webserver Ports
 
 openHAB has a built-in webserver, which listens on port 8080 for HTTP and 8443 for HTTPS requests.
-In general, it is advised to use HTTPS communication over HTTP.
+In general, it is advised to use HTTPS in perefence to HTTP.
 
 The default ports 8080 and 8443 can be changed by setting the environment variables `OPENHAB_HTTP_PORT` resp. `OPENHAB_HTTPS_PORT`.
 In an apt installation, you would best do this in the file `/etc/default/openhab`.


### PR DESCRIPTION
CLARIFIED HTTPS SHOULD BE USED RATHER THAN HTTP. 

As written, it could confuse some readers. 