### PR TITLE
ui/sitemaps.md: emphasize period= is mandatory parameter in Chart

### DIFF
--- a/ui/sitemaps.md
+++ b/ui/sitemaps.md
@@ -496,8 +496,8 @@ Video url="https://demo.openhab.org/Hue.m4v"
 ### Element Type 'Chart'
 
 ```java
-Chart [item=<itemname>] [icon="<iconname>"] [label="<labelname>"] [refresh=xxxx]
-[period=xxxx] [service="<service>"] [legend=true/false] [forceasitem=true/false] [yAxisDecimalPattern=xxxx]
+Chart item=<itemname> [icon="<iconname>"] [label="<labelname>"] [refresh=xxxx]
+period=xxxx [service="<service>"] [legend=true/false] [forceasitem=true/false] [yAxisDecimalPattern=xxxx]
 ```
 
 Adds a time-series chart object for the display of logged data.


### PR DESCRIPTION
I just struggled to configure a Chart in sitemap, until I figured out that `period=` must be set.

This changeset emphasizes that `period=` is mandatory.  It also sets `item=` in `Text` and `Chart` as mandatory, and `item=` in `Group` as optional, as this is what makes sense for me.