### PR TITLE
Tagging conventions for commonly confused cases

### DIFF
--- a/developers/bindings/thing-xml.md
+++ b/developers/bindings/thing-xml.md
@@ -994,3 +994,31 @@ The contents of this list are dynamic, and it may be extended from time to time.
 If you are an addon developer and you think there is something missing from the list please open an [Issue](https://github.com/openhab/openhab-core/issues) or [Pull Request](https://github.com/openhab/openhab-core/pulls) on GitHub.
 
 1. For further reading please see the [Description of the Semantic Model]({{base}}/tutorial/model.html), the [Developer Guidelines on Semantic Tags](semantic-tags.md) and the [Thing-Type and Channel-Type validation schema](https://www.openhab.org/schemas/thing-description-1.0.0.xsd).
+
+## Tagging Conventions for Commonly Confused Use Cases
+
+The following are some use cases that commonly lead to confusion.
+The purpose of this list is to provide the convention for tagging such cases:
+
+1. In the case of `Point` and `Property` tags it may help to consider the `Point` as the VERB and the `Property` as the OBJECT in a sentence.
+So a channel may make a 'Measurement' of a 'Temperature', or show the 'Status' of an operating 'Mode' etc.
+
+1. Do not confuse `Property` tags with Units of Measure.
+A `Property` tag is a WORD (see above) that describes the nature an the action being taken by its respective `Point`.
+So for example `Speed` need not be taken precisely to mean `m/sec` .. but can in general cover operations that "do much stuff in little time".
+
+1. For turning a piece of equipment on or off:
+`Switch.Light` should be used if the equipment is a light, otherwise `Switch.Power` should be used.
+
+1. For switching the operating mode of a piece of equipment (e.g. Auto/Manual, Day/Night, Disable/Enable, etc.):
+`Switch.Mode` should be used.
+
+1. For equipment having a set-point, even if the set-point is read-only for openHAB, it is OK to use `Setpoint.whatever`.
+
+1. For weather channels:
+`Forecast.whatever` is advised.
+
+1. For astronomical channels: `Calculation.whatever` should be used instead of `Forecast.whatever`.
+
+1. For equipment (e.g. fans, pumps) that can run at several speed/power/volume/flow-rates (e.g. Off/Low/Medium/High):
+`Control.Speed` should be used.

--- a/developers/bindings/thing-xml.md
+++ b/developers/bindings/thing-xml.md
@@ -1022,8 +1022,8 @@ However for **_this specific case_** ("throughput of a fan/pump") `Control.Speed
 
 1. The `Calculation` point type is used when (past or future) data is derived via a precise mathematical formula.
 By contrast the `Forecast` point type is used when (future) data is derived via a human or algorithmic estimation.
-So `Calculation` should be used for astronomical data e.g. the time of sunrise tomorrow.
-Whereas `Forecast` should be used for weather or solar forecasts, future energy prices or currency rates, etc.
+So `Calculation` should be used e.g. for astronomical data such as the time of sunrise tomorrow.
+Whereas `Forecast` should be used e.g. for weather or solar forecasts, etc.
 
 1. For tagging channels that represent entertainment media (e.g. album, artist, composer, actor, director. etc.):
 `Status.Info` should be used.

--- a/developers/bindings/thing-xml.md
+++ b/developers/bindings/thing-xml.md
@@ -1011,7 +1011,7 @@ So for example `Speed` need not be taken precisely to mean `m/sec` .. but can in
 `Switch.Light` should be used if the equipment is a light, otherwise `Switch.Power` should be used.
 
 1. For reporting or controlling the operating mode of a piece of equipment (e.g. auto/manual, day/night, disable/enable, etc.):
-If the channel has a two states (e.g. via a `Switch` type channel) then `Switch.Mode` should be used.
+If the channel has two states (e.g. via a `Switch` type channel) then `Switch.Mode` should be used.
 Or if it has multiple states (e.g. heat/cool/dry/fan/auto via a `String` type channel) then `Control.Mode` should be used.
 
 1. For equipment having a set-point, even if the set-point is read-only for openHAB, it is OK to use `Setpoint.whatever`.
@@ -1028,4 +1028,5 @@ Or if it has multiple states (e.g. heat/cool/dry/fan/auto via a `String` type ch
 `Status.Info` should be used.
 
 1. For tagging channels that relate to the progress of playing entertainment media, or of an automatic program:
-`Status.Progress` should be used.
+`Status.Progress` should be used to indicate the current progress.
+Or `Control.Progress` to change the progress (e.g. via a 'fast forward' or 'next' command).

--- a/developers/bindings/thing-xml.md
+++ b/developers/bindings/thing-xml.md
@@ -1015,8 +1015,8 @@ If the channel has two states (e.g. via a `Switch` type channel) then `Switch.Mo
 Or if it has multiple states (e.g. heat/cool/dry/fan/auto via a `String` type channel) then `Control.Mode` should be used.
 
 1. For equipment (e.g. fans, pumps) that can run at several speed/power/volume/flow-rates (e.g. Off/Low/Medium/High):
-In theory the above-mentioned "operating mode of a piece of equipment" `Control.Mode` ***could*** also be applied in this case.
-However for ***this specific case*** ("throughput of a fan/pump") `Control.Speed` should be used instead.
+In theory the above-mentioned "operating mode of a piece of equipment" `Control.Mode` **_could_** also be applied in this case.
+However for **_this specific case_** ("throughput of a fan/pump") `Control.Speed` should be used instead.
 
 1. For equipment having a set-point, even if the set-point is read-only for openHAB, it is appropriate to use `Setpoint.whatever`.
 

--- a/developers/bindings/thing-xml.md
+++ b/developers/bindings/thing-xml.md
@@ -1005,7 +1005,6 @@ So a channel may make a 'Measurement' of a 'Temperature', or show the 'Status' o
 
 1. Do not confuse `Property` tags with Units of Measure.
 A `Property` tag is a WORD (see above) that describes the nature of the action being taken by its respective `Point`.
-
 So for example `Speed` need not be taken precisely to mean `m/sec` .. but can in general cover operations that "do much stuff in little time".
 
 1. For turning a piece of equipment on or off:

--- a/developers/bindings/thing-xml.md
+++ b/developers/bindings/thing-xml.md
@@ -1022,3 +1022,9 @@ So for example `Speed` need not be taken precisely to mean `m/sec` .. but can in
 
 1. For equipment (e.g. fans, pumps) that can run at several speed/power/volume/flow-rates (e.g. Off/Low/Medium/High):
 `Control.Speed` should be used.
+
+1. For tagging channels that represent entertainment media (e.g. album, artist, composer, actor, director. etc.):
+`Status.Info` should be used.
+
+1. For tagging channels that relate to the progress of playing entertainment media, or of an automatic program:
+`Status.Progress` should be used.

--- a/developers/bindings/thing-xml.md
+++ b/developers/bindings/thing-xml.md
@@ -1011,8 +1011,9 @@ So for example `Speed` need not be taken precisely to mean `m/sec` .. but can in
 1. For turning a piece of equipment on or off:
 `Switch.Light` should be used if the equipment is a light, otherwise `Switch.Power` should be used.
 
-1. For switching the operating mode of a piece of equipment (e.g. Auto/Manual, Day/Night, Disable/Enable, etc.):
-`Switch.Mode` should be used.
+1. For reporting or controlling the operating mode of a piece of equipment (e.g. auto/manual, day/night, disable/enable, etc.):
+If the channel has a two states (e.g. via a `Switch` type channel) then `Switch.Mode` should be used.
+Or if it has multiple states (e.g. heat/cool/dry/fan/auto via a `String` type channel) then `Control.Mode` should be used.
 
 1. For equipment having a set-point, even if the set-point is read-only for openHAB, it is OK to use `Setpoint.whatever`.
 

--- a/developers/bindings/thing-xml.md
+++ b/developers/bindings/thing-xml.md
@@ -1004,7 +1004,8 @@ The purpose of this list is to provide the convention for tagging such cases:
 So a channel may make a 'Measurement' of a 'Temperature', or show the 'Status' of an operating 'Mode' etc.
 
 1. Do not confuse `Property` tags with Units of Measure.
-A `Property` tag is a WORD (see above) that describes the nature an the action being taken by its respective `Point`.
+A `Property` tag is a WORD (see above) that describes the nature of the action being taken by its respective `Point`.
+
 So for example `Speed` need not be taken precisely to mean `m/sec` .. but can in general cover operations that "do much stuff in little time".
 
 1. For turning a piece of equipment on or off:

--- a/developers/bindings/thing-xml.md
+++ b/developers/bindings/thing-xml.md
@@ -1014,15 +1014,16 @@ So for example `Speed` need not be taken precisely to mean `m/sec` .. but can in
 If the channel has two states (e.g. via a `Switch` type channel) then `Switch.Mode` should be used.
 Or if it has multiple states (e.g. heat/cool/dry/fan/auto via a `String` type channel) then `Control.Mode` should be used.
 
-1. For equipment having a set-point, even if the set-point is read-only for openHAB, it is OK to use `Setpoint.whatever`.
-
-1. For weather channels:
-`Forecast.whatever` is advised.
-
-1. For astronomical channels: `Calculation.whatever` should be used instead of `Forecast.whatever`.
-
 1. For equipment (e.g. fans, pumps) that can run at several speed/power/volume/flow-rates (e.g. Off/Low/Medium/High):
-`Control.Speed` should be used.
+In theory the above-mentioned "operating mode of a piece of equipment" `Control.Mode` ***could*** also be applied in this case.
+However for ***this specific case*** ("throughput of a fan/pump") `Control.Speed` should be used instead.
+
+1. For equipment having a set-point, even if the set-point is read-only for openHAB, it is appropriate to use `Setpoint.whatever`.
+
+1. The `Calculation` point type is used when (past or future) data is derived via a precise mathematical formula.
+By contrast the `Forecast` point type is used when (future) data is derived via a human or algorithmic estimation.
+So `Calculation` should be used for astronomical data e.g. the time of sunrise tomorrow.
+Whereas `Forecast` should be used for weather or solar forecasts, future energy prices or currency rates, etc.
 
 1. For tagging channels that represent entertainment media (e.g. album, artist, composer, actor, director. etc.):
 `Status.Info` should be used.


### PR DESCRIPTION
This adds a documentation chapter for commonly confused/discussed tagging use cases.

Background: during the current ongoing mass tagging process it was discovered that there are some common use cases where code owners and code maintainers have been confused by, or raised questions about, the proper convention for common tag use cases. These cases have often been decided on-the-fly in the review comments of the respective PRs (which makes it hard to keep track of afterwards). This document captures the conclusions for posterity in one central place.

Signed-off-by: Andrew Fiddian-Green <software@whitebear.ch>
