### PR TITLE
Update windows.md

### DIFF
--- a/installation/windows.md
+++ b/installation/windows.md
@@ -93,6 +93,7 @@ By installing the openHAB process as a service in Windows, you can:
     set.default.OPENHAB_RUNTIME=%OPENHAB_HOME%\runtime
     set.default.OPENHAB_USERDATA=%OPENHAB_HOME%\userdata
     set.default.OPENHAB_LOGDIR=%OPENHAB_USERDATA%\logs
+    set.default.KARAF_LOG=%OPENHAB_USERDATA%\logs
     set.default.KARAF_HOME=%OPENHAB_RUNTIME%
     set.default.KARAF_BASE=%OPENHAB_USERDATA%
     set.default.KARAF_DATA=%OPENHAB_USERDATA%


### PR DESCRIPTION
When running as a service an extra folder called log is created in userdata  (Note: OpenHab log folder is userdata/logs with the s on the end). This extra folder is created because the default Karaf log folder is not explicitly set in the wrapper config.  These changes update the wrapper config file to make sure the Karaf log folder is set to the same as the OpenHab Logs folder.

See Community post - https://community.openhab.org/t/oh3-oh4-running-as-service-on-windows-creates-spurious-log-folder-with-openhab-log-empty/145048