### PR TITLE
Removed author-tags from binding definitions

### DIFF
--- a/developers/guidelines.md
+++ b/developers/guidelines.md
@@ -29,12 +29,12 @@ The structure of a binding follows the structure of a typical OSGi bundle projec
 |- doc                   Images and other assets used in the Readme.md
 |- src/main
 |---- feature
-|-------- feature.xml   Your OSGI feature file
-|---- java             Your Java code
+|-------- feature.xml     Your OSGI feature file
+|---- java                Your Java code
 |-------- org/openhab/[...]
 |- src/main/resources/OH-INF
 |---- binding
-|-------- binding.xml      Binding name, description, author and other meta data
+|-------- binding.xml     Binding name, description and other meta data
 |---- config              Configuration description files when not in things files
 |-------- *.xml
 |---- i18n                Your localized binding texts
@@ -42,9 +42,9 @@ The structure of a binding follows the structure of a typical OSGi bundle projec
 |---- thing               One or more xml files with thing descriptions
 |-------- *.xml
 |- src/test
-|---- java             It's easy to write unit tests and fellow developers will thank you
+|---- java                It's easy to write unit tests and fellow developers will thank you
 |-------- org/openhab/[...]
-|---- resources        Any resource files used in your unit tests, like test data
+|---- resources           Any resource files used in your unit tests, like test data
 |-------- [...]
 |- NOTICE                 License information
 |                         3rd party content has to be given in the NOTICE file


### PR DESCRIPTION
- Removed author-tags from binding definitions

Signed-off-by: Christoph Weitkamp <github@christophweitkamp.de>