### PR TITLE
Removed author-tags in binding definitions

### DIFF
--- a/developers/utils/i18n.md
+++ b/developers/utils/i18n.md
@@ -76,7 +76,6 @@ XML file (`binding.xml`):
     <name>YahooWeather Binding</name>
     <description>The Yahoo Weather Binding requests the Yahoo Weather Service
         to show the current temperature, humidity and pressure.</description>
-    <author>Kai Kreuzer</author>
 </binding:binding>
 ```
 
@@ -421,7 +420,6 @@ XML file (`binding.xml`):
 <binding:binding id="yahooweather">
     <name>@text/bindingName</name>
     <description>@text/bindingName</description>
-    <author>Kai Kreuzer</author>
 </binding:binding>
 ```
 


### PR DESCRIPTION
- Removed author-tags in binding definitions

Signed-off-by: Christoph Weitkamp <github@christophweitkamp.de>