### PR TITLE
Clarification: Rules DSL derives from XBase and is similar to Xtend

### DIFF
--- a/configuration/rules-dsl.md
+++ b/configuration/rules-dsl.md
@@ -53,7 +53,7 @@ Check out the editors page for more information and additional editor possibilit
 ### The Syntax
 
 ::: tip Note
-The rule syntax is based on [Xbase](https://www.eclipse.org/Xtext/#xbase) and as a result it is sharing many details with [Xtend](https://www.eclipse.org/xtend/), which is built on top of Xbase as well.
+The rule syntax is based on [Xbase](https://eclipse.dev/Xtext/documentation/305_xbase.html#xbase-language-ref-introduction) and as a result it is sharing many details with [Xtend](https://eclipse.dev/Xtext/xtend/documentation/), which is built on top of Xbase as well.
 As a result, we will often point to the Xtend documentation for details.
 :::
 

--- a/tutorials/getting_started/rules_advanced.md
+++ b/tutorials/getting_started/rules_advanced.md
@@ -16,10 +16,10 @@ For what ever reason, openHAB has you covered with text based Script Actions and
 openHAB supports a growing list of programming languages in which rules can be written.
 openHAB comes with the following languages to choose from:
 
-| Language                                           | Details                                                                                                       | Intended Audience       |
-| -------------------------------------------------- | ------------------------------------------------------------------------------------------------------------- | ----------------------- |
-| [Blockly]({{base}}/configuration/blockly/)         | See the previous page                                                                                         | Non-developers          |
-| [Rules DSL]({{base}}/configuration/rules-dsl.html) | A programming language developed specifically for openHAB based on [Xtend](https://eclipse.dev/Xtext/xtend/). | Long time openHAB users |
+| Language                                           | Details                                                                                                                                                             | Intended Audience       |
+| -------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------- |
+| [Blockly]({{base}}/configuration/blockly/)         | See the previous page                                                                                                                                               | Non-developers          |
+| [Rules DSL]({{base}}/configuration/rules-dsl.html) | A programming language developed specifically for openHAB based on [Xbase](https://eclipse.dev/Xtext/documentation/305_xbase.html#xbase-language-ref-introduction). | Long time openHAB users |
 
 In addition to these default choices, one can install a number of different languages as an Automation add-on.
 Such diverse languages as [JavaScript](/addons/automation/jsscripting/), [Ruby](/addons/automation/jrubyscripting), [Python](/addons/automation/jythonscripting/), [Groovy](/addons/automation/groovyscripting/), Java, and more are available with more to come.


### PR DESCRIPTION
* update hyperlinks to Xbase Language Reference and Xtend Documentation

Before this change there were contradicting statements, whether DSL is based on Xbase or on Xtend.