### PR TITLE
Remove broken link to Raspberry Pi page

### DIFF
--- a/installation/index.md
+++ b/installation/index.md
@@ -28,7 +28,7 @@ Always keep this in mind when searching for help and solutions.
 Many devices are suited to host a continuous installation of openHAB.
 Experiences with different devices and environments can be found in the [community forum hardware section](https://community.openhab.org/c/hardware/server).
 
-The [Raspberry Pi](rasppi.html) as a minimal sufficient device is quite popular, especially as we offer a quick setup with [openHABian](openhabian.html).
+The Raspberry Pi as a minimal sufficient device is quite popular, especially as we offer a quick setup with [openHABian](openhabian.html).
 A popular alternative is [our solution for the Synology DiskStation](synology.html), which many users already own in their homes.
 The previously mentioned [openHABian](openhabian.html) can also be used to kickstart your openHAB experience on existing Debian/Ubuntu based Linux systems.
 


### PR DESCRIPTION
This page was removed with https://github.com/openhab/openhab-docs/pull/1533.

Fixes https://github.com/openhab/openhab-docs/issues/1615