### PR TITLE
Adjust add-on README logo

### DIFF
--- a/process_addons.groovy
+++ b/process_addons.groovy
@@ -95,10 +95,13 @@ def process_addon_type = { features, sources, type, collection, suffix, lblremov
                     }
                     front = front + feature
                     def toYaml = { '---\n' + it.collect{ /$it.key: $it.value/ }.join('\n') + '\n---\n\n' }
+                    def heading = readme.text.find(/# .*/)
+                    def text = readme.text.replace(heading, '')
                     readme.write(toYaml(front)
                       + '<!-- Attention authors: Do not edit directly. Please add your changes to the appropriate source repository -->\n\n{% include base.html %}\n\n'
-                      + ((logo_svg || logo_png) ? '<AddonLogo />\n\n' : '')
-                      + readme.text)
+                      + heading
+                      + ((logo_svg || logo_png) ? '\n\n<AddonLogo />' : '')
+                      + text)
                 }
             }
             print "\n"


### PR DESCRIPTION
Follow-up for #2380.

Currently, the `<AddonLogo />` component is inserted as the first child into the readme, which causes styling issues.
It instead needs to be put after the heading.