### PR TITLE
Add forceAsItem-Option for Charts in Sitemaps

### DIFF
--- a/ui/sitemaps.md
+++ b/ui/sitemaps.md
@@ -442,6 +442,7 @@ Video url="https://demo.openhab.org/Hue.m4v"
 ```perl
 Chart [item=<itemname>] [icon="<iconname>"] [label="<labelname>"] [refresh=xxxx]
 [period=xxxx] [service="<service>"] [begin=yyyyMMddHHmm] [end=yyyyMMddHHmm] [legend=true/false]
+[forceAsItem=true/false]
 ```
 
 Adds a time-series chart object for the display of logged data.
@@ -460,6 +461,8 @@ Adds a time-series chart object for the display of logged data.
 - `legend` is used to show or to hide the chart legend.
     Valid values are `true` (always show the legend) and `false` (never show the legend).
     If this parameter is not set, the legend is hidden if there is only one chart series.
+    
+- `forceAsItem` is used to show the value of a `Group` instead of showing a graph for each member (which is the default).
 
 Visit [Charts](https://github.com/openhab/openhab/wiki/Charts) in the Wiki for examples.
 


### PR DESCRIPTION
This is documentation for https://github.com/openhab/openhab-core/issues/2185.

This feature usable in the Basic UI and will soon be usable in the Android-App (just needs testing before it's merged). Status for the iOS App is unknown, but since it's implemented in openhab-core aswell as the Basic UI it should be documented.