### PR TITLE
Update floorplan-pages.md to show URL details required

### DIFF
--- a/ui/floorplan-pages.md
+++ b/ui/floorplan-pages.md
@@ -21,7 +21,17 @@ The `tooltipStyles` property can be configured in YAML to set additional CSS pro
 
 ## Building a Floorplan Page
 
-In the Design view, configure the properties below Page Configuration.
+In the Design view, configure the properties below Background Configuration.
+
+Images should be stored in /conf/html/[your directory]/
+
+Image URL:
+  /static/[your directory]/[your image file]
+
+    e.g: /static/floorplan/FloorPlan3Dsmall.jpg
+
+Image Width and Image Height:
+  Enter the actual sizes of your image
 
 To add markers, you can do it either:
 


### PR DESCRIPTION
Add some detail to the Floor Plan documentation to show the correct URL to use for Browser and Android App to prevent blank images on the Android app related to non relative URL

Signed-off-by: Mark van Gelder <vangelder.mark@gmail.com>