### PR TITLE
rules_overview.md: elaborate about concurrency support in rule engines

### DIFF
--- a/tutorials/getting_started/rules_overview.md
+++ b/tutorials/getting_started/rules_overview.md
@@ -16,12 +16,14 @@ The list is sorted alphabetically by name and it is meant as a starting point fo
 | Name                                                         | Native             | Language/Graphical | Notes                                                                                     |
 |--------------------------------------------------------------|--------------------|--------------------|-------------------------------------------------------------------------------------------|
 | [Blockly](rules_blockly.html)                                | :heavy_check_mark: | Graphical          | Only available through the UI                                                             |
-| [GraalVM JavaScript](/addons/automation/jsscripting/)        | :heavy_check_mark: | ECMAScript 2024+   | Enabled by installing an official add-on                                                  |
+| [GraalVM JavaScript](/addons/automation/jsscripting/)        | :heavy_check_mark: | ECMAScript 2024+   | Enabled by installing an official add-on.  Has no concurrency.                            |
 | [Groovy](/addons/automation/groovyscripting/)                | :heavy_check_mark: | Groovy 4.0         | Enabled by installing an official add-on                                                  |
 | [HABApp](https://habapp.readthedocs.io/)                     | :x:                | >= Python 3.8      | A third-party solution                                                                    |
 | [JRuby](/addons/automation/jrubyscripting/)                  | :heavy_check_mark: | Ruby 3.4           | Enabled by installing an official add-on                                                  |
 | [Jython](/addons/automation/jythonscripting)                 | :heavy_check_mark: | Python 2.7         | Enabled by installing an official add-on. This has been superseded by Python (3.x) below. |
 | [Nashorn JavaScript](/addons/automation/jsscriptingnashorn/) | :heavy_check_mark: | ECMAScript 5.1     | Deprecated                                                                                |
 | NodeRed                                                      | :x:                | Graphical          | Own UI. A third-party solution                                                            |
-| [Python](/addons/automation/pythonscripting/)                | :heavy_check_mark: | Python 3.x         | Enabled by installing an official add-on                                                  |
+| [Python](/addons/automation/pythonscripting/)                | :heavy_check_mark: | Python 3.x         | Enabled by installing an official add-on.  Has no concurrency.                            |
 | [RulesDSL](/docs/configuration/rules-dsl.html)               | :heavy_check_mark: | RulesDSL           | Built-in                                                                                  |
+
+No concurrency means, that at any time only a single rule or transformation is executed by the rule engine.


### PR DESCRIPTION
Based on discussion at https://community.openhab.org/t/java223-scripting-script-with-java-on-openhab-5-0-1-0-6-0-0-0/159853/27, and looking for `git grep [^a-zA-Z]Lock bundles/org.openhab.automation.*`, I see that only `org.openhab.automation.pythonscripting.internal.PythonScriptEngine` and `org.openhab.automation.jsscripting.internal.OpenhabGraalJSScriptEngine` implement `Lock`.  My understanding is that in these cases there is a single thread, which executes all the Python/GraalVM code, and another thread for executing all the JavaScript/GraalVM code.  Hence the last sentence of the changeset.