### PR TITLE
Remove references to Yahoo in developer documentation

### DIFF
--- a/developers/bindings/index.md
+++ b/developers/bindings/index.md
@@ -185,8 +185,6 @@ All configuration values will be mapped to properties of the class.
 The type of the property must match the type of the configuration.
 The following types are supported for configuration values: `Boolean`, `boolean`, `String`, `BigDecimal`, `int`, `long`, `float` and `double`.
 
-For example, the Yahoo Weather binding allows configuration of the location and the refresh frequency.
-
 ### Properties
 
 *Things* can have properties.


### PR DESCRIPTION
- Remove references to Yahoo in developer documentation

Signed-off-by: Christoph Weitkamp <github@christophweitkamp.de>