### PR TITLE
Fix Documentation of Transform Values - specifically Script Transformations

### DIFF
--- a/configuration/transformations.md
+++ b/configuration/transformations.md
@@ -142,18 +142,18 @@ Examples:
 ::: tab DSL
 
 ```java
-DSL(|"String has " + input.length + " characters")
+DSL:|"String has " + input.length + " characters"
 ```
 
 :::
 
 ::: tab JS
 
-For the modern JS Scripting, the transformation is `JS(|...)`.
-For the legacy JS Scripting, the transformation is `NASHORNJS(|...)`.
+For the modern JS Scripting, the transformation is `JS:|...`.
+For the legacy JS Scripting, the transformation is `NASHORNJS:|...`.
 
 ```javascript
-JS(|"String has " + input.length + " characters")
+JS:|"String has " + input.length + " characters"
 ```
 
 :::
@@ -161,7 +161,7 @@ JS(|"String has " + input.length + " characters")
 ::: tab JRuby
 
 ```ruby
-RB(|"String has #{input.length} characters")
+RB:|"String has #{input.length} characters"
 ```
 
 :::
@@ -169,7 +169,7 @@ RB(|"String has #{input.length} characters")
 ::: tab Groovy
 
 ```groovy
-GROOVY(|"String has ${input.length()} characters")
+GROOVY:|"String has ${input.length()} characters"
 ```
 
 :::


### PR DESCRIPTION
Transformations given as example for JavaScript `JS(|"String has " + input.length + " characters")` result in following error in OpenHAB 4.2.1 log:

Configuration error for channel 'mqtt:topic:...' java.lang.IllegalArgumentException: The transformation pattern must consist of the type and the pattern separated by a colon

Using format `JS:|"String has " + input.length + " characters"` the transformation works as expected.