### PR TITLE
Fix markdown in installation/index.md

### DIFF
--- a/installation/index.md
+++ b/installation/index.md
@@ -153,10 +153,6 @@ If the tool is not operated from that folder, it can be specified by using `--di
 
 Example:
 
-```
+```shell
 java -jar upgradetool.jar --dir /var/lib/openhab --command itemCopyUnitToMetadata
 ```
-
-
-
-


### PR DESCRIPTION
I think this is the reason why #2073 is not showing up on next.openhab.org. The question is, why this did not show up in the PR builds.