### PR TITLE
getting_started: Persistence can be configured over UI

### DIFF
--- a/tutorials/getting_started/index.md
+++ b/tutorials/getting_started/index.md
@@ -59,7 +59,7 @@ Cons:
 
 - Can be slower to reach one's goal if you already know what you're doing and if there's a lot of bulk changes or duplicating required.
 - Harder to remove obsolete stuff.
-- Some things cannot be configured with the UI yet (e.g. persistence).
+- Some aspects cannot be configured with the UI yet.
 - You need to sit in front of a device with access to the UI to make changes.
 
 ## Table of Contents


### PR DESCRIPTION
Since openHAB 4.0 Persistence and Transformation can be configured over Main Ui.

I do not dare to ask here if there are other things, which cannot be configured yet over UI, justifying the remaining part of the line, as [I will be invited to delete the question](https://github.com/openhab/openhab-docs/pull/2586#issuecomment-3427656253).