### PR TITLE
Remove requirement for compact profile 2 as those do not exist anymore for Java 11

### DIFF
--- a/developers/guidelines.md
+++ b/developers/guidelines.md
@@ -137,10 +137,7 @@ Data-transfer-objects (DTOs map from Json/XML to Java classes) do not require Ja
 
 ## D. Language Levels and Libraries
 
-1. openHAB generally targets the long time supported Java 11 releases with the following restrictions:
-
-- To allow optimized runtimes, the set of Java packages to be used is further restricted to [Compact Profile 2](https://www.oracle.com/technetwork/java/embedded/resources/tech/compact-profiles-overview-2157132.html).
-
+1. openHAB generally targets the long time supported Java 11 release.
 1. The [OSGi Core Release 7](https://osgi.org/download/r7/osgi.core-7.0.0.pdf) with [OSGI Compendium Release 7](https://osgi.org/download/r7/osgi.cmpn-7.0.0.pdf) is targeted, and newer features should not be used.
 1. [slf4j](http://slf4j.org) is used for logging.
 


### PR DESCRIPTION
Signed-off-by: Kai Kreuzer <kai@openhab.org>