### PR TITLE
DSL Examples: Skip the optional bar for XBase Lamda expressions without params

### DIFF
--- a/concepts/rules.md
+++ b/concepts/rules.md
@@ -618,9 +618,9 @@ rule "Window open reminder"
 when
   Member of gWindows changed to OPEN
 then
-  createTimer(now.plusMinutes(60), [ |
+  createTimer(now.plusMinutes(60)) [
     if (triggeringItem.state == OPEN) sendBroadcastNotification(triggeringItem.label + " is open for one hour!")
-  ])
+  ]
 end
 ```
 

--- a/configuration/actions.md
+++ b/configuration/actions.md
@@ -159,10 +159,10 @@ then
             logInfo("rules", "Timer rescheduled")
             myTimer.reschedule(now.plusMinutes(5))
         } else {
-            myTimer = createTimer(now.plusMinutes(5), [ |
+            myTimer = createTimer(now.plusMinutes(5)) [
                 logInfo("rules", "Timer activated")
                 //Do something...
-            ])
+            ]
             logInfo("rules", "Timer created")
         }
     } else {

--- a/configuration/jsr223.md
+++ b/configuration/jsr223.md
@@ -455,9 +455,9 @@ actions.scriptExecution.createTimer(time.toZDT(1000), () => {
 ::: tab DSL
 
 ```java
-createTimer(now.plusSeconds(1), [ |
+createTimer(now.plusSeconds(1)) [
   logInfo('Test logger', 'Timer ran')
-])
+]
 ```
 
 :::


### PR DESCRIPTION
https://eclipse.dev/Xtext/documentation/305_xbase.html#xbase-expressions-lambda says:

> When a function object is expected to be the last parameter of a feature call, you may declare the lambda expression after the parentheses:
> myList.findFirst() [ e | e.name==null ]

and https://eclipse.dev/Xtext/xtend/documentation/203_xtend_expressions.html#lambdas adds:

> A lambda expression with zero arguments can be written with or without the bar. They are both the same.
```
    val Runnable aBar = [|
      println("Hello I'm executed!")
    ]
    val Runnable noBar = [
      println("Hello I'm executed!")
    ]
```

> When a method call’s last parameter is a lambda it can be passed right after the parameter list. For instance if you want to sort some strings by their length, you could write :
```
    Collections.sort(someStrings) [ a, b |
      a.length - b.length
    ]
```
> which is just the same as writing
```
    Collections.sort(someStrings, [ a, b |
      a.length - b.length
    ])
```