### PR TITLE
Add missing parameters to Windows wrapper documentation

### DIFF
--- a/installation/windows.md
+++ b/installation/windows.md
@@ -126,11 +126,16 @@ By installing the openHAB process as a service in Windows, you can:
     wrapper.java.additional.11=-Dopenhab.userdata="%OPENHAB_HOME%\userdata"
     wrapper.java.additional.12=-Dopenhab.logdir="%OPENHAB_USERDATA%\logs"
     wrapper.java.additional.13=-Dfelix.cm.dir="%OPENHAB_HOME%\userdata\config"
-    wrapper.java.additional.14=-Dorg.osgi.service.http.port=8080
-    wrapper.java.additional.15=-Dorg.osgi.service.http.port.secure=8443
-    wrapper.java.additional.16=-Djava.util.logging.config.file="%KARAF_ETC%\java.util.logging.properties"
-    wrapper.java.additional.17=-Dkaraf.logs="%OPENHAB_LOGDIR%"
-    wrapper.java.additional.18=-Dfile.encoding=UTF-8
+    wrapper.java.additional.14=-Djdk.util.zip.disableZip64ExtraFieldValidation=true
+    wrapper.java.additional.15=-Djetty.host=0.0.0.0
+    wrapper.java.additional.16=-Djetty.http.compliance=RFC2616
+    wrapper.java.additional.17=-Dorg.apache.cxf.osgi.http.transport.disable=true
+    wrapper.java.additional.18=-Dorg.osgi.service.http.port=8080
+    wrapper.java.additional.19=-Dorg.osgi.service.http.port.secure=8443
+    wrapper.java.additional.20=-Djava.util.logging.config.file="%KARAF_ETC%\java.util.logging.properties"
+    wrapper.java.additional.21=-Dkaraf.logs="%OPENHAB_LOGDIR%"
+    wrapper.java.additional.22=-Djava.awt.headless=true
+    wrapper.java.additional.23=-Dfile.encoding=UTF-8
     wrapper.java.maxmemory=512
 
     # Wrapper Logging Properties


### PR DESCRIPTION
Using the right parameters prevents issues when running openHAB as Windows service.

See:

* [setenv.bat](https://github.com/openhab/openhab-distro/blob/main/distributions/openhab/src/main/resources/bin/setenv.bat)
* [Community topic](https://community.openhab.org/t/trouble-connecting-to-basic-ui-over-local-network/152448)