### PR TITLE
Fix broken link to addons transform section

### DIFF
--- a/configuration/transformations.md
+++ b/configuration/transformations.md
@@ -211,6 +211,6 @@ Number <itemName> { channel="<channelUID>"[profile="transform:RB", toItemScript=
 
 ::: tip
 
-You can find the available transformation services [here]({{base}}/adddons/#transform).
+You can find the available transformation services [here](/addons/#transform).
 
 :::


### PR DESCRIPTION
Should be applied to the current 4.2 docs too