### PR TITLE
[ism8] Fix broken image in docs

### DIFF
--- a/_addons_bindings/ism8/readme.md
+++ b/_addons_bindings/ism8/readme.md
@@ -210,4 +210,4 @@ NULL=Undefiniert
 ```
 
 _Result_
-<img src="doc/Sitemap-Example.png" width="800" height="600">
+<img src="./doc/Sitemap-Example.png" width="800" height="600">


### PR DESCRIPTION
try to backport openhab/openhab-addons#17175 to stable docs, not sure if this is the right way to do it