### PR TITLE
configuration/jsr223: formatting of RuleSimple preset

### DIFF
--- a/configuration/jsr223.md
+++ b/configuration/jsr223.md
@@ -245,7 +245,7 @@ With `scriptExtension.get("automationManager")` the `automationManager` can be m
   - [`ScriptExtension` Objects (all JSR223 languages)](#scriptextension-objects-all-jsr223-languages)
     - [Default Preset (`importPreset` not required)](#default-preset-importpreset-not-required)
       - [`events` operations](#events-operations)
-    - [RuleSimple Preset](#rulesimple-preset)
+    - [`RuleSimple` Preset](#rulesimple-preset)
     - [`RuleSupport` Preset](#rulesupport-preset)
     - [`RuleFactories` Preset](#rulefactories-preset)
     - [`ScriptAction` Preset](#scriptaction-preset)
@@ -329,7 +329,7 @@ With `scriptExtension.get("automationManager")` the `automationManager` can be m
 - `events.storeStates(Item...)`
 - `events.restoreStates(Map<Item, State>)`
 
-#### RuleSimple Preset
+#### `RuleSimple` Preset
 
 These variables and classes are loaded using:
 


### PR DESCRIPTION
This is supposed to fix the formatting at https://www.openhab.org/docs/configuration/jsr223.html:

<img width="237" height="144" alt="image" src="https://github.com/user-attachments/assets/e28bd4d7-8681-4d07-ac0e-a56055b6d4aa" />

<img width="189" height="691" alt="image" src="https://github.com/user-attachments/assets/c2f4a85e-ddd7-421c-9b10-cd11f6193257" />
