### PR TITLE
Remove references to deprecated `DateTimeType` method `getZonedDateTime`

### DIFF
--- a/configuration/actions.md
+++ b/configuration/actions.md
@@ -263,7 +263,7 @@ Action | Returns
 `getNextBankHoliday` | name of the next bank holiday
 `getNextBankHoliday(<file>)` | name of the next bank holiday defined in `<file>`
 `getNextBankHoliday(<offset>)` | name of the next bank holiday after `<offset>` days from today
-`getNextBankHoliday(<offset>, <file>)` | name of the next bank holiday after `<offset>` days from today defined in `<file>`. :warning: This action is broken in OH 2.5.x. Use `getNextBankHoliday(<datetime>, <file>)` instead by replacing `<datetime>` with `new DateTimeType().zonedDateTime.now().plusDays(<offset>)`
+`getNextBankHoliday(<offset>, <file>)` | name of the next bank holiday after `<offset>` days from today defined in `<file>`. :warning: This action is broken in OH 2.5.x. Use `getNextBankHoliday(<datetime>, <file>)` instead by replacing `<datetime>` with `now.plusDays(<offset>)`
 `getNextBankHoliday(<datetime>)` | name of the next bank holiday after the day defined by the `ZonedDateTime` `<datetime>`
 `getNextBankHoliday(<datetime>, <file>)` | name of the next bank holiday after the day defined by the `ZonedDateTime` `<datetime>` defined in `<file>`
 `isBankHoliday` | `true` if today is a bank holiday (see below), `false` otherwise

--- a/configuration/rules-dsl.md
+++ b/configuration/rules-dsl.md
@@ -496,13 +496,13 @@ A DateTime Item carries a **DateTimeType**, which internally holds a Java `Zoned
 
 ```java
 // Get epoch from DateTimeType
-val Number epoch = (MyDateTimeItem.state as DateTimeType).zonedDateTime.toInstant.toEpochMilli
+val Number epoch = (MyDateTimeItem.state as DateTimeType).instant.toEpochMilli
 
 // Get epoch from Java ZonedDateTime
 val Number nowEpoch = now.toInstant.toEpochMilli
 
 // Convert DateTimeType to Java ZonedDateTime
-val javaZonedDateTime = (MyDateTimeItem.state as DateTimeType).zonedDateTime
+val javaZonedDateTime = (MyDateTimeItem.state as DateTimeType).getZonedDateTime(ZoneId.systemDefault)
 
 // Convert Java ZonedDateTime to DateTimeType
 val DateTimeType date = new DateTimeType(now)
@@ -531,13 +531,13 @@ ZonedDateTimes provide a number of useful methods for comparing date times toget
 
 ```java
 // See if DateTimeType is before now
-if(now.isBefore((MyDateTimeItem.state as DateTimeType).zonedDateTime)) ...
+if(now.toInstant.isBefore((MyDateTimeItem.state as DateTimeType).instant)) ...
 
 // See if DateTimeType is after now
-if(now.isAfter((MyDateTimeItem.state as DateTimeType).zonedDateTime)) ...
+if(now.toInstant.isAfter((MyDateTimeItem.state as DateTimeType).instant)) ...
 
 // Get the hour in the day from a DateTimeType
-val hour = (MyDateTimeItem.state as DateTimeType).zonedDateTime.hour
+val hour = (MyDateTimeItem.state as DateTimeType).getZonedDateTime(ZoneId.systemDefault).hour
 ```
 
 ##### Dimmer Item


### PR DESCRIPTION
Related to openhab/openhab-core#3583