### PR TITLE
Describe XSD schema requirement and IDE validation tools

### DIFF
--- a/developers/guidelines.md
+++ b/developers/guidelines.md
@@ -99,8 +99,9 @@ Thing-Type definitions must comply with the [thing-description-1.0.0.xsd schema]
 
 To enable automatic schema validation in your IDE you many need to do the following:
 
-- Eclipse: download the latest copy of `thing-description-1.0.0.xsd` to your `.lemminx\cache\https\openhab.org\schemas` cache folder.
-- Visual Studio Code: install the XML extension from Red Hat.
+- Eclipse: Download the latest copy of `thing-description-1.0.0.xsd` to your `.lemminx\cache\https\openhab.org\schemas` cache folder.
+- IntelliJ: Put the cursor into the `xsi:schemeLocation` field of the XML, trigger the <kbd>Alt</kbd><kbd>Enter</kbd> shortcut and select _Fetch external resource_.
+- Visual Studio Code: Install the XML extension from Red Hat.
 
 ### Java Coding Style
 


### PR DESCRIPTION
This PR describes the requirement that thing-type XML files must comply with the thing-type XSD schema. And provides information about how to ensure automatic schema validation in both the Eclipse IDE and Visual Studio Code.

Signed-off-by: Andrew Fiddian-Green <software@whitebear.ch>
