### PR TITLE
Some guidelines.md fixes

### DIFF
--- a/developers/guidelines.md
+++ b/developers/guidelines.md
@@ -180,13 +180,13 @@ class MyCoolClass {
 }
 ```
 
-- Parametrized logging must be used (instead of string concatenation).
+- Parameterized logging must be used (instead of string concatenation).
 
 ```java
 void myFun() {
     String someValue = "abc";
     int someInt = 12;
-    logger.log("Current value is {} and int is {}", someValue, someInt);
+    logger.debug("Current value is {} and int is {}", someValue, someInt);
 }
 ```
 


### PR DESCRIPTION
There is no `log` method on Loggers, see:

https://slf4j.org/api/org/slf4j/Logger.html