### PR TITLE
Set params when using `@text/`

### DIFF
--- a/developers/utils/i18n.md
+++ b/developers/utils/i18n.md
@@ -403,7 +403,7 @@ discovery.darksky.weather-and-forecast.api.local.label = Lokales Wetter und Wett
 In addition to the default keys the developer can also specify custom keys inside the XML file.
 But with this approach the XML file cannot longer contain the English texts.
 So it is mandatory to define a language file for the English language.
-The syntax for custom keys is `@text/<key>`.
+The syntax for custom keys is `@text/<key> [params]`.
 The keys are unique across the whole bundle, so a constant can reference any key in all files inside the `OH-INF/i18n` folder.
 
 The following snippet shows a binding XML that uses custom keys:
@@ -428,7 +428,7 @@ addon.acmeweather.description = Binding for ACME Weather
 
 # thing status descriptions
 
-offline.communication-error = The ACME Weather API is currently not available.
+offline.communication-error = The ACME Weather API is currently not available. Error {0}
 ```
 
 Language file (`acmeweather_de.properties`):
@@ -441,13 +441,13 @@ addon.acmeweather.description = Binding für ACME Wetter
 
 # thing status descriptions
 
-offline.communication-error = Die ACME Wetter API ist zur Zeit nicht verfügbar.
+offline.communication-error = Die ACME Wetter API ist zur Zeit nicht verfügbar. Fehler {0}
 ```
 
 The custom keys are a very good practice to translate bundle dependent error messages.
 
 ```java
-updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.OFFLINE.COMMUNICATION_ERROR, "@text/offline.communication-error");
+updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.OFFLINE.COMMUNICATION_ERROR, "@text/offline.communication-error [\"EX-500\"]");
 ```
 
 ## Generating I18N properties file


### PR DESCRIPTION
Hey, I've spend some time to figure out how to pass params in `@text\`, because it was not put in the doc.

The example with `error` is kind of silly, but I did not come anything better.