### PR TITLE
Updated external content (Jenkins build 692)

### DIFF
--- a/_addons_bindings/touchwand/readme.md
+++ b/_addons_bindings/touchwand/readme.md
@@ -23,10 +23,10 @@ TouchWand products are compatible with most major Z-Wave products, IP controlled
 ## Supported Things
 
 This binding supports switches, shutters dimmers alarm sensors and wall controllers configured in Touchwand Wanderfull™ Hub Controller.
-The binding also supports [AcWand™](http://www.touchwand.com/products/touchwand-acwand/) - smart control for your air conditioner controller.
+The binding also supports [AcWand™](https://www.touchwand.com/products/touchwand-acwand/) - smart control for your air conditioner controller.
 
 
-![AcWand](http://www.touchwand.com/wp-content/uploads/2019/04/AcWand-300x350.png)
+![AcWand](https://www.touchwand.com/wp-content/uploads/2019/04/AcWand-300x350.png)
 
 
 ## Control and Status


### PR DESCRIPTION
This will add a small change into the stable docs, which will prevent the netlify website builds from throwing insecure mixed content warnings.