### PR TITLE
Add default libraries for SSE

### DIFF
--- a/developers/guidelines.md
+++ b/developers/guidelines.md
@@ -355,3 +355,9 @@ For Web Socket Operations
 ::: tip Note
 WebSocketClient instances should be obtained by the handler factory through the WebSocketClientFactory service and unless there are specific configuration requirements, the shared instance should be used.
 :::
+
+For Server Sent Events (SSE) Operations
+
+- javax.ws.rs.client
+- javax.ws.rs.core
+- javax.ws.rs.sse


### PR DESCRIPTION
During the review of the Miele Cloud Binding I had a [discussion with @kaikreuzer regarding the use of JAX-RS as a library for SSE](https://github.com/openhab/openhab-addons/pull/9146#issuecomment-848951048). It seems to be common practice to use JAX-RS for SSE within openHAB and as the restriction to [compact profile 2 has been lifted](https://github.com/openhab/openhab-docs/pull/1602) I think this should be added here.

Signed-off-by: Björn Lange <bjoern.lange@tu-dortmund.de>