### PR TITLE
Fix add-ons stylization

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ Afterwards we will redeploy the website with the latest content from the _final_
 There are two triggers available currently.
 The `merge docs` job is triggerd after something has been added to the documentation through this repository.
 The `gather external docs` job is started with a __successful__ build of the openhab-distribution.
-A successful disribution build will include all of the latest changes that have been made to external sources like addons.
+A successful disribution build will include all of the latest changes that have been made to external sources like add-ons.
 So when a distribution build is successful, we will trigger the gathering of all external sources.
 
 When one of these jobs is finished, we will then notify our website hosting service to start a new website build.

--- a/administration/bundles.md
+++ b/administration/bundles.md
@@ -110,7 +110,7 @@ Bundles are named according to the following convention:
 where
 
 - **prefix** is the first element to categorize the bundle.
-  For addons this is `org.openhab`.
+  For add-ons this is `org.openhab`.
 - **type** is the add-on type, e.g. "binding", "persistence", or "ui"
 - **id** is the identifier for this bundle
 

--- a/concepts/rules.md
+++ b/concepts/rules.md
@@ -246,7 +246,7 @@ At some point, when basic UI rules are not sophisticated enough, rule templates 
 Someone may have already written the rule and provided it as a template in the community marketplace.
 
 To enable access to rule templates, navigate to _Settings_ -> _Community Marketplace_ and toggle _Enable Community Marketplace_ to ON.
-Then to install a rule template, visit the web UI and navigate: _Settings_ -> _Add-Ons_ -> _Automation_ -> Scroll down to the _Rule Templates_ section.
+Then to install a rule template, visit the web UI and navigate: _Settings_ -> _Add-ons_ -> _Automation_ -> Scroll down to the _Rule Templates_ section.
 Click on a rule template to review it's documentation, open the community thread and install the template to your system.
 Check the template's documentation for dependencies and install them!
 Otherwise the rule won't work.

--- a/configuration/index.md
+++ b/configuration/index.md
@@ -14,7 +14,7 @@ You as the end-user have **full control** over every aspect of your smart home, 
 Every device connected to openHAB is functionally and logically different.
 In order to represent all of these, openHAB defines the following base components:
 
-- [Add-ons](addons.html) - The numerous Add-ons to communicate with your devices
+- [Add-ons](addons.html) - The numerous add-ons to communicate with your devices
 - [Things](things.html) - Your devices represented in openHAB
 - [Items](items.html) - properties and capabilities of your Things
 - [Groups](items.html#groups) - collections or categories containing Items

--- a/developers/bindings/index.md
+++ b/developers/bindings/index.md
@@ -1059,7 +1059,7 @@ If it does, it is time to [contribute your work](../contributing.html)!
 
 ## Add your binding's logo to the openHAB website
 
-After your pull request has been merged and the next openHAB version is released, your binding will be available in the addons search on the openHAB website with a default logo.
+After your pull request has been merged and the next openHAB version is released, your binding will be available in the add-ons search on the openHAB website with a default logo.
 
 You can upload a logo to display it on the openhab.org start page, the addon search and in the readme.
 

--- a/developers/ide/intellij.md
+++ b/developers/ide/intellij.md
@@ -27,7 +27,7 @@ This article refers to the directory where you installed the distribution as `<D
 1. Use Maven to clean & install the addons project
 
     - mvn clean install in the root of `<ADDON_DIR>` using commandline Maven (or IntelliJ Maven view)
-    - some of the addons might fail to build - if it's not the one, you're interested in that should not bother you
+    - some of the add-ons might fail to build - if it's not the one, you're interested in that should not bother you
     - when the Maven project finished, you should find the freshly built addon JAR in the target directory
 
 ## Debug your addon

--- a/developers/index.md
+++ b/developers/index.md
@@ -79,7 +79,8 @@ Not sure what to choose?: openHAB maintainers use [Eclipse IDE](https://wiki.ecl
 ## Develop a NEW binding
 
 To help start developing a new binding, a script is available to generate the basic skeleton for you.
-This script is specific for binding addons. Follow these steps to generate your binding:
+This script is specific for binding add-ons.
+Follow these steps to generate your binding:
 
 1. From the command line in `openhab-addons/bundles` directory to create a skeleton of a new binding `mynewbinding` run:
 

--- a/settings/addons.md
+++ b/settings/addons.md
@@ -1,9 +1,9 @@
 ---
 layout: documentation
-title:  Add-Ons
+title:  Add-ons
 ---
 
-# Settings - Add-Ons
+# Settings - Add-ons
 
 This is the section that allows openHAB to be extended via add-ons.
 There is a huge variety of extension possibilities that openHAB provides:
@@ -75,7 +75,7 @@ However, openHAB supports some more User Interfaces like
   - PHP support for CometVisu
   - and  [Habot](/docs/ui/habot/),
 
-## Other Add-Ons
+## Other Add-ons
 
 - **System integrations**: Integrate openHAB with external systems
 Here you can found the

--- a/tutorials/getting_started/item_widgets.md
+++ b/tutorials/getting_started/item_widgets.md
@@ -89,7 +89,7 @@ If you have more than one Item that should look and behave the same, create a cu
 Once a custom widget is created, it will appear in the list of widget types.
 Properties can be used to customize the widget to work for each Item.
 See the docs referenced above for details, and the next page of this tutorial for some general advice and approaches.
-Look in the [Add-Ons - UI Category on the forum](https://community.openhab.org/c/add-ons/uis/30) for lots of examples.
+Look in the [Add-ons - UI Category on the forum](https://community.openhab.org/c/add-ons/uis/30) for lots of examples.
 
 ## Import Widgets from the openHAB marketplace
 


### PR DESCRIPTION
This makes the documentation a bit more consistent to use "add-ons" or "Add-ons" where possible.