### PR TITLE
Remove wrappers from inline transformation documentation examples

### DIFF
--- a/configuration/transformations.md
+++ b/configuration/transformations.md
@@ -145,7 +145,7 @@ Examples:
 ::: tab DSL
 
 ```java
-DSL(|"String has " + input.length + " characters")
+|"String has " + input.length + " characters"
 ```
 
 :::
@@ -156,7 +156,7 @@ For the modern JS Scripting, the transformation is `JS(|...)`.
 For the legacy JS Scripting, the transformation is `NASHORNJS(|...)`.
 
 ```javascript
-JS(|"String has " + input.length + " characters")
+|"String has " + input.length + " characters"
 ```
 
 :::
@@ -164,7 +164,7 @@ JS(|"String has " + input.length + " characters")
 ::: tab JRuby
 
 ```ruby
-RB(|"String has #{input.length} characters")
+|"String has #{input.length} characters"
 ```
 
 :::
@@ -172,7 +172,7 @@ RB(|"String has #{input.length} characters")
 ::: tab Groovy
 
 ```groovy
-GROOVY(|"String has ${input.length()} characters")
+|"String has ${input.length()} characters"
 ```
 
 :::


### PR DESCRIPTION
Based on my observations on 4.3.0.M2, the inline transformations should not be like `JS(|"String has " + input.length + " characters")` like shown in the current documentation. Instead, it should be like `|"String has " + input.length + " characters"`.

I tested the syntax with DSL and ECMAScript but assume the same thing applies to Ruby and Groovy (but did not test those).

Cheers,
Markus