### PR TITLE
MainUI: Add documentation for blockly editor

### DIFF
--- a/mainui/settings/blockly-editor.md
+++ b/mainui/settings/blockly-editor.md
@@ -33,5 +33,4 @@ Redo & Undo:
 
 - <kbd>Ctrl+Z</kbd>: Undo the last change.
 - <kbd>Ctrl+Y</kbd> (<kbd>Shift+Cmd+Z</kbd> on Mac): Redo the last change.
-
 <!-- END MAINUI SIDEBAR DOC - DO NOT REMOVE -->

--- a/mainui/settings/blockly-editor.md
+++ b/mainui/settings/blockly-editor.md
@@ -25,8 +25,8 @@ Deleting a block:
 
 Copy & Paste:
 
-- <kbd>Ctrl+C</kbd>: Copy the current line or the current selection.
-- <kbd>Ctrl+X</kbd>: Cut the current line or the current selection.
+- <kbd>Ctrl+C</kbd>: Copy the selected block.
+- <kbd>Ctrl+X</kbd>: Cut selected block.
 - <kbd>Ctrl+V</kbd>: Paste what has been copied.
 
 Redo & Undo:

--- a/mainui/settings/blockly-editor.md
+++ b/mainui/settings/blockly-editor.md
@@ -1,0 +1,37 @@
+---
+layout: documentation
+title: Blockly Editor
+---
+
+# Blockly Editor
+
+<!-- START MAINUI SIDEBAR DOC - DO NOT REMOVE -->
+The Blockly editor is used to create automation using Blockly.
+
+## Keyboard Shortcuts
+
+The following is a short overview of the most important keyboard shortcuts.
+
+Mac users should use <kbd>Cmd</kbd> instead of <kbd>Ctrl</kbd> for most shortcuts.
+
+Selection:
+
+- Click a block to select it.
+
+Deleting a block:
+
+- Once selected, it can be deleted with the <kbd>Delete</kbd> key.
+- Alternatively the block can be dragged into the toolbox area to delete it.
+
+Copy & Paste:
+
+- <kbd>Ctrl+C</kbd>: Copy the current line or the current selection.
+- <kbd>Ctrl+X</kbd>: Cut the current line or the current selection.
+- <kbd>Ctrl+V</kbd>: Paste what has been copied.
+
+Redo & Undo:
+
+- <kbd>Ctrl+Z</kbd>: Undo the last change.
+- <kbd>Ctrl+Y</kbd> (<kbd>Shift+Cmd+Z</kbd> on Mac): Redo the last change.
+
+<!-- END MAINUI SIDEBAR DOC - DO NOT REMOVE -->


### PR DESCRIPTION
Initial doc for blockly editor. Hoping that this can be merged now in conjunction with https://github.com/openhab/openhab-webui/pull/2424

The content can be improved upon later.

When https://github.com/openhab/openhab-webui/pull/2419 is merged, this document needs to be updated with the new features