### PR TITLE
Update timer example

### DIFF
--- a/addons/actions.md
+++ b/addons/actions.md
@@ -167,7 +167,7 @@ then
         }
     } else {
         logInfo("rules", "Timer canceled")
-        myTimer.cancel()
+        myTimer?.cancel()
         myTimer = null
     }
 end


### PR DESCRIPTION
Make sure that `myTimer` is not null when invoking the cancel() method