### PR TITLE
Update docs for OSGi R8 upgrade

### DIFF
--- a/developers/guidelines.md
+++ b/developers/guidelines.md
@@ -133,7 +133,7 @@ Data-transfer-objects (DTOs map from JSON/XML to Java classes) do not require Ja
 ## D. Language Levels and Libraries
 
 1. openHAB generally targets the long time supported Java 17 release.
-1. The [OSGi Core Release 7](https://osgi.org/download/r7/osgi.core-7.0.0.pdf) with [OSGi Compendium Release 7](https://osgi.org/download/r7/osgi.cmpn-7.0.0.pdf) is targeted, and newer features should not be used.
+1. The [OSGi Core Release 8](https://osgi.org/download/r8/osgi.core-8.0.0.pdf) with [OSGi Compendium Release 8](https://osgi.org/download/r8/osgi.cmpn-8.0.0.pdf) is targeted, and newer features should not be used.
 1. [SLF4J](http://slf4j.org) is used for logging.
 
 You might also have the need to use other libraries for specific use cases like XML processing, networking etc.

--- a/developers/osgi/configadmin.md
+++ b/developers/osgi/configadmin.md
@@ -5,7 +5,7 @@ title: Configuration Admin
 
 # Configuration Admin Service
 
-As defined in the [OSGi Compendium Release 7][OSGi-cmpn] _configuration is the process of defining the configuration data of bundles and assuring that those bundles receive that data when they are active in the OSGi Service Platform._
+As defined in the [OSGi Compendium Release 8][OSGi-cmpn] _configuration is the process of defining the configuration data of bundles and assuring that those bundles receive that data when they are active in the OSGi Service Platform._
 
 In OSGi, configurations are stored in a central database that is being managed by a special service - the _Configuration Admin Service_(`org.osgi.service.cm.ConfigurationAdmin`).
 This service monitors the service registry and **provides a configuration to the services** that are registered with a _service.pid_ property.
@@ -154,9 +154,9 @@ If the location is not set correctly the Config Admin may not send the update to
 
 ## Further Reading
 
-- [OSGi Compendium Release 7][OSGi-cmpn]
+- [OSGi Compendium Release 8][OSGi-cmpn]
 - <https://enroute.osgi.org/Tutorial/>
 - <http://blog.vogella.com/2016/06/21/getting-started-with-osgi-declarative-services/>
 - <http://blog.vogella.com/2016/09/26/configuring-osgi-declarative-services/>
 
-[OSGi-cmpn]: https://osgi.org/download/r7/osgi.cmpn-7.0.0.pdf
+[OSGi-cmpn]: https://osgi.org/download/r8/osgi.cmpn-8.0.0.pdf

--- a/developers/osgi/equinox.md
+++ b/developers/osgi/equinox.md
@@ -5,7 +5,7 @@ title: Equinox
 
 # Equinox
 
-[Equinox][Equinox] is considered to be a reference implementation of the [OSGi Core Release 7][OSGi-core].
+[Equinox][Equinox] is considered to be a reference implementation of the [OSGi Core Release 8][OSGi-core].
 It is an [open source project][Equinox-repo], part of the [Eclipse project][Eclipse].
 It provides a set of bundles, that implement various optional OSGi services.
 
@@ -96,7 +96,7 @@ Some or all of these bundles must be included in your runtime configuration, if 
  Name | Bundle Symbolic Name | Description
  -------- | -------- | --------
 Declarative Services | org.eclipse.equinox.ds | An implementation of the OSGi [Declarative Services](osgids.html) specification
-Event Admin Service | org.eclipse.equinox.event | OSGi Compendium Release 7 [Event Admin](https://osgi.org/javadoc/osgi.cmpn/7.0.0/org/osgi/service/event/EventAdmin.html) Service provides an inter-bundle communication mechanism based on an event publish and subscribe model
+Event Admin Service | org.eclipse.equinox.event | OSGi Compendium Release 8 [Event Admin](https://osgi.org/javadoc/osgi.cmpn/8.0.0/org/osgi/service/event/EventAdmin.html) Service provides an inter-bundle communication mechanism based on an event publish and subscribe model
 Equinox Utilities | org.eclipse.equinox.util | A library of utility classes that are frequently used from the Equinox OSGi Service implementation bundles
 OSGi Services API | org.eclipse.osgi.service | This bundle contains the set of OSGi specified service APIs
 
@@ -121,7 +121,7 @@ Table 2. OSGi Bundles (Full list can be found at: <https://www.eclipse.org/equin
 - [RT meets p2](https://bkapukaranov.wordpress.com/category/tech/virgo/)
 
 [Equinox]: https://www.eclipse.org/equinox/
-[OSGi-Core]: https://osgi.org/download/r7/osgi.core-7.0.0.pdf
+[OSGi-Core]: https://osgi.org/download/r8/osgi.core-8.0.0.pdf
 [Equinox-repo]: https://git.eclipse.org/c/equinox/
 [Eclipse]: https://eclipse.org/eclipse/
 [Equinox-Bundles]: https://www.eclipse.org/equinox/bundles/

--- a/developers/osgi/eventadmin.md
+++ b/developers/osgi/eventadmin.md
@@ -9,7 +9,7 @@ In a dynamic environment like OSGi, communication with events has a wide variety
 A lot of core services share information using events, so understanding how to use events in OSGi is fundamental.
 
 OSGi events are based on the publish-subscribe messaging pattern.
-Let's use the definition for the pattern that can be found in the [OSGi Compendium Release 7][OSGi-cmpn]:
+Let's use the definition for the pattern that can be found in the [OSGi Compendium Release 8][OSGi-cmpn]:
 
 _This pattern decouples sources from their handlers by interposing an event channel between them.
 The publisher posts events to the channel, which identifies which handlers need to be notified and then takes care of the notification process._
@@ -76,10 +76,10 @@ The service contains two methods for sending events:
 
 ## Further Reading
 
-- [OSGi Compendium Release 7][OSGi-cmpn]
+- [OSGi Compendium Release 8][OSGi-cmpn]
 - <https://enroute.osgi.org/services/org.osgi.service.event.html>
 - <http://blog.vogella.com/2017/05/16/osgi-event-admin-publish-subscribe/>
 
 [fig1]:images/event-admin.png
 
-[OSGi-cmpn]: https://osgi.org/download/r7/osgi.cmpn-7.0.0.pdf
+[OSGi-cmpn]: https://osgi.org/download/r8/osgi.cmpn-8.0.0.pdf

--- a/developers/osgi/osgi.md
+++ b/developers/osgi/osgi.md
@@ -65,7 +65,7 @@ Import-Package: org.example.required
 Export-Package: org.example.provided
 ```
 
-[OSGi Core Release 7, Chapter 3: Module Layer][OSGi-core] contains detailed information about the _Module Layer_ and description of the headers (_Manifest-Version_, _Bundle-ManifestVersion_, _Bundle-Name_) used in this example.
+[OSGi Core Release 8, Chapter 3: Module Layer][OSGi-core] contains detailed information about the _Module Layer_ and description of the headers (_Manifest-Version_, _Bundle-ManifestVersion_, _Bundle-Name_) used in this example.
 
 Bundles are used often to register and consume services.
 You will find more information about that in the [Services](#services) section.
@@ -153,9 +153,9 @@ We will list the most popular OSGi containers with a short description of their 
 
 ## Important Definitions
 
-**bundle** - a unit of modularization, defined by the OSGi framework. A bundle is comprised of Java classes and other resources, which together can provide functions to end users. For more detailed definition - [OSGi Core Release 7, Chapter 3.2: Bundles][OSGi-core]
+**bundle** - a unit of modularization, defined by the OSGi framework. A bundle is comprised of Java classes and other resources, which together can provide functions to end users. For more detailed definition - [OSGi Core Release 8, Chapter 3.2: Bundles][OSGi-core]
 
-**service** - any object that is registered in the OSGi Service Registry and can be looked up using its interface name(s). Definition - [OSGi Core Release 7, Chapter 5.2: Services][OSGi-core]
+**service** - any object that is registered in the OSGi Service Registry and can be looked up using its interface name(s). Definition - [OSGi Core Release 8, Chapter 5.2: Services][OSGi-core]
 
 **manifest** - descriptive information about the bundle, contained in its JAR file
 
@@ -163,15 +163,15 @@ We will list the most popular OSGi containers with a short description of their 
 
 ## Further Reading
 
-- [OSGi Core Release 7][OSGi-core]
-- [OSGi API](https://osgi.org/javadoc/osgi.core/7.0.0/)
+- [OSGi Core Release 8][OSGi-core]
+- [OSGi API](https://osgi.org/javadoc/osgi.core/8.0.0/)
 - [OSGi Vogella guide](http://www.vogella.com/tutorials/OSGi/article.html)
 - [Lifecycle of a bundle](https://developer.atlassian.com/docs/atlassian-platform-common-components/plugin-framework/behind-the-scenes-in-the-plugin-framework/lifecycle-of-a-bundle)
 - [OSGi enRoute](https://enroute.osgi.org/)
 - <https://www.osgi.org/developer/where-to-start/>
 
 [OSGi]: https://www.osgi.org/
-[OSGi-core]: https://osgi.org/download/r7/osgi.core-7.0.0.pdf
+[OSGi-core]: https://osgi.org/download/r8/osgi.core-8.0.0.pdf
 [fig1]:images/layeringosgi.png
 [fig2]:images/states.png
 [fig3]:images/services.png

--- a/developers/osgi/osgids.md
+++ b/developers/osgi/osgids.md
@@ -48,7 +48,7 @@ A component requires the following artifacts in a bundle:
 - An **implementation class** that is specified in the component description.
 
 Because we do not write the XML files or the manifest ourselves, we will concentrate on the Java annotations in the examples below.
-A component may use different strategies to access the bound services: _Constructor injection_, _Field injection_ or _Method injection_ (see [OSGi Compendium Release 7, Chapter 112.3: References to Services][OSGi-cmpn]).
+A component may use different strategies to access the bound services: _Constructor injection_, _Field injection_ or _Method injection_ (see [OSGi Compendium Release 8, Chapter 112.3: References to Services][OSGi-cmpn]).
 
 ### Example - Reference a Service
 
@@ -157,7 +157,7 @@ public class MyService {
 
 ### Example - Provide a Service
 
-Very often you will have to register a service, that implements an interface defined in the framework (e.g [_EventHandler_](https://osgi.org/javadoc/osgi.cmpn/7.0.0/org/osgi/service/event/EventHandler.html)) or interface, that you have defined.
+Very often you will have to register a service, that implements an interface defined in the framework (e.g [_EventHandler_](https://osgi.org/javadoc/osgi.cmpn/8.0.0/org/osgi/service/event/EventHandler.html)) or interface, that you have defined.
 An interface allows you to change the implementation easily or register multiple implementations in the Service Registry.
 
 We will use DS to register an implementation of the EventHandler service in the OSGi Service Registry.
@@ -196,7 +196,7 @@ Three type of components are defined:
 - **delayed** - with ```immediate``` attribute set to ```false```;
 - **factory** - we will not discuss the lifecycle of this type in this article.
 
-You can find more information in the [OSGi Compendium Release 7, Chapter 112.2: Components][OSGi-cmpn].
+You can find more information in the [OSGi Compendium Release 8, Chapter 112.2: Components][OSGi-cmpn].
 
 ## Component Lifecycle
 
@@ -272,9 +272,9 @@ You might review again the [Equinox commands](equinox.html#iv-commands) before y
 
 ## Further Reading
 
-- [OSGi Compendium Release 7][OSGi-cmpn]
+- [OSGi Compendium Release 8][OSGi-cmpn]
 - [Lars Vogel - Declarative services](http://www.vogella.com/tutorials/OSGiServices/article.html#declarativeservices)
 - [Getting Started with OSGi: Declarative Services](https://www.eclipsezone.com/eclipse/forums/t97690.rhtml)
 - <https://stackoverflow.com/questions/8886430/what-is-the-difference-between-osgi-components-and-services>
 
-[OSGi-cmpn]: https://osgi.org/download/r7/osgi.cmpn-7.0.0.pdf
+[OSGi-cmpn]: https://osgi.org/download/r8/osgi.cmpn-8.0.0.pdf


### PR DESCRIPTION
This is related to the dependency upgrades due to the Karaf 4.4.3 upgrade.

See: https://github.com/openhab/openhab-core/pull/3252.