### PR TITLE
Document the script-prefix for Nashorn JavaScript

### DIFF
--- a/addons/transformations.md
+++ b/addons/transformations.md
@@ -92,9 +92,10 @@ returnValue
 
 :::
 
-::: tab Nashorn JS
+::: tab JS
 
-The script-prefix is `js`.
+The script-prefix is `js` when using the modern JS Scripting add-on and `nashornjs` when using the legacy JS Scripting add-on.
+Note the overall syntax is the same.
 
 ```javascript
 (function(data) {


### PR DESCRIPTION
Added note what the script prefix is for Nashorn JS, noted that Nashorn is legacy and explicitly stated that the syntax is the same for both JS add-ons.