### PR TITLE
configuration/items: clarify that items linked to channels have implicit state presentation

### DIFF
--- a/configuration/items.md
+++ b/configuration/items.md
@@ -257,7 +257,7 @@ The state presentation for the Item in the following example is "`%.1f °C`":
 Number:Temperature Livingroom_Temperature "Temperature [%.1f °C]"
 ```
 
-If no state presentation is given, or there is no text between the square brackets, the Item will not provide a textual presentation of its internal state (i.e. in UIs no state is shown).
+If no square brackets are given and the Item is not linked to a channel, the Item will not provide a textual presentation of its internal state (i.e. in UIs no state is shown).
 This is often meaningful when an Item is presented by a non-textual UI elements like a switch or a diagram.
 
 Formatting of the presentation is done applying [Java formatter class syntax](https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/util/Formatter.html#syntax).


### PR DESCRIPTION
Per https://github.com/openhab/openhab-webui/issues/2251#issuecomment-1890903468 third bullet, if an item without explicit state presentation is linked to a channel, the State presentation is inherited from the channel.

This sentence is now complicated with its structure `If not A, or not B, and not C, then`. I am open to suggestions how to improve the structure of the sentence, to make it easier to understand.  But on the other side adding the current clarification is an improvement.