### PR TITLE
Enable Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,13 +5,6 @@
 
 version: 2
 
-# this would enable querying all packages from our repo first,
-# disabled for now as we do not want to use it. Kept for reference.
-#registries:
-#  openhab-jfrog:
-#    type: "maven-repository"
-#    url: "https://openhab.jfrog.io/artifactory/libs-all/"
-
 updates:
   - package-ecosystem: "github-actions" # See documentation for possible values
     directory: "/" # Location of package manifests
@@ -20,4 +13,3 @@ updates:
     open-pull-requests-limit: 10
     labels:
       - dependencies
-


### PR DESCRIPTION
Enable Dependabot to update all GitHub actions.

This will _not_ update the vue config.

I tried this on my fork. When merged, it will create 4 PRs for outdated actions.
If no Dependabot actions runs, pls check https://github.com/openhab/openhab-docs/network/updates and enable Dependabot. It will complain that no config is available, this can be ignored; the config is in this PR.