### PR TITLE
Renamed Yahoo to ACME

### DIFF
--- a/developers/utils/i18n.md
+++ b/developers/utils/i18n.md
@@ -49,10 +49,10 @@ Example files:
 ```text
 |- OH-INF
 |---- i18n
-|------- yahooweather.properties
-|------- yahooweather_de.properties
-|------- yahooweather_de_DE.properties
-|------- yahooweather_fr.properties
+|------- acmeweather.properties
+|------- acmeweather_de.properties
+|------- acmeweather_de_DE.properties
+|------- acmeweather_fr.properties
 ```
 
 ## Internationalize Binding XML files
@@ -67,38 +67,38 @@ Typically all texts for a binding are put into one file with name of the binding
 
 ### Binding Definition
 
-The following snippet shows the binding XML file of the Yahoo Weather Binding and its language file that localizes the binding name and description for the German language.
+The following snippet shows the binding XML file of an ACME Weather Binding and its language file that localizes the binding name and description for the German language.
 
 XML file (`binding.xml`):
 
 ```xml
-<binding:binding id="yahooweather">
-    <name>YahooWeather Binding</name>
-    <description>The Yahoo Weather Binding requests the Yahoo Weather Service
+<binding:binding id="acmeweather">
+    <name>ACME Weather Binding</name>
+    <description>The ACME Weather Binding requests the ACME Weather Service
         to show the current temperature, humidity and pressure.</description>
 </binding:binding>
 ```
 
-Language file (`yahooweather_de.properties`):
+Language file (`acmeweather_de.properties`):
 
 ```ini
-binding.yahooweather.name = Yahoo Wetter Binding
-binding.yahooweather.description = Das Yahoo Wetter Binding stellt verschiedene Wetterdaten wie die Temperatur, die Luftfeuchtigkeit und den Luftdruck für konfigurierbare Orte vom yahoo Wetterdienst bereit.
+binding.acmeweather.name =ACME Wetter Binding
+binding.acmeweather.description = Das ACME Wetter Binding stellt verschiedene Wetterdaten wie die Temperatur, die Luftfeuchtigkeit und den Luftdruck für konfigurierbare Orte vom ACME Wetterdienst bereit.
 ```
 
 So the key for referencing the name of a binding is `binding.<binding-id>.name` and `binding.<binding-id>.description` for the description text.
 
 ### Thing Types
 
-The following snippet shows an excerpt of the thing type definition XML file of the Yahoo Weather Binding and its language file that localizes labels and descriptions for the German language.
+The following snippet shows an excerpt of the thing type definition XML file of an ACME Weather Binding and its language file that localizes labels and descriptions for the German language.
 
 XML file (`thing-types.xml`):
 
 ```xml
-<thing:thing-descriptions bindingId="yahooweather">
+<thing:thing-descriptions bindingId="acmeweather">
     <thing-type id="weather">
         <label>Weather Information</label>
-        <description>Provides various weather data from the Yahoo service</description>
+        <description>Provides various weather data from the ACME Weather Service.</description>
         <channels>
             <channel id="precipitation" typeId="precipitation" />
             <channel id="temperature" typeId="temperature" />
@@ -110,8 +110,7 @@ XML file (`thing-types.xml`):
         <config-description>
             <parameter name="location" type="text">
                 <label>Location</label>
-                <description>Location for the weather information. Syntax is WOEID, see https://en.wikipedia.org/wiki/WOEID.
-                </description>
+                <description>Location for the weather information. Syntax is WOEID, see https://en.wikipedia.org/wiki/WOEID.</description>
                 <required>true</required>
             </parameter>
         </config-description>
@@ -160,36 +159,36 @@ XML file (`thing-types.xml`):
 </thing:thing-descriptions>
 ```
 
-Language file (`yahooweather_de.properties`):
+Language file (`acmeweather_de.properties`):
 
 ```ini
-thing-type.yahooweather.weather.label = Wetterinformation
-thing-type.yahooweather.weather.description = Stellt verschiedene Wetterdaten vom Yahoo Wetterdienst bereit.
+thing-type.acmeweather.weather.label = Wetterinformation
+thing-type.acmeweather.weather.description = Stellt verschiedene Wetterdaten vom ACME Wetterdienst bereit.
 
-thing-type.config.yahooweather.weather.location.label = Ort
-thing-type.config.yahooweather.weather.location.description = Ort der Wetterinformation. Syntax ist WOEID, siehe https://en.wikipedia.org/wiki/WOEID.
+thing-type.config.acmeweather.weather.location.label = Ort
+thing-type.config.acmeweather.weather.location.description = Ort der Wetterinformation. Syntax ist WOEID, siehe https://en.wikipedia.org/wiki/WOEID.
 
-channel-type.yahooweather.precipitation.label = Niederschlag
-channel-type.yahooweather.precipitation.description = Aktueller Niederschlag (Trocken, Regen, Schnee).
-channel-type.yahooweather.precipitation.state.option.dry = Trocken
-channel-type.yahooweather.precipitation.state.option.rain = Regen
-channel-type.yahooweather.precipitation.state.option.snow = Schnee
+channel-type.acmeweather.precipitation.label = Niederschlag
+channel-type.acmeweather.precipitation.description = Aktueller Niederschlag (Trocken, Regen, Schnee).
+channel-type.acmeweather.precipitation.state.option.dry = Trocken
+channel-type.acmeweather.precipitation.state.option.rain = Regen
+channel-type.acmeweather.precipitation.state.option.snow = Schnee
 
-channel-type.yahooweather.temperature.label = Temperatur
-channel-type.yahooweather.temperature.description = Aktuelle Temperatur in Grad Celsius (Metrisch) oder Grad Fahrenheit (US).
-channel-type.yahooweather.temperature.state.pattern = %d Wert
+channel-type.acmeweather.temperature.label = Temperatur
+channel-type.acmeweather.temperature.description = Aktuelle Temperatur in Grad Celsius (Metrisch) oder Grad Fahrenheit (US).
+channel-type.acmeweather.temperature.state.pattern = %d Wert
 
-thing-type.yahooweather.weather.channel.minTemperature.label = Min. Temperatur
-thing-type.yahooweather.weather.channel.minTemperature.description = Minimale Temperatur in Grad Celsius (Metrisch) oder Grad Fahrenheit (US).
+thing-type.acmeweather.weather.channel.minTemperature.label = Min. Temperatur
+thing-type.acmeweather.weather.channel.minTemperature.description = Minimale Temperatur in Grad Celsius (Metrisch) oder Grad Fahrenheit (US).
 
-channel-type.config.yahooweather.temperature.unit.label = Temperatur Einheit
-channel-type.config.yahooweather.temperature.unit.description = Auswahl der gewünschten Temperatur Einheit.
-channel-type.config.yahooweather.temperature.unit.option.C = Grad Celsius
-channel-type.config.yahooweather.temperature.unit.option.F = Grad Fahrenheit
+channel-type.config.acmeweather.temperature.unit.label = Temperatur Einheit
+channel-type.config.acmeweather.temperature.unit.description = Auswahl der gewünschten Temperatur Einheit.
+channel-type.config.acmeweather.temperature.unit.option.C = Grad Celsius
+channel-type.config.acmeweather.temperature.unit.option.F = Grad Fahrenheit
 
-channel-type.yahooweather.cmd-channel.command.option.RESET = Reset Device
-channel-type.yahooweather.cmd-channel.command.option.CMD1 = Command one
-channel-type.yahooweather.cmd-channel.command.option.CMD2 = Command two
+channel-type.acmeweather.cmd-channel.command.option.RESET = Reset Device
+channel-type.acmeweather.cmd-channel.command.option.CMD1 = Command one
+channel-type.acmeweather.cmd-channel.command.option.CMD2 = Command two
 ```
 
 So the key for referencing a label of a defined thing type is `thing-type.<binding-id>.<thing-type-id>.label`.
@@ -211,11 +210,11 @@ XML file (`thing-types.xml`):
             <channel-group id="current" typeId="current" />
             <channel-group id="forecastTomorrow" typeId="forecast">
                 <label>Weather Forecast Tomorrow</label>
-                <description>This is the weather forecast for tomorrow</description>
+                <description>This is the weather forecast for tomorrow.</description>
             </channel-group>
             <channel-group id="forecastDay2" typeId="forecast">
                 <label>Weather Forecast Day 2</label>
-                <description>This is the weather forecast in two days</description>
+                <description>This is the weather forecast in two days.</description>
             </channel-group>
         </channel-groups>
 
@@ -223,15 +222,15 @@ XML file (`thing-types.xml`):
             <parameter name="apikey" type="text" required="true">
                 <context>password</context>
                 <label>API Key</label>
-                <description>API key to access the Weather Underground service</description>
+                <description>API key to access the Weather Underground service.</description>
             </parameter>
             <parameter name="location" type="text" required="true">
                 <label>Location of Weather Information</label>
-                <description>Multiple syntaxes are supported. Please read the binding documentation for more information</description>
+                <description>Multiple syntaxes are supported. Please read the binding documentation for more information.</description>
             </parameter>
             <parameter name="language" type="text" required="false">
                 <label>Language</label>
-                <description>Language to be used by the Weather Underground service</description>
+                <description>Language to be used by the Weather Underground service.</description>
                 <options>
                     <option value="EN">English</option>
                     <option value="FR">French</option>
@@ -248,7 +247,7 @@ XML file (`thing-types.xml`):
 
     <channel-group-type id="current">
         <label>Current Weather</label>
-        <description>This is the current weather</description>
+        <description>This is the current weather.</description>
         <channels>
             <channel id="conditions" typeId="currentConditions" />
             <channel id="temperature" typeId="temperature" />
@@ -257,7 +256,7 @@ XML file (`thing-types.xml`):
 
     <channel-group-type id="forecast">
         <label>Weather Forecast</label>
-        <description>This is the weather forecast</description>
+        <description>This is the weather forecast.</description>
         <channels>
             <channel id="temperature" typeId="temperature">
                 <label>Temperature</label>
@@ -270,20 +269,20 @@ XML file (`thing-types.xml`):
     <channel-type id="currentConditions">
         <item-type>String</item-type>
         <label>Current Conditions</label>
-        <description>Weather current conditions</description>
+        <description>Weather current conditions.</description>
         <state readOnly="true" pattern="%s"></state>
     </channel-type>
 
     <channel-type id="temperature">
         <item-type>Number</item-type>
         <label>Temperature</label>
-        <description>Current temperature</description>
+        <description>Current temperature.</description>
         <category>Temperature</category>
         <state readOnly="true" pattern="%.1f" />
         <config-description>
             <parameter name="SourceUnit" type="text" required="true">
                 <label>Temperature Source Unit</label>
-                <description>Select the temperature unit provided by the Weather Underground service</description>
+                <description>Select the temperature unit provided by the Weather Underground service.</description>
                 <options>
                     <option value="C">Degree Celsius</option>
                     <option value="F">Degree Fahrenheit</option>
@@ -296,13 +295,13 @@ XML file (`thing-types.xml`):
     <channel-type id="maxTemperature">
         <item-type>Number</item-type>
         <label>Maximum Temperature</label>
-        <description>Maximum temperature</description>
+        <description>Maximum temperature.</description>
         <category>Temperature</category>
         <state readOnly="true" pattern="%.1f" />
         <config-description>
             <parameter name="SourceUnit" type="text" required="true">
                 <label>Maximum Temperature Source Unit</label>
-                <description>Select the maximum temperature unit provided by the Weather Underground service</description>
+                <description>Select the maximum temperature unit provided by the Weather Underground service.</description>
                 <options>
                     <option value="C">Degree Celsius</option>
                     <option value="F">Degree Fahrenheit</option>
@@ -417,26 +416,26 @@ The following snippet shows a binding XML that uses custom keys:
 XML file (`binding.xml`):
 
 ```xml
-<binding:binding id="yahooweather">
+<binding:binding id="acmeweather">
     <name>@text/bindingName</name>
     <description>@text/bindingName</description>
 </binding:binding>
 ```
 
-Language file (`yahooweather_en.properties`):
+Language file (`acmeweather_en.properties`):
 
 ```ini
-bindingName = Yahoo Weather Binding
+bindingName = ACME Weather Binding
 
-offline.communication-error=The Yahoo Weather API is currently not available.
+offline.communication-error=The ACME Weather API is currently not available.
 ```
 
-Language file (`yahooweather_de.properties`):
+Language file (`acmeweather_de.properties`):
 
 ```ini
-bindingName = Yahoo Wetter Binding
+bindingName = ACME Wetter Binding
 
-offline.communication-error=Die Yahoo Wetter API ist zur Zeit nicht verfügbar.
+offline.communication-error=Die ACME Wetter API ist zur Zeit nicht verfügbar.
 ```
 
 The custom keys are a very good practice to translate bundle dependent error messages.


### PR DESCRIPTION
- Renamed Yahoo to ACME

Yahoo ended their service whereas A Company that Manufactures/Makes Everything is still providing weather data. 😉

Signed-off-by: Christoph Weitkamp <github@christophweitkamp.de>