### PR TITLE
README: update how to build the documentation locally

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@ rvm install ruby-3.3.2
 Next, you can build & serve the documentation preview:
 
 ```shell script
+npm install           # This needs to be run once for initialization
 npm run serve-preview
 ```
 


### PR DESCRIPTION
Calling just

> npm run serve-preview

prints
```
  ➡️  docs/installation/openhabian-backup.md
  ➡️  docs/installation/openhabian-exim.md

> openhab-docs@4.2.0 build-only
> vuepress build .

sh: line 1: vuepress: command not found
```