### PR TITLE
[CI/CD] - The preview link created by the pipeline point to an empty page

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,3 @@
+[[redirects]]
+  from = "/"
+  to = "/docs"


### PR DESCRIPTION
Fixes #2269

📜 netlify configuration file added (redirection from `/` ➡️ `/docs`