### PR TITLE
Set nginx proxy HTTP version to 1.1 in reverse proxy config

### DIFF
--- a/installation/reverse-proxy.md
+++ b/installation/reverse-proxy.md
@@ -46,6 +46,7 @@ server {
     add_header 'Access-Control-Allow-Methods' 'GET,POST,OPTIONS,PUT,DELETE,PATCH' always;
 
     location / {
+        proxy_http_version                    1.1;
         proxy_pass                            http://localhost:8080/;
         proxy_set_header Host                 $http_host;
         proxy_set_header X-Real-IP            $remote_addr;
@@ -326,6 +327,7 @@ server {
     add_header                      Strict-Transport-Security "max-age=31536000"; # Remove if using self-signed and are having trouble.
 
     location / {
+        proxy_http_version                      1.1;
         proxy_pass                              http://localhost:8080/;
         proxy_set_header Host                   $http_host;
         proxy_set_header X-Real-IP              $remote_addr;
@@ -468,6 +470,7 @@ server {
     add_header Set-Cookie X-OPENHAB-AUTH-HEADER=1;
 
     location / {
+        proxy_http_version                      1.1;
         proxy_pass                              https://localhost:8443/; #Update the port number if needed
         proxy_set_header Host                   $http_host;
         proxy_set_header X-Real-IP              $remote_addr;


### PR DESCRIPTION
HTTP 1.1 is required for WebSockets to work.
As the new log viewer uses the log WebSocket, it is required to modify the reverse proxy config.