### PR TITLE
Fixing once again pgp vs gpg

### DIFF
--- a/installation/linux.md
+++ b/installation/linux.md
@@ -87,7 +87,7 @@ Then, you can choose between, *Official (Stable)*, *Beta* or *Snapshot* builds:
     Add the **openHAB Stable Repository** to your systems apt sources list:
 
     ```shell
-    echo 'deb [signed-by=/usr/share/keyrings/openhab.pgp] https://openhab.jfrog.io/artifactory/openhab-linuxpkg stable main' | sudo tee /etc/apt/sources.list.d/openhab.list
+    echo 'deb [signed-by=/usr/share/keyrings/openhab.gpg] https://openhab.jfrog.io/artifactory/openhab-linuxpkg stable main' | sudo tee /etc/apt/sources.list.d/openhab.list
     ```
 
 - **Testing Release**
@@ -97,7 +97,7 @@ Then, you can choose between, *Official (Stable)*, *Beta* or *Snapshot* builds:
     Add the **openHAB Beta Repository** to your systems apt sources list:
 
     ```shell
-    echo 'deb [signed-by=/usr/share/keyrings/openhab.pgp] https://openhab.jfrog.io/artifactory/openhab-linuxpkg testing main' | sudo tee /etc/apt/sources.list.d/openhab.list
+    echo 'deb [signed-by=/usr/share/keyrings/openhab.gpg] https://openhab.jfrog.io/artifactory/openhab-linuxpkg testing main' | sudo tee /etc/apt/sources.list.d/openhab.list
     ```
 
 - **Snapshot Release**
@@ -109,7 +109,7 @@ Then, you can choose between, *Official (Stable)*, *Beta* or *Snapshot* builds:
     To use it, add the **openHAB Unstable Repository** to your systems apt sources list:
 
     ```shell
-    echo 'deb [signed-by=/usr/share/keyrings/openhab.pgp] https://openhab.jfrog.io/artifactory/openhab-linuxpkg unstable main' | sudo tee /etc/apt/sources.list.d/openhab.list
+    echo 'deb [signed-by=/usr/share/keyrings/openhab.gpg] https://openhab.jfrog.io/artifactory/openhab-linuxpkg unstable main' | sudo tee /etc/apt/sources.list.d/openhab.list
     ```
 
 Next, resynchronize the package index:


### PR DESCRIPTION
I couldn't see how to apply the `release-stable` label. Do you mean tag? I can't find it there either and it won't let me create one. 

Anyway, this PR needs to be applied to both release and latest.

Signed-off-by: Richard Koshak <rlkoshak@gmail.com>