### PR TITLE
add markdown info for contribution, reformat

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -2,53 +2,52 @@
 
 ## Pull requests are always welcome
 
-We are always thrilled to receive pull requests, and do our best to
-process them as fast as possible. Not sure if that typo is worth a pull
-request? Do it! We will appreciate it.
+We are always thrilled to receive pull requests, and do our best to process them as fast as possible.
+Not sure if that typo is worth a pull request?
+Do it!
+We will appreciate it.
 
 ## Conventions
 
 Fork the repo and make changes on your fork in a feature branch.
 
-Pull requests descriptions should be as clear as possible and include a
-reference to all the issues that they address.
+Any change will be checked against selected **markdown rules**, defined in the [.markdownlint.yaml](.markdownlint.yaml), and will be automatically checked during the build.
+An explanation of the rules can be found [here](https://github.com/DavidAnson/markdownlint#rules--aliases).
+Please make sure that your contributed content is therefore compliant with these rules before contributing them.
+Checkout the [markdownlint project](https://github.com/DavidAnson/markdownlint) for support of your favorite IDE.
+In doubt, ask us to guide you on these rules.
+
+Pull requests descriptions should be as clear as possible and include a reference to all the issues that they address.
 
 Pull requests must not contain commits from other users or branches.
 
-Commit messages must start with a capitalized and short summary (max. 50
-chars) written in the imperative, followed by an optional, more detailed
-explanatory text which is separated from the summary by an empty line.
+Commit messages must start with a capitalized and short summary (max. 50 chars) written in the imperative, followed by an optional, more detailed explanatory text which is separated from the summary by an empty line.
 
-Code review comments may be added to your pull request. Discuss, then make the
-suggested modifications and push additional commits to your feature branch. Be
-sure to post a comment after pushing. The new commits will show up in the pull
-request automatically, but the reviewers will not be notified unless you
-comment.
+Code review comments may be added to your pull request. Discuss, then make the suggested modifications and push additional commits to your feature branch.
+Be sure to post a comment after pushing.
+The new commits will show up in the pull request automatically, but the reviewers will not be notified unless you comment.
 
-Commits that fix or close an issue should include a reference like `Closes #XXX`
-or `Fixes #XXX`, which will automatically close the issue when merged.
+Commits that fix or close an issue should include a reference like `Closes #XXX` or `Fixes #XXX`, which will automatically close the issue when merged.
 
 ## Community Guidelines
 
-We want to keep the openHAB community awesome, growing and collaborative. We
-need your help to keep it that way. To help with this we've come up with some
-general guidelines for the community as a whole:
+We want to keep the openHAB community awesome, growing and collaborative.
+We need your help to keep it that way.
+To help with this we've come up with some general guidelines for the community as a whole:
 
-- Be nice: Be courteous, respectful and polite to fellow community members: no
-  regional, racial, gender, or other abuse will be tolerated. We like nice people
-  way better than mean ones!
+- Be nice:
+  Be courteous, respectful and polite to fellow community members:
+  no regional, racial, gender, or other abuse will be tolerated.
+  We like nice people way better than mean ones!
 
-- Encourage diversity and participation: Make everyone in our community
-  feel welcome, regardless of their background and the extent of their
-  contributions, and do everything possible to encourage participation in
-  our community.
+- Encourage diversity and participation:
+  Make everyone in our community feel welcome, regardless of their background and the extent of their contributions, and do everything possible to encourage participation in our community.
 
-- Keep it legal: Basically, don't get us in trouble. Share only content that
-  you own, do not share private or sensitive information, and don't break the
-  law.
+- Keep it legal:
+  Basically, don't get us in trouble.
+  Share only content that you own, do not share private or sensitive information, and don't break the law.
 
-- Stay on topic: Make sure that you are posting to the correct channel
-  and avoid off-topic discussions. Remember when you update an issue or
-  respond to an email you are potentially sending to a large number of
-  people.  Please consider this before you update.  Also remember that
-  nobody likes spam.
+- Stay on topic:
+  Make sure that you are posting to the correct channel and avoid off-topic discussions.
+  Remember when you update an issue or respond to an email you are potentially sending to a large number of people.
+  Please consider this before you update.  Also remember that nobody likes spam.


### PR DESCRIPTION
Add markdown check background information for the contribution manual.
Reformat according to guidelines.