### PR TITLE
[ide-vscode] Add instructions to tasks.json

### DIFF
--- a/developers/ide/examples/vscode/tasks.json
+++ b/developers/ide/examples/vscode/tasks.json
@@ -159,7 +159,7 @@
             "type": "shell",
             "command": "mvn",
             "args": [
-                "spotless:apply",
+                "spotless:apply"
             ],
             "problemMatcher": []
         

--- a/developers/ide/examples/vscode/tasks.json
+++ b/developers/ide/examples/vscode/tasks.json
@@ -169,7 +169,19 @@
             "type": "shell",
             "command": "mvn",
             "args": [
-                "org.openhab.core.tools:i18n-maven-plugin:3.3.0:generate-default-translations",
+                "i18n:generate-default-translations",
+                "-pl",
+                ":$env:binding"
+            ],
+            "problemMatcher": []
+        
+        },
+        {
+            "label": "mvn update properties (Default) [full plug-in name]",
+            "type": "shell",
+            "command": "mvn",
+            "args": [
+                "mvn org.openhab.core.tools:i18n-maven-plugin:3.4.0:generate-default-translations",
                 "-pl",
                 ":$env:binding"
             ],

--- a/developers/ide/examples/vscode/tasks.json
+++ b/developers/ide/examples/vscode/tasks.json
@@ -41,6 +41,9 @@
                 "clean",
                 "install"
             ],
+            "dependsOn": [
+                "mvn Spotless (Fix codestyle)"                
+            ],
             "problemMatcher": []
         },
         {
@@ -51,6 +54,9 @@
                 "clean",
                 "install",
                 "-DskipChecks"
+            ],
+            "dependsOn": [
+                "mvn Spotless (Fix codestyle)"                
             ],
             "problemMatcher": []
         },
@@ -63,6 +69,9 @@
                 "clean",
                 "install",
                 "-DskipChecks"
+            ],
+            "dependsOn": [
+                "mvn Spotless (Fix codestyle)"                
             ],
             "problemMatcher": []
         },
@@ -144,6 +153,28 @@
                 "panel": "new"
             },
            "problemMatcher": []
+        },
+        {
+            "label": "mvn Spotless (Fix codestyle)",
+            "type": "shell",
+            "command": "mvn",
+            "args": [
+                "spotless:apply",
+            ],
+            "problemMatcher": []
+        
+        },
+        {
+            "label": "mvn update properties (Default)",
+            "type": "shell",
+            "command": "mvn",
+            "args": [
+                "org.openhab.core.tools:i18n-maven-plugin:3.3.0:generate-default-translations",
+                "-pl",
+                ":$env:binding"
+            ],
+            "problemMatcher": []
+        
         }
     ]
 }


### PR DESCRIPTION
Add 3 tasks for Visual Studio Code IDE :
- mvn Spotless (Fix codestyle)
- mvn update properties (Default)
- mvn update properties (Default) [full plug-in name]

Force code style update before compile.

Signed-off-by: Daniel Rosengarten <github@praetorians.be>