### PR TITLE
Fix documentation PR preview

### DIFF
--- a/.vuepress/add_placeholders.rb
+++ b/.vuepress/add_placeholders.rb
@@ -17,7 +17,10 @@ def add_placeholder_pages()
         "docs/ecosystem/google-assistant",
         "docs/ecosystem/ifttt",
         "docs/ecosystem/mycroft",
-        "docs/installation/openhabian.md"
+        "docs/installation/openhabian.md",
+        "docs/installation/openhabian-troubleshooting.md",
+        "docs/installation/openhabian-backup.md",
+        "docs/installation/openhabian-exim.md"
     ].each { |path|
         puts "  ➡️ #{path}"
         page = path


### PR DESCRIPTION
The openHABian sidebar entries added in #2434 break the Netlify preview build so some more placeholder files are necessary.