### PR TITLE
jsr223 adjust ScriptAction Groovy example

### DIFF
--- a/configuration/jsr223.md
+++ b/configuration/jsr223.md
@@ -408,10 +408,8 @@ This preset can be useful for scheduling asynchronous code execution with `org.o
 
 ```groovy
 scriptExtension.importPreset("ScriptAction")
-scriptExtension.importPreset("RuleSupport")
-scriptExtension.importPreset("RuleSimple")
 
-scriptExecution.createTimer(ZonedDateTime.now(), {
+scriptExecution.createTimer(ZonedDateTime.now().plusSeconds(1), {
   org.slf4j.LoggerFactory.getLogger('Test logger').warn('Timer ran')
 })
 ```


### PR DESCRIPTION
* The removed `scriptExtension.importPreset`s are not relevant for this example.
* All other examples for scriptExecution.createTimer have a delay of 1 second.