### PR TITLE
Add notes about Java 21

### DIFF
--- a/developers/index.md
+++ b/developers/index.md
@@ -49,7 +49,7 @@ Please ensure that you have the following prerequisites installed as well:
 
 1. [Git](https://git-scm.com/downloads) For retrieving our source code and push changes back. On Windows: Must be available in %PATH%
 1. [Maven 3.x](https://maven.apache.org/download.cgi) Our build system tool. On Windows: Must be available in %PATH%
-1. Java JDK 17 or JDK 21, for example from Oracle [Oracle JDK 17](https://www.oracle.com/java/technologies/javase/jdk17-archive-downloads.html) or [Oracle JDK 21](https://www.oracle.com/java/technologies/javase/jdk17-archive-downloads.html). On Windows: %JAVA% must be set.
+1. Java JDK 17 or JDK 21, for example from Oracle [Oracle JDK 17](https://www.oracle.com/java/technologies/javase/jdk17-archive-downloads.html) or [Oracle JDK 21](https://www.oracle.com/java/technologies/javase/jdk21-archive-downloads.html). On Windows: %JAVA% must be set.
 
 ::: tip Note
 Whereas we recommend Java 17 for running openHAB, development can be safely done on Java 21.

--- a/developers/index.md
+++ b/developers/index.md
@@ -49,7 +49,14 @@ Please ensure that you have the following prerequisites installed as well:
 
 1. [Git](https://git-scm.com/downloads) For retrieving our source code and push changes back. On Windows: Must be available in %PATH%
 1. [Maven 3.x](https://maven.apache.org/download.cgi) Our build system tool. On Windows: Must be available in %PATH%
-1. Java JDK 17, for example from Oracle [Oracle JDK 17](https://www.oracle.com/java/technologies/javase/jdk17-archive-downloads.html). On Windows: %JAVA% must be set.
+1. Java JDK 17 or JDK 21, for example from Oracle [Oracle JDK 17](https://www.oracle.com/java/technologies/javase/jdk17-archive-downloads.html) or [Oracle JDK 21](https://www.oracle.com/java/technologies/javase/jdk17-archive-downloads.html). On Windows: %JAVA% must be set.
+
+::: tip Note
+Whereas we recommend Java 17 for running openHAB, development can be safely done on Java 21.
+With default settings, the Java 21 compiler will generate Java objects compatible with JRE 17.
+If you run your openHAB server on Java 21, you can enable native Java 21 objects by adding `-Pj21` to the Maven command line.
+Note that our CI checks Java 17 and Java 21 compatibility, and we only use language features available in Java 17.
+:::
 
 You can use any IDE that is suitable for OSGi/Java development.
 We have prepared some step-by-step guides for the following IDEs:

--- a/installation/index.md
+++ b/installation/index.md
@@ -41,7 +41,10 @@ You could also [download Azul Zulu](https://www.azul.com/downloads/zulu-communit
 Oracle Java is also suitable for most configurations but it's not recommended. Licensing restrictions may apply.
 
 ::: warning
-Please note that versions of Java higher than 17 are not supported at the moment.
+Java 17 is recommended for openHAB.
+Using Java 21 is possible, but still considered experimental.
+OpenHABian can install Java 21, but only on the native 64-bit image.
+Please note that versions of Java other than 17 and 21 are not supported at the moment.
 :::
 
 | Java Platform                               | Advantages                                                                                                                                                                            | Disadvantages                                                                                                                                                                                                                                                                                                                        |

--- a/installation/linux.md
+++ b/installation/linux.md
@@ -34,6 +34,7 @@ When installing Zulu or Zulu Embedded from a .zip or .tar archive, make sure to 
 
 ::: tip Note
 Make sure to download Zulu or Java **17**.
+Using Java 21 is possible, but still considered experimental.
 :::
 
 ## Installation


### PR DESCRIPTION
Document current state of Java 21 support.

Not sure why we recommend Oracle JDK and not OpenJDK....