### PR TITLE
Add match property name for process addon finder.

### DIFF
--- a/developers/addons/addon.md
+++ b/developers/addons/addon.md
@@ -106,9 +106,9 @@ Notes:
 |--------------|----------------------------------------------------------------------------------------------------------------------------------------------|
 | `ip`         | "response".                                                                                                                                  |
 | `mdns`       | Frequently used properties are "name", and "application". But mDNS permits any property name depending on the service concerned.             |
-| `processs`   | "command".                                                                                                                                   |
+| `process`    | "command", "commandLine".                                                                                                                    |
 | `upnp`       | "deviceType", "manufacturer", "manufacturerURI", "modelName", "modelNumber", "modelDescription", "modelURI", "serialNumber", "friendlyName". |
-| `usb`        | "product", "manufacturer", "chipId", "remote".                                                                                          |
+| `usb`        | "product", "manufacturer", "chipId", "remote".                                                                                               |
 
 ## Example
 


### PR DESCRIPTION
See https://github.com/openhab/openhab-core/pull/4061

Add match property name for process addon finder.

Signed-off-by: Andrew Fiddian-Green <software@whitebear.ch>
