### PR TITLE
jsr223: RuleSupport preset - add hyperlinks to the imported classes

### DIFF
--- a/configuration/jsr223.md
+++ b/configuration/jsr223.md
@@ -360,19 +360,19 @@ These variables and classes are loaded using:
 scriptExtension.importPreset("RuleSupport")
 ```
 
-| Variable          | Description                                                                       |
-| ----------------- | --------------------------------------------------------------------------------- |
-| Action            | `org.openhab.core.automation.Action`                                              |
-| ActionBuilder     | `org.openhab.core.automation.ActionBuilder`                                       |
-| Condition         | `org.openhab.core.automation.Condition`                                           |
-| ConditionBuilder  | `org.openhab.core.automation.ConditionBuilder`                                    |
-| Configuration     | `org.openhab.core.config.core.Configuration`                                      |
-| ModuleBuilder     | `org.openhab.core.automation.ModuleBuilder`                                       |
-| Rule              | `org.openhab.core.automation.Rule` (use `SimpleRule` for defining rules)          |
-| Trigger           | `org.openhab.core.automation.Trigger`                                             |
-| TriggerBuilder    | `org.openhab.core.automation.util.TriggerBuilder`                                 |
-| automationManager | Instance for managing rules and other openHAB module instances. (e.g., `addRule`) |
-| ruleRegistry      | `org.openhab.core.automation.Rule`                                                |
+| Variable          | Description                                                                                                                                                                                                                                                                                                 |
+| ----------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Action            | [`org.openhab.core.automation.Action`](https://www.openhab.org/javadoc/latest/org/openhab/core/automation/action)                                                                                                                                                                                           |
+| ActionBuilder     | [`org.openhab.core.automation.util.ActionBuilder`](https://www.openhab.org/javadoc/latest/org/openhab/core/automation/util/actionbuilder)                                                                                                                                                                   |
+| Condition         | [`org.openhab.core.automation.Condition`](https://www.openhab.org/javadoc/latest/org/openhab/core/automation/condition)                                                                                                                                                                                     |
+| ConditionBuilder  | [`org.openhab.core.automation.util.ConditionBuilder`](https://www.openhab.org/javadoc/latest/org/openhab/core/automation/util/conditionbuilder)                                                                                                                                                             |
+| Configuration     | [`org.openhab.core.config.core.Configuration`](https://www.openhab.org/javadoc/latest/org/openhab/core/config/core/configuration)                                                                                                                                                                           |
+| ModuleBuilder     | [`org.openhab.core.automation.util.ModuleBuilder`](https://www.openhab.org/javadoc/latest/org/openhab/core/automation/util/modulebuilder)                                                                                                                                                                   |
+| Rule              | [`org.openhab.core.automation.Rule`](https://www.openhab.org/javadoc/latest/org/openhab/core/automation/rule) (use `SimpleRule` for defining rules)                                                                                                                                                         |
+| Trigger           | [`org.openhab.core.automation.Trigger`](https://www.openhab.org/javadoc/latest/org/openhab/core/automation/trigger)                                                                                                                                                                                         |
+| TriggerBuilder    | [`org.openhab.core.automation.util.TriggerBuilder`](https://www.openhab.org/javadoc/latest/org/openhab/core/automation/util/triggerbuilder)                                                                                                                                                                 |
+| automationManager | [`org.openhab.core.automation.module.script.rulesupport.shared.ScriptedAutomationManager`](https://www.openhab.org/javadoc/latest/org/openhab/core/automation/module/script/rulesupport/shared/scriptedautomationmanager) instance for managing rules and other openHAB module instances. (e.g., `addRule`) |
+| ruleRegistry      | `org.openhab.core.automation.Rule`                                                                                                                                                                                                                                                                          |
 
 #### `RuleFactories` Preset
 


### PR DESCRIPTION
This clarifies that `automationManager` is of type ScriptedAutomationManager; inserts `.util` before ActionBuilder, ConditionBuilder and ModuleBuilder;  and puts hyperlinks to the documentation of the classes.

The last line:
```
| Variable          | Description                                                                       |
| ----------------- | --------------------------------------------------------------------------------- |
| ruleRegistry      | `org.openhab.core.automation.Rule`                                                |
```
was left as incorrect as it was.  It is discussed at https://github.com/openhab/openhab-docs/pull/2360.