### PR TITLE
Update expire examples

### DIFF
--- a/configuration/items.md
+++ b/configuration/items.md
@@ -631,7 +631,7 @@ The first example shows a symbiosis of the LG webOS Binding and the Wake-on-LAN 
 
 While the `channel` parameter is used to link an item to a channel of a thing, it is possible to add further parameters for additional features.
 Parameters are provided as a comma separated list.
-The order of parameters doesn´t matter and is interchangeable.
+The order of the parameters does not matter.
   
 {: #autoupdate}
   

--- a/configuration/items.md
+++ b/configuration/items.md
@@ -629,7 +629,7 @@ The first example shows a symbiosis of the LG webOS Binding and the Wake-on-LAN 
 
 #### Parameters
 
-While the `channel` parameter is used to link an item to a channel of a thing, it´s possible to add additional parameters for more features.
+While the `channel` parameter is used to link an item to a channel of a thing, it is possible to add further parameters for additional features.
 Multiple parameters can be divided by a comma and a space.
 The order of parameters doesn´t matter and is interchangeable.
   

--- a/configuration/items.md
+++ b/configuration/items.md
@@ -630,7 +630,7 @@ The first example shows a symbiosis of the LG webOS Binding and the Wake-on-LAN 
 #### Parameters
 
 While the `channel` parameter is used to link an item to a channel of a thing, it is possible to add further parameters for additional features.
-Multiple parameters can be divided by a comma and a space.
+Parameters are provided as a comma separated list.
 The order of parameters doesn´t matter and is interchangeable.
   
 {: #autoupdate}

--- a/configuration/items.md
+++ b/configuration/items.md
@@ -666,11 +666,10 @@ This duration can optionally be followed by a comma and the state or command to 
 If this optional section is not present, it defaults to the Undefined (`UnDefType.UNDEF`) state.
 
 ```shell
-Player MyPlayer   { expire="1h,command=STOP" } // send STOP command after one hour
-Number MyChannel  { expire="5m,state=0" }      // update state to 0 after five minutes
-String MyMessage  { expire="3m12s,Hello" }     // update state to Hello after three minutes and 12 seconds
-Switch MySwitch   { expire="2h" }              // update state to Undefined two hours after last value
-Switch MyTrigger  { channel="openhab:speedtest:binding:trigger_test", expire="5s,command=OFF" } // update state to OFF after 5 seconds
+Player MyPlayer   { channel="xxx", expire="1h,command=STOP" } // send STOP command after one hour
+Number MyChannel  { channel="xxx", expire="5m,state=0" }      // update state to 0 after five minutes
+String MyMessage  { channel="xxx", expire="3m12s,Hello" }     // update state to Hello after three minutes and 12 seconds
+Switch MySwitch   { channel="xxx", expire="2h" }              // update state to Undefined two hours after last value
 ```
 
 Note that the `state=` part is optional.

--- a/configuration/items.md
+++ b/configuration/items.md
@@ -649,7 +649,8 @@ This parameter allows to post an update or command to an item after a period of 
 
 The expiration timer is started or restarted every time an item receives an update or a command *other than* the specified "expire" update/command.
 Any future expiring update or command is cancelled, if the item receives an update or command that matches the "expire" update/command.
-
+The expire parameter can also be combined with items that are connected to a channel.
+  
 The parameter accepts a duration of time that can be a combination of hours, minutes and seconds in the format
 
 ```shell
@@ -669,6 +670,7 @@ Player MyPlayer   { expire="1h,command=STOP" } // send STOP command after one ho
 Number MyChannel  { expire="5m,state=0" }      // update state to 0 after five minutes
 String MyMessage  { expire="3m12s,Hello" }     // update state to Hello after three minutes and 12 seconds
 Switch MySwitch   { expire="2h" }              // update state to Undefined two hours after last value
+Switch MyTrigger  { channel="openhab:speedtest:binding:trigger_test", expire="5s,command=OFF" } // update state to OFF after 5 seconds
 ```
 
 Note that the `state=` part is optional.

--- a/configuration/items.md
+++ b/configuration/items.md
@@ -657,7 +657,6 @@ This parameter allows to post an update or command to an item after a period of 
 
 The expiration timer is started or restarted every time an item receives an update or a command *other than* the specified "expire" update/command.
 Any future expiring update or command is cancelled, if the item receives an update or command that matches the "expire" update/command.
-The expire parameter can also be combined with items that are connected to a channel.
   
 The parameter accepts a duration of time that can be a combination of hours, minutes and seconds in the format
 

--- a/configuration/items.md
+++ b/configuration/items.md
@@ -625,9 +625,17 @@ Switch Office_PC {
 
 The first example shows a symbiosis of the LG webOS Binding and the Wake-on-LAN Binding to interact with a TV.
 
-{: #autoupdate}
+{: #parameters}
 
-#### Parameter `autoupdate`
+#### Parameters
+
+While the `channel` parameter is used to link an item to a channel of a thing, it´s possible to add additional parameters for more features.
+Multiple parameters can be divided by a comma and a space.
+The order of parameters doesn´t matter and is interchangeable.
+  
+{: #autoupdate}
+  
+##### Parameter `autoupdate`
 
 When left as default, openHAB's `autoupdate` function attempts to predict the outcome of a *command* on the Item *state*.
 This prediction may be influenced by any linked channels.
@@ -643,7 +651,7 @@ Switch Garage_Gate {channel="xxx", autoupdate="false"}
 
 {: #expire}
 
-#### Parameter `expire`
+##### Parameter `expire`
 
 This parameter allows to post an update or command to an item after a period of time has passed.
 
@@ -666,7 +674,7 @@ This duration can optionally be followed by a comma and the state or command to 
 If this optional section is not present, it defaults to the Undefined (`UnDefType.UNDEF`) state.
 
 ```shell
-Player MyPlayer   { channel="xxx", expire="1h,command=STOP" } // send STOP command after one hour
+Player MyPlayer   { expire="1h,command=STOP" }                // send STOP command after one hour
 Number MyChannel  { channel="xxx", expire="5m,state=0" }      // update state to 0 after five minutes
 String MyMessage  { channel="xxx", expire="3m12s,Hello" }     // update state to Hello after three minutes and 12 seconds
 Switch MySwitch   { channel="xxx", expire="2h" }              // update state to Undefined two hours after last value


### PR DESCRIPTION
Added a description that the expire parameter can be combined with items that are connected to a channel.
Added an example to show the correct syntax when combining channels and expire.

Signed-off-by: Michael Bredehorn michael@bredehorn.nrw (github: bredmich)