### PR TITLE
Remove link to openHAB 1 add-ons from contributing page

### DIFF
--- a/appendix/contributing.md
+++ b/appendix/contributing.md
@@ -18,8 +18,7 @@ When no solution was found, use the table below to determine where your issue sh
 
 | Issue                                                        | Where to report                                                    |
 |--------------------------------------------------------------|--------------------------------------------------------------------|
-| Problems and feature requests for openHAB 1 add-ons          | [openHAB 1](https://github.com/openhab/openhab/issues)               |
-| Problems and feature requests for openHAB 2 add-ons          | [openHAB 2+](https://github.com/openhab/openhab-addons/issues)             |
+| Problems and feature requests for openHAB add-ons            | [openHAB-addons](https://github.com/openhab/openhab-addons/issues) |
 | Issues related to the runtime environment, IDE and packaging | [openHAB-distro](https://github.com/openhab/openhab-distro/issues) |
 | Issues related to the core openHAB bundles                   | [openHAB-core](https://github.com/kaikreuzer/openhab-core/issues)  |
 


### PR DESCRIPTION
This project is archived and the add-ons are not part of openHAB 3+.