### PR TITLE
Update event source guidelines

### DIFF
--- a/developers/utils/events.md
+++ b/developers/utils/events.md
@@ -43,9 +43,12 @@ This string type presentation is used by event subscribers for event subscriptio
 The event source identifies the sender.
 Not all senders will set the source.
 The source should be structured, consisting of a series of concatenated components (separated by `=>` to indicate delegation), and each component consists of a bundle name with an optional actor name (separated by `$`).
-Bundle names cannot contain either the delegation separator, or the actor separator.
+For example, given `org.openhab.ui.basic$default:03=>org.openhab.core.io.rest` we have two components separated by the `=>`.
+The first component has the bundle `org.openhab.ui.basic` and the actor `default:03`.
+The second component only has the bundle `org.openhab.core.io.rest`.
+Bundle names can contain neither the delegation separator, nor the actor separator.
 Actor names cannot contain the delegation separator.
-The sending bundle is meant to be the OSGi bundle name of the component that sent the event.
+The sending bundle is meant to be the OSGi bundle name of the component that sent the event, though this isn't a strict rule and may be violated in some cases, especially for something like `org.openhab.core` that has many different packages in it.
 For non-Java components generating a source (such as the Android and iOS apps), it should still be in Java package name format, as if the component were a Java package.
 The actor piece is an identifier of some sort that identifies the end user, device, rule, or other identifier of a specific instance that initiated the event, if one is relevant.
 If an event is passed through multiple components before being processed, it should preserve the original source, and append (separated by `=>`) another component for itself.
@@ -56,9 +59,9 @@ A few concrete examples:
 - `org.openhab.io.homekit$1467397f-c2e7-4b15-a7dc-315331ced2db` would mean the event was initiated from the HomeKit addon by a user identified by a UUID.
 - `org.openhab.ui.basic$default:03=>org.openhab.android$my-phone=>org.openhab.io.openhabcloud$user@gmail.com=>org.openhab.core.io.rest` would mean the event was initiated by using a sitemap in the Android openHAB app, and proxied through myopenhab.org using the user `user@gmail.com` (and finally through the REST API, but without a user).
 - `org.openhab.core.io.console` would mean the event was sent via the Karaf console.
-- `org.openhab.core.automation` would mean the event was triggered by a command sent in a rule action in most langauges.
+- `org.openhab.core.automation` would mean the event was triggered by a command or update sent in a rule action in most langauges. Some languages might provide a more detailed source.
 - `org.openhab.automation.jrubyscripting$rule:virtual_lighting:98` would mean the event was sent by an action written in JRuby using the helper library, with rule ID `virtual_lighting:98`.
-- `org.openhab.binding.mqtt$mqtt:thing:mything:mychannel` would mean the event was sent by a specific channel from the MQTT binding (updating a state).
+- `org.openhab.binding.mqtt$mqtt:thing:mything:mychannel` would mean the event was sent by the `mychannel` channel of the `mything` thing from the MQTT binding (updating a state).
 - `org.openhab.core.persistence` would mean the event was sent by the persistence engine (restoring the state).
 - `org.openhab.core.autoupdate` would mean the event was sent by the AutoUpdate manager (updating the state automatically).
 


### PR DESCRIPTION
Avoid confusing syntax, rename package to bundle, and add and update examples to match actual implementation.