### PR TITLE
Use SVG openHAB logo

### DIFF
--- a/introduction.md
+++ b/introduction.md
@@ -18,7 +18,7 @@ h1.welcome {
 }
 </style>
 
-<img src="/openhab-logo-square.png" width="150" height="150" class="intro-logo" />
+<img src="/openhab-logo-square.svg" width="150" height="150" class="intro-logo" />
 
 <h1 class="welcome">Welcome!</h1>
 


### PR DESCRIPTION
This updates the current stable docs to use the SVG openHAB logo after the merge of openhab/website#465.