### PR TITLE
Fix .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -6,7 +6,7 @@ root = true
 [*]
 indent_style = space
 indent_size = 2
-end_of_line = crlf
+end_of_line = lf
 charset = utf-8
 trim_trailing_whitespace = true
 insert_final_newline = true


### PR DESCRIPTION
The editor config specifies CRLF as line-ending while we use LF. This is corrected now.

Signed-off-by: Jan N. Klug <github@klug.nrw>