### PR TITLE
[JSR223] Mention difference between NashornJS and GraalJS

### DIFF
--- a/configuration/jsr223.md
+++ b/configuration/jsr223.md
@@ -14,7 +14,13 @@ and are comfortable working with the command line prompt of the operating system
 
 [JSR223](https://docs.oracle.com/javase/8/docs/technotes/guides/scripting/) ([spec](https://jcp.org/aboutJava/communityprocess/pr/jsr223/index.html)) is a standard scripting API for Java Virtual Machine (JVM) [languages](https://en.wikipedia.org/wiki/List_of_JVM_languages).
 The JVM languages provide varying levels of support for the JSR223 API and interoperability with the Java runtime.
-Currently the following languages are known to work well for openHAB scripting: [**Apache Groovy**](/addons/automation/groovyscripting/) (JVM scripting language), [**JavaScript**](/addons/automation/jsscripting/), [**Ruby**](/addons/automation/jrubyscripting/), and [**Jython**](https://www.openhab.org/addons/automation/jythonscripting/) (Python on the JVM).
+Currently the following languages are known to work well for openHAB scripting: [**Apache Groovy**](/addons/automation/groovyscripting/) (JVM scripting language), **JavaScript/ECMA - 262 Edition 5.1**, [**JavaScript/ECMAScript 262 Edition 11**](/addons/automation/jsscripting/), [**Ruby**](/addons/automation/jrubyscripting/), and [**Jython**](https://www.openhab.org/addons/automation/jythonscripting/) (Python on the JVM).
+
+Please note that **JavaScript/ECMA - 262 Edition 5.1** (whose setup is described here) is using an older engine called NashornJS, which has been removed from JDK 15 and will be unavailable one day. 
+Moreover, you need to work with the raw openHAB Java APIs in this JavaScript environment which is not easy.
+In contrast to this, [**JavaScript/ECMAScript 262 Edition 11**](/addons/automation/jsscripting/) supports the latest **ES6** features like `let` and `const` by using a new engine called GraalJS. 
+It is recommended to use the [**JavaScript/ECMAScript 262 Edition 11**](/addons/automation/jsscripting/), also known as [JS Scripting](/addons/automation/jsscripting/), 
+because of the [openHAB JavaScript library](https://github.com/openhab/openhab-js/) which provides convenient access to the openHAB APIs just with plain JavaScript - no messing with Java is needed.
 
 Although JSR223 scripts can be used as a general-purpose extension language for openHAB, it is most commonly used for the creation of rules, and within scripted Actions or Conditions.
 Currently, openHAB allows JSR223 scripting to access all packages, which may not be included in the official APIs.
@@ -25,7 +31,7 @@ New APIs are planned to be implemented in the future, which will provide standar
 
 :::: tabs
 
-::: tab JavaScript
+::: tab JavaScript/ECMAScript - 262 Edition 5.1
 
 ```js
 'use strict';


### PR DESCRIPTION
Fixes https://github.com/openhab/openhab-js/issues/139.

This explains the difference between the two available JavaScript options and recommends to use JS Scripting.

Signed-off-by: Florian Hotze <florianh_dev@icloud.com>