### PR TITLE
Document addon installation in Karaf from Marketplace

### DIFF
--- a/configuration/addons.md
+++ b/configuration/addons.md
@@ -94,4 +94,17 @@ Place the .jar file in the folder Additional add-on files as described in File L
 ## Through the openHAB console
 
 Add-ons (also known as bundles) can be also installed and updated via the openHAB console.
-A detailed description can be found at [Installing or Updating Bundles](/docs/administration/bundles.html).
+
+To see the available online and offline add-ons:
+
+```sh
+openhab:addons list
+```
+
+To install an add-on in the background:
+
+```sh
+openhab:addons install <id-as-from-list-command>
+```
+
+Another approach can be found at [Installing or Updating Bundles](/docs/administration/bundles.html).


### PR DESCRIPTION
as implemented in https://github.com/openhab/openhab-core/pull/4057 .

I do not understand how exactly the `openhab:addon list` command is supposed to work.

With OH 4.2.0M1 I can do in karaf `openhab:addons list karaf` or `openhab:addons list marketplace`.

The first lists as:

```sh
…
  binding-mecmeter                              4.2.0.M1             mecMeter Binding
  binding-meteoblue                             4.2.0.M1             meteoblue Binding
  binding-mycroft                               4.2.0.M1             mycroft Binding
  binding-mystrom                               4.2.0.M1             mystrom Binding
  misc-openhabcloud                             4.2.0.M1             openHAB Cloud Connector
  binding-zigbee                                4.2.0.M1             openHAB ZigBee Binding
  binding-pixometer                             4.2.0.M1             pixometer Binding
  binding-solax                                 4.2.0.M1             solax Binding
…
```
the second:
```sh
…
  marketplace:123573                            not set              Fire Alarm
  marketplace:128255                            not set              Scene Control Suite - Scene Modification
  marketplace:129987                            not set              Twitter
  marketplace:129618                            not set              BT devices in range widget
  marketplace:126440                            not set              ConnectedCar Details View Widget
  marketplace:121655                            not set              Caddx Binding Widget
  marketplace:106820                            not set              Keypad
…
```
What is the difference between these, as in
```
  automation-jsscriptingnashorn                 4.2.0.M1             JavaScript Scripting (Nashorn)
  marketplace:134770                            not set              JavaScript Scripting (Nashorn)
```
?  Aren’t all of them originating from the market place and why are then the names (ids) completely different?
