### PR TITLE
Fix typos, inconsistencies and remove references to JavaScript transformation

### DIFF
--- a/configuration/blockly/index.md
+++ b/configuration/blockly/index.md
@@ -6,7 +6,7 @@ title: Rules Blockly
 
 # Blockly Reference
 
-One of the core feature that OpenHAB provides is writing rules to allow specific behaviour with the home automation system.
+One of the core feature that openHAB provides is writing rules to allow specific behaviour with the home automation system.
 The usual way of developing rules is by coding them like described in the [Textual Rules](/docs/configuration/rules-dsl.html).
 
 However, this art of programming may become intimidating early on and shy away away people with few or almost no experience in programming.
@@ -53,7 +53,7 @@ Three Youtube tutorials have been made available via the [openHAB Youtube channe
 - [Episode 1](https://www.youtube.com/watch?v=EdllUlJ7p6k)
   - [Introduction](https://www.youtube.com/watch?v=EdllUlJ7p6k)
   - [Quick Intro Blockly Rules](https://youtu.be/EdllUlJ7p6k?t=295)
-  - [Debugging Rules with OpenHAB Developer Tools to watch Item-Status](https://youtu.be/EdllUlJ7p6k?t=325)
+  - [Debugging Rules with openHAB Developer Tools to watch Item-Status](https://youtu.be/EdllUlJ7p6k?t=325)
   - [Creating a Blockly Rule](https://youtu.be/EdllUlJ7p6k?t=429)
   - [Overview of the Blockly Sections](https://youtu.be/EdllUlJ7p6k?t=558)
   - [Logging](https://youtu.be/EdllUlJ7p6k?t=670)

--- a/configuration/blockly/rules-blockly-before-using.md
+++ b/configuration/blockly/rules-blockly-before-using.md
@@ -17,7 +17,7 @@ Please read them carefully before asking questions in the forum.
 
 [[toc]]
 
-## **OpenHAB Configuration Files**
+## **openHAB Configuration Files**
 
 Some openHAB blocks rely on particular configuration files found in the openHAB configuration folder.
 This folder is referred to as $OPENHAB\_CONF in this page, and the location of this folder for your setup can be found via the UI: _Help & About_ -> _Technical Information_ -> _Configuration folder_.
@@ -137,7 +137,7 @@ More on that topic can be viewed at ![youtube](../images/blockly/youtube-logo-sm
 ## Show an item status watch list besides the blockly rules
 
 In the developer section there is the possibility to add a sidebar to the blockly rules development workspace that allows to watch live status of an item.
-View the chapter ![youtube](../images/blockly/youtube-logo-small.png) [Debugging Rules with OpenHAB Developer Tools to watch Item-Status](https://youtu.be/EdllUlJ7p6k?t=325) for more information
+View the chapter ![youtube](../images/blockly/youtube-logo-small.png) [Debugging Rules with openHAB Developer Tools to watch Item-Status](https://youtu.be/EdllUlJ7p6k?t=325) for more information
 
 ## Return to Blockly Reference
 

--- a/configuration/blockly/rules-blockly-run-and-process.md
+++ b/configuration/blockly/rules-blockly-run-and-process.md
@@ -86,14 +86,13 @@ A rule carries contextual information when triggered - this block can retrieve t
 
 ## Transform values via Map, Regex or JsonPath and others
 
-OpenHAB provides many [transformations](https://www.openhab.org/docs/configuration/transformations.html):
+openHAB provides many [transformations](https://www.openhab.org/docs/configuration/transformations.html):
 
 - [Map](https://www.openhab.org/addons/transformations/map/)
 - [Regex](https://www.openhab.org/addons/transformations/regex/)
 - [JsonPath](https://www.openhab.org/addons/transformations/jsonpath/)
 - [Binary to Json](https://www.openhab.org/addons/transformations/bin2json/)
 - [Exec](https://www.openhab.org/addons/transformations/exec/)
-- [JavaScript](https://www.openhab.org/addons/transformations/javascript/)
 - [Jinja](https://www.openhab.org/addons/transformations/jinja/)
 - [Scale](https://www.openhab.org/addons/transformations/scale/)
 - [XPath](https://www.openhab.org/addons/transformations/xpath/)

--- a/configuration/rules-ng.md
+++ b/configuration/rules-ng.md
@@ -11,7 +11,7 @@ If your are looking for general rules explanations have a look at our [Rules](ht
 # Next-Generation Rule Engine
 
 Since openHAB 2.4 another Rule Engine has been added.
-It allows Rules to be edited in a graphical fashion and to interact with [JSR223 Scripts (Javascript, Jypthon, etc)](https://www.openhab.org/docs/configuration/jsr223.html).
+It allows Rules to be edited in a graphical fashion and to interact with [JSR223 Scripts (JavaScript, Jython, etc)](https://www.openhab.org/docs/configuration/jsr223.html).
 
 ## Concept
 

--- a/settings/addons.md
+++ b/settings/addons.md
@@ -73,7 +73,7 @@ openHAB by default support the Basic UI as well as the HABPanel (which used to b
 However, openHAB supports some more User Interfaces like
   - the [CometVisu-Backend](https://www.cometvisu.org/)
   - PHP support for CometVisu
-  - and  [Habot](/docs/ui/habot/),
+  - and [HABot](/docs/ui/habot/),
 
 ## Other Add-Ons
 
@@ -88,15 +88,14 @@ Here you can found the
   - RRD
   - InfluxDB
   - mongoDB
-  - mapDB
+  - MapDB
   - several JDBC Connectors and
   - JPA Persistence
 
 - **Transformation Add-ons**: Extensions for a particular transformation like
   - JSONPath
   - RegEx
-  - JavaScript (transformation written in Javascript)
-  - MapDB
+  - Map
   - Binary To JSON
   - Exec (executes an external program and returns the output as a string)
   - Jinja


### PR DESCRIPTION
The JavaScript transformation was removed with https://github.com/openhab/openhab-addons/pull/13276.