### PR TITLE
Add doc fetch actions

### DIFF
--- a/.github/workflows/fetch_docs_openhabian.yml
+++ b/.github/workflows/fetch_docs_openhabian.yml
@@ -1,0 +1,18 @@
+name: Fetch openHABian Docs
+
+on:
+  # Repository dispatch event, to be triggerd by an openhabian release
+  # or manually from the openhabian repository
+  repository_dispatch:
+    types: [update-openhabian-docs-event]
+  workflow_dispatch:
+
+jobs:
+  call-reusable-fetch-workflow:
+    uses: openhab/openhab-docs/.github/workflows/fetch_external_docs_reusable.yml@main
+    with:
+      base_source_repository: openhabian
+      base_folder: installation
+      doc_base_name: openhabian
+      has_images: true
+      image_base_name: openHABian

--- a/.github/workflows/fetch_external_docs_reusable.yml
+++ b/.github/workflows/fetch_external_docs_reusable.yml
@@ -64,7 +64,6 @@ jobs:
         run: |
           echo "Copy current doc contents"
           cp -v ./external_contents/${{inputs.base_source_repository}}/docs/${{inputs.doc_base_name}}*.md ${{inputs.base_folder}}
-          cp -v ./external_contents/${{inputs.base_source_repository}}/docs/images/${{inputs.image_base_name}}* ${{inputs.base_folder}}/images
 
       # Copy images only if flag is set to true
       - name: Copy newest images

--- a/.github/workflows/fetch_external_docs_reusable.yml
+++ b/.github/workflows/fetch_external_docs_reusable.yml
@@ -1,0 +1,96 @@
+name: Fetch Docs Reusable
+# Generic action for fetching doc contents
+# This action is meant to be called by a detailled action for a specific repository, defining the needed parameters
+
+on:
+  workflow_call:
+    inputs:
+      base_target_branch:
+        description: 'The branch to check out in the target repository. Defaults to `final-stable`.'
+        default: 'final-stable'
+        required: false
+        type: string
+      base_source_organization:
+        description: 'The organization or user, that is holding the base repository. Defaults to `openhab`.'
+        default: 'openhab'
+        required: false
+        type: string
+      base_source_repository:
+        description: 'The repository that holds the source contents to copy.'
+        required: true
+        type: string
+      base_source_branch:
+        description: 'The branch that contents should get copied. Defaults to `main`.'
+        default: 'main'
+        required: false
+        type: string
+      base_folder:
+        description: 'The folder that is holding the contents in the target repository.'
+        required: true
+        type: string
+      doc_base_name:
+        description: 'The doc file name prefix for lookup options.'
+        required: true
+        type: string
+      has_images:
+        description: 'Flag for enabling image copy commands.'
+        required: true
+        type: boolean
+      image_base_name:
+        description: 'The image name prefix for lookup options'
+        required: true
+        type: string
+
+jobs:
+  fetchDocs:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2.4.0
+        with:
+          ref: ${{inputs.base_target_branch}}
+
+      - name: Checkout external repository
+        uses: actions/checkout@v2.4.0
+        with:
+          repository: ${{inputs.base_source_organization}}/${{inputs.base_source_repository}}
+          path: './external_contents/${{inputs.base_source_repository}}'
+
+      - name: Remove existing doc contents
+        run: find ${{inputs.base_folder}} -iname "${{inputs.doc_base_name}}*" -type f -delete
+
+      - name: Copy newest doc contents
+        run: |
+          echo "Copy current doc contents"
+          cp -v ./external_contents/${{inputs.base_source_repository}}/docs/${{inputs.doc_base_name}}*.md ${{inputs.base_folder}}
+          cp -v ./external_contents/${{inputs.base_source_repository}}/docs/images/${{inputs.image_base_name}}* ${{inputs.base_folder}}/images
+
+      # Copy images only if flag is set to true
+      - name: Copy newest images
+        if: ${{ inputs.has_images == true}}
+        run: |
+          echo "Copy current images"
+          cp -v ./external_contents/${{inputs.base_source_repository}}/docs/images/${{inputs.image_base_name}}* ${{inputs.base_folder}}/images
+
+      - name: Remove external repositories
+        run: rm -rf ./external_contents
+
+      # Create an automated pull request, if the resulting branch is ahead of the `base-target-branch`
+      - name: Create Pull Request
+        id: cpr
+        uses: peter-evans/create-pull-request@v3
+        with:
+          commit-message: Automated ${{inputs.base_source_repository}} Docs fetch
+          committer: openHAB Bot <info@openhab.org>
+          author: openHAB Bot <info@openhab.org>
+          branch: automated/fetch_${{inputs.base_source_repository}}_docs
+          delete-branch: true
+          title: "[Automated] Fetch ${{inputs.base_source_repository}} docs"
+          labels: |
+            automated_pr
+
+      - name: Check outputs
+        run: |
+          echo "Pull Request Number - ${{ steps.cpr.outputs.pull-request-number }}"
+          echo "Pull Request URL - ${{ steps.cpr.outputs.pull-request-url }}"


### PR DESCRIPTION
This will add a reusable action base for fetching external docs contents.

## Goal

Provide updated "stable" docs for parts of openHAB, that have their own indipendent release cycle.

## Workflow

### Reusable template action

The introduced reusable action is meant to be called from other repo based actions.
It will check for matching files based on a given configuration and remove the current existing doc files.
After that it will copy the newest available version from the external repository.

### Detailled repository action

A detailed action can be added per external repository.
This action simply calls the reuseable action with a repository specific configuration.
As a proof of concept the first repository based action comes with this pr and enables this workflow for the [openhab/openhabian](https://github.com/openhab/openhabian) repository.

### External trigger events

The detailled repository action is able to get triggered from the external repo through the `repository_dispatch` event.
This needs a personal access token, with `public_repo` access for the openhab-docs repository.

The external repo can then actively trigger a docs update. (For example when a new openHABian version is released.)

