### PR TITLE
DSL examples: remove optional brackets

### DIFF
--- a/configuration/actions.md
+++ b/configuration/actions.md
@@ -167,7 +167,7 @@ then
         }
     } else {
         logInfo("rules", "Timer canceled")
-        myTimer?.cancel()
+        myTimer?.cancel
         myTimer = null
     }
 end

--- a/configuration/rules-dsl.md
+++ b/configuration/rules-dsl.md
@@ -564,7 +564,7 @@ If the conversion from or into hexadecimal values is necessary, the following ex
 // to convert a hex_code (a number expressed in hexadecimals) to a Number type
 val dimVal =  Integer.parseInt(hex_code, 16) as Number
 //for very large_hex_codes use
-val dimVal = Long.valueOf(large_hex_code, 16).longValue() as Number
+val dimVal = Long.valueOf(large_hex_code, 16).longValue as Number
 
 // and here an additional example to convert an integer_value to hex_code string
 var String hex = Long.toHexString(integer_value);
@@ -807,17 +807,17 @@ It may be necessary to guard against concurrency.
 ```javascript
 import java.util.concurrent.locks.ReentrantLock
 
-val ReentrantLock lock  = new ReentrantLock()
+val ReentrantLock lock  = new ReentrantLock
 
 rule ConcurrentCode
 when
     Item Dummy received update
 then
-    lock.lock()
+    lock.lock
     try {
         // do stuff
     } finally{
-        lock.unlock()
+        lock.unlock
     }
 end
 ```


### PR DESCRIPTION
https://eclipse.dev/Xtext/documentation/305_xbase.html#xbase-expressions-lambda contains „in Xbase parentheses are optional for method calls“ and https://eclipse.dev/Xtext/xtend/documentation/203_xtend_expressions.html#feature-calls repeats “A simple name can refer to a local field, variable or parameter. In addition it can point to a method with zero arguments, since empty parentheses are optional.”

Note that the change in configuration/actions.md is spelled for “```php`, and PHP is shown in the final page, while the changes in configuration/rules-dsl.md are after ”```java” or after “```javascript” and as such are displayed explicitly at https://next.openhab.org/docs/configuration/rules-dsl.html.  However in practice the snippets are for DSL, as the name of the changed file implies.