### PR TITLE
Modify openHAB service setup instructions for manual Linux installations

### DIFF
--- a/installation/linux.md
+++ b/installation/linux.md
@@ -557,7 +557,7 @@ A cleaner approach is to create a Linux service.
 The following instructions are intended for a Linux init system based on **systemd** (e.g. Debian 8 / Ubuntu 15.x and newer).
 This will allow you to register openHAB as a service, so that it runs at startup and automatically restarts if openHAB crashes.
 The service will be running with the privileges of the user "openhab" and expects the openHAB files under `/opt/openhab`.
-Additionally, if you need to modify environment variables, create the file `/opt/openhab/conf/misc/linux.parameters` with your changes or additions.
+Additionally, if you need to modify environment variables, create the file `/opt/openhab/conf/linux.parameters` with your changes or additions.
 
 Create the file `/usr/lib/systemd/system/openhab.service` with the following content:
 
@@ -574,7 +574,7 @@ User=openhab
 Group=openhab
 
 WorkingDirectory=/opt/openhab
-EnvironmentFile=-/opt/openhab/conf/misc/linux.parameters
+EnvironmentFile=-/opt/openhab/conf/linux.parameters
 
 ExecStart=/opt/openhab/runtime/bin/karaf daemon
 ExecStop=/opt/openhab/runtime/bin/karaf stop


### PR DESCRIPTION
Updated the instructions for setting up openHAB as a systemd service on manual Linux installations to include the newly introduced linux.parameters file for overwriting environmental variables:

https://github.com/openhab/openhab-linuxpkg/pull/233

Tested here:
https://community.openhab.org/t/etc-openhab-linux-parameters/163246/12