### PR TITLE
stateDescription: change to read-write

### DIFF
--- a/configuration/items.md
+++ b/configuration/items.md
@@ -271,6 +271,13 @@ Number    Livingroom_Clock_Battery "Battery Charge [%d %%]"            // e.g. "
 Location  My_Location              "My Location [%2$s°N %3$s°E %1$sm]" // e.g. "49.26°N 123.19°E 0m"
 ```
 
+##### State Description
+
+Internally items have a State Description, which can be obtained by GET `/rest/items/<itemName>`.
+When an item is linked to a channel without `CommandTopic`, the State Description of the item is read-only.
+Some UIs may disallow the user to send commands to such an item.
+To change the item to read-write add `stateDescription=" "[readOnly=false]` in bindingconfig.
+
 #### State Transformation
 
 Transformations can be used in the state part of an Item, to translate the raw state of an Item into another language, or to convert technical values into human readable information.


### PR DESCRIPTION
This takes the text from https://github.com/openhab/openhab-addons/issues/18362#issuecomment-2797687192 and extends the documentation, telling the user how an item, bound to read-only channel, can be made read-write.

However I have experience only with MQTT and there `CommandTopic` applies.  For other things `CommandTopic` might not be adequate.