### PR TITLE
Update sitemaps.md

### DIFF
--- a/ui/sitemaps.md
+++ b/ui/sitemaps.md
@@ -5,7 +5,11 @@ title: Sitemaps
 
 # Sitemaps
 
-Sitemaps have existed since the first versions of openHAB. Therefore you will probably encounter a lot of examples referring to them throughout the documentation and in older community discussions. ⚠️ **Keep in mind that the main UI is not currently able to display them**. If you are a new user, it's probably a good idea to start [customizing your Overview page first]({{base}}/tutorial/auto_overview.html#customization-page-configuration).
+::: tip
+Sitemaps have existed since the first versions of openHAB. Therefore you will probably encounter a lot of examples referring to them throughout the documentation and in older community discussions.
+⚠️ **Keep in mind that the main UI is not currently able to display them**.
+If you are a new user, it's probably a good idea to start [customizing your Overview page first]({{base}}/tutorial/auto_overview.html#customization-page-configuration).
+:::
 
 In openHAB a collection of [Things]({{base}}/concepts/things.html) and [Items]({{base}}/concepts/items.html) represent physical or logical objects in the user's home automation setup.
 Sitemaps are one way to select and compose these elements into a user-oriented representation for various User Interfaces (UIs), including [BasicUI]({{base}}/configuration/ui/basic/) and the [openHAB app for Android]({{base}}/apps/android.html).

--- a/ui/sitemaps.md
+++ b/ui/sitemaps.md
@@ -5,8 +5,10 @@ title: Sitemaps
 
 # Sitemaps
 
+Sitemaps have existed since the first versions of openHAB. Therefore you will probably encounter a lot of examples referring to them throughout the documentation and in older community discussions. ⚠️ **Keep in mind that the main UI is not currently able to display them**. If you are a new user, it's probably a good idea to start [customizing your Overview page first]({{base}}/tutorial/auto_overview.html#customization-page-configuration).
+
 In openHAB a collection of [Things]({{base}}/concepts/things.html) and [Items]({{base}}/concepts/items.html) represent physical or logical objects in the user's home automation setup.
-Sitemaps are used to select and prepare these elements in order to compose a user-oriented presentation of this setup for various User Interfaces (UIs), including [BasicUI]({{base}}/configuration/ui/basic/), the [openHAB app for Android]({{base}}/apps/android.html) and others.
+Sitemaps are one way to select and compose these elements into a user-oriented representation for various User Interfaces (UIs), including [BasicUI]({{base}}/configuration/ui/basic/) and the [openHAB app for Android]({{base}}/apps/android.html).
 
 This page is structured as follows:
 


### PR DESCRIPTION
As a new user, I was frustrated to find this out far too late. I really did read, twice, the page about sitemaps. I didn't understand why I couldn't see the results as in the screenshots. Where is it? Am I crazy?

There is so much documentation, a new user is not going to read every page. They learn, read or hear that they would need a sitemap, so that's what they are going to read in the documentation. They are not going to read a [different page](https://www.openhab.org/docs/ui/) first, where the above warning is present.

I advise all documentation writers to keep, move or duplicate all important information surrounding a subject _on the page about that subject_.

If you don't like the wording, just change it to your liking. You get the global idea. :heart: 
![image](https://user-images.githubusercontent.com/1702193/142639375-456f69d6-c915-4582-ab9a-95b0f0be2385.png)
