### PR TITLE
configuration/items: [] means no textual presentation

### DIFF
--- a/configuration/items.md
+++ b/configuration/items.md
@@ -258,6 +258,7 @@ Number:Temperature Livingroom_Temperature "Temperature [%.1f °C]"
 ```
 
 If no square brackets are given and the Item is not linked to a channel, the Item will not provide a textual presentation of its internal state (i.e. in UIs no state is shown).
+No text between the square brackets also implies no textual presentation.
 This is often meaningful when an Item is presented by a non-textual UI elements like a switch or a diagram.
 
 Formatting of the presentation is done applying [Java formatter class syntax](https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/util/Formatter.html#syntax).


### PR DESCRIPTION
As discussed at https://github.com/openhab/openhab-docs/pull/2214 .