### PR TITLE
Script Editor: Update shortcut key for deleting the current line

### DIFF
--- a/mainui/settings/script-editor.md
+++ b/mainui/settings/script-editor.md
@@ -36,7 +36,7 @@ Other:
 
 - <kbd>Tab</kbd>: Indent more.
 - <kbd>Shift</kbd><kbd>Tab</kbd>: Indent less.
-- <kbd>Ctrl</kbd><kbd>D</kbd>: Delete the current line.
+- <kbd>Ctrl</kbd><kbd>Shift</kbd><kbd>K</kbd>: Delete the current line or selection.
 - <kbd>Ctrl</kbd><kbd>/</kbd>: Comment/Uncomment the current line.
 - <kbd>Ctrl</kbd><kbd>A</kbd>: Select all.
 <!-- END MAINUI SIDEBAR DOC - DO NOT REMOVE -->


### PR DESCRIPTION
See: https://github.com/openhab/openhab-webui/pull/3156

@florian-h05 
- There was "Delete the curent line" Ctrl+D already there, but I found that, at least on a Mac:

  - Ctrl D deletes a character, not the line
  - Cmd D deletes the line, but not when it's the last line
  - However, either of those, caused the script to get disabled/enabled

So I've decided to just replace the entry in the doc with the new Ctrl Shift K