### PR TITLE
Replace OH_CONF with OPENHAB_CONF

### DIFF
--- a/tutorials/getting_started/auto_overview.md
+++ b/tutorials/getting_started/auto_overview.md
@@ -179,7 +179,7 @@ config:
   invertText: false
 ```
 
-Place your custom imge files in `$OH_CONF/html`.
+Place your custom imge files in `$OPENHAB_CONF/html`.
 Once they are there, you can use the relative path `/static/image.name` as the URL to the image.
 For example, I placed the file `garage.jpg` in `/etc/openhab/html` and referenced it as you see in the YAML above.
 This is how you use a custom image as the background of a card.


### PR DESCRIPTION
cd $OH_CONF is invalid

sudo openhab-cli info

Version:     3.2.0 (Build)

User:        openhab (Active Process 535)
User Groups: openhab tty dialout audio

Directories: Folder Name      | Path                        | User:Group
             -----------      | ----                        | ----------
             OPENHAB_HOME     | /usr/share/openhab          | openhab:openhab
             OPENHAB_RUNTIME  | /usr/share/openhab/runtime  | openhab:openhab
             OPENHAB_USERDATA | /var/lib/openhab            | openhab:openhab
             OPENHAB_CONF     | /etc/openhab                | openhab:openhab
             OPENHAB_LOGDIR   | /var/log/openhab            | openhab:openhabian
             OPENHAB_BACKUPS  | /var/lib/openhab/backups    | openhab:openhab