### PR TITLE
ScriptExecution actions: callScript() returns a value

### DIFF
--- a/configuration/actions.md
+++ b/configuration/actions.md
@@ -223,7 +223,7 @@ if ((thingStatusInfo !== null) && (thingStatusInfo.getStatus().toString() == "ON
 
 openHAB has several subsystems that can be accessed from Rules. These include persistence, see [Persistence Extensions in Scripts and Rules]({{base}}/configuration/persistence.html#persistence-extensions-in-scripts-and-rules), transformations, scripts.
 
-- `callScript(String scriptName)`: Calls a script which must be located in the `$OPENHAB_CONF/scripts` folder.
+- `callScript(String scriptName)`: Calls a script which must be located in the `$OPENHAB_CONF/scripts` folder. `callScript` returns the value of the last expression of the script.
 
 Scripts are small pieces of Rules DSL code that can be called from Rules.
 However, Scripts have limitations.


### PR DESCRIPTION
… because the loaded script is in Xbase, in Xbase everything is an expression, there are no statements.

In any case, here a test: in openhab/scripts/a.script I put
```
logError('A', "STARTED")
7
```
and in rules/z.rules
```
rule "change"
when Item r3 changed
then
  logError("B", "when Item r3 changed")
  logError("D", "M " + callScript("a"))
end

```
Then I get in openhab.log:
```
2025-10-15 19:30:56.904 [ERROR] [org.openhab.core.model.script.A   ] - when Item r3 changed
2025-10-15 19:30:56.932 [ERROR] [org.openhab.core.model.script.B   ] - STARTED
2025-10-15 19:30:56.935 [ERROR] [org.openhab.core.model.script.D   ] - M 7
```
so the value 7 (last line/exrpession of the script) was received by the rule.