### PR TITLE
Persistence configuration: no comma before `filter=`

### DIFF
--- a/configuration/persistence.md
+++ b/configuration/persistence.md
@@ -160,7 +160,7 @@ The syntax is as follows:
 
 ```java
 Items {
-    <itemlist1> : strategy = <strategy1>, <strategy2>, ... [filter = <filter1>, <filter2>, ...]
+    <itemlist1> : strategy = <strategy1>, <strategy2> ... [filter = <filter1>, <filter2>, ...]
     <itemlist2> : strategy = <strategyX>, <strategyY>, ...
     ...
 


### PR DESCRIPTION
Defining an Item in a `.persistence` file with a comma before the filter:
```
Items {
    a: strategy=everyChange, filter=f
}
```
logs a hard to understand message:
```
Configuration model '….persist' has errors, therefore ignoring it: [6,44]: missing RULE_ID at 'filter'
```
The [grammar](https://github.com/openhab/openhab-core/blob/main/bundles/org.openhab.core.model.persistence/src/org/openhab/core/model/persistence/Persistence.xtext) is:
```
PersistenceConfiguration:
	items+=(AllConfig | ItemConfig | GroupConfig | ItemExcludeConfig | GroupExcludeConfig)
		(',' items+=(AllConfig | ItemConfig | GroupConfig | ItemExcludeConfig | GroupExcludeConfig))* 
	(':' ('strategy' '=' strategies+=[Strategy|ID] (',' strategies+=[Strategy|ID])*)
			('filter' '=' filters+=[Filter|ID] (',' filters+=[Filter|ID])*)?) 
;
```
so immediately before `filter=` there might be no comma and this change is supposed to show exactly this.