### PR TITLE
jsr223.md: Unify the names of the tabs for JavaScript

### DIFF
--- a/configuration/jsr223.md
+++ b/configuration/jsr223.md
@@ -31,7 +31,7 @@ New APIs are planned to be implemented in the future, which will provide standar
 
 :::: tabs
 
-::: tab JavaScript/ECMAScript&nbsp;-&nbsp;262&nbsp;Edition&nbsp;5.1
+::: tab JS&nbsp;Nashorn
 
 ```js
 'use strict';
@@ -418,7 +418,7 @@ scriptExecution.createTimer(ZonedDateTime.now(), {
 
 :::
 
-::: tab JSScripting
+::: tab JS&nbsp;Scripting
 
 ```javascript
 actions.scriptExecution.createTimer(time.toZDT(1000), () => {
@@ -466,7 +466,7 @@ sharedCache.put("x", "y")
 
 :::
 
-::: tab Nashorn&nbsp;JS
+::: tab JS&nbsp;Nashorn
 
 ```js
 scriptExtension.importPreset("cache")


### PR DESCRIPTION
either “JS Nashorn” or “JS Scripting”.