### PR TITLE
Make recently added logos visible on the website

### DIFF
--- a/_addons_bindings/freeathome/readme.md
+++ b/_addons_bindings/freeathome/readme.md
@@ -5,6 +5,7 @@ title: ABB/Busch-free@home Smart Home binding - Bindings
 type: binding
 description: "openHAB ABB/Busch-free@home binding based on the offical free@home local API."
 since: 3x
+logo: images/addons/freeathome.svg
 install: auto
 ---
 

--- a/_addons_bindings/freecurrency/readme.md
+++ b/_addons_bindings/freecurrency/readme.md
@@ -5,6 +5,7 @@ title: Freecurrency - Bindings
 type: binding
 description: "The Freecurrency binding connects [Freecurrency API](https://freecurrencyapi.com) to openHAB."
 since: 3x
+logo: images/addons/freecurrency.png
 install: auto
 ---
 


### PR DESCRIPTION
This change is required as Jenkins is not migrating external content anymore, and therefore the new logos are not picked up.