### PR TITLE
JSR223: make clear two different implementations of RuleRegistry are injected

### DIFF
--- a/configuration/jsr223.md
+++ b/configuration/jsr223.md
@@ -309,7 +309,7 @@ The `default` preset is preloaded, so it does not require importing.
 | `ir`                    | Alias for `itemRegistry`                                                                                                                                                                                    |
 | `itemRegistry`          | Instance of `org.openhab.core.items.ItemRegistry`                                                                                                                                                           |
 | `things`                | Instance of `org.openhab.core.thing.ThingRegistry`                                                                                                                                                          |
-| `rules`                 | Instance of `org.openhab.core.automation.RuleRegistry`                                                                                                                                                      |
+| `rules`                 | One implementation of [`org.openhab.core.automation.RuleRegistry`](https://www.openhab.org/javadoc/latest/org/openhab/core/automation/ruleregistry)                                                         |
 | `events`                | (internal) Used to send events, post commands, etc. [Details](#events-operations) below]                                                                                                                    |
 | `actions`               | Instance of [`org.openhab.core.automation.module.script.defaultscope.ScriptThingActions`](https://www.openhab.org/javadoc/latest/org/openhab/core/automation/module/script/defaultscope/scriptthingactions) |
 | `scriptExtension`       | (internal) For loading script presets.                                                                                                                                                                      |
@@ -371,7 +371,7 @@ scriptExtension.importPreset("RuleSupport")
 | Trigger           | `org.openhab.core.automation.Trigger`                                             |
 | TriggerBuilder    | `org.openhab.core.automation.TriggerBuilder`                                      |
 | automationManager | Instance for managing rules and other openHAB module instances. (e.g., `addRule`) |
-| ruleRegistry      | `org.openhab.core.automation.Rule`                                                |
+| ruleRegistry      | Another implementation of `org.openhab.core.automation.RuleRegistry`              |
 
 #### `RuleFactories` Preset
 


### PR DESCRIPTION
For some reason JSR223 injects two different implementations of the [org.openhab.core.automation](https://www.openhab.org/javadoc/latest/org/openhab/core/automation/package-summary) interface.

This is confirmed by the Groovy code below:
```java
import org.openhab.core.automation.RuleRegistry

org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger("a1")

scriptExtension.importPreset("RuleSupport")
logger.info(rules.class.toString())
logger.info(rules instanceof RuleRegistry? "true": "false") // from Default preset
logger.info(rules instanceof org.openhab.core.automation.Action ? "true" : "false")

logger.info(ruleRegistry.class.toString())
logger.info(ruleRegistry instanceof RuleRegistry ? "true" : "false") // from RuleSupport preset
logger.info(ruleRegistry instanceof org.openhab.core.automation.Action ? "true" : "false")
```
which prints
```
2024-09-04 14:11:12.512 [INFO ] [ort.loader.AbstractScriptFileWatcher] - (Re-)Loading script '/etc/openhab/automation/jsr223/t.groovy'
2024-09-04 14:11:12.551 [INFO ] [a1 ] - class org.openhab.core.automation.internal.RuleRegistryImpl
2024-09-04 14:11:12.553 [INFO ] [a1 ] - true
2024-09-04 14:11:12.555 [INFO ] [a1 ] - false
2024-09-04 14:11:12.560 [INFO ] [a1 ] - class org.openhab.core.automation.module.script.rulesupport.shared.RuleSupportRuleRegistryDelegate
2024-09-04 14:11:12.562 [INFO ] [a1 ] - true
2024-09-04 14:11:12.563 [INFO ] [a1 ] - false
```

I asked for the rationale on this at  https://community.openhab.org/t/why-does-jsr223-provide-two-implementations-of-the-ruleregistry-interface/.