### PR TITLE
Change workflow permissions for fork pull requests.

### DIFF
--- a/.github/workflows/cherryPickAutomation.yml
+++ b/.github/workflows/cherryPickAutomation.yml
@@ -2,12 +2,10 @@ name: Cherry pick automation
 # Automatically create pull requests to release branches on condition
 
 on:
-  pull_request:
+  pull_request_target:
     branches:
       - main
     types: ["closed"]
-
-permissions: write-all
 
 jobs:
   cherry_pick_release_stable:


### PR DESCRIPTION
Trying to get cherry pick action to work with correct permissions on repo forks like explained here:
https://github.blog/2020-08-03-github-actions-improvements-for-fork-and-pull-request-workflows/