### PR TITLE
jsr223: adjust for new name in Python 3 settings

### DIFF
--- a/configuration/jsr223.md
+++ b/configuration/jsr223.md
@@ -823,7 +823,7 @@ logger.error("I am logged first.")
 
 ::: tab Python
 
-When the setting "Use scope and import wrapper" is enabled, the `scope` module is available:
+When the setting “Python environment” is not “Disable completely”:
 
 ```python
 import sys
@@ -840,7 +840,7 @@ scope.lifecycleTracker.addDisposeHook(lambda : print("I am logged fourth. Bye!")
 print("I am logged first.")
 ```
 
-When the `scope` module is disabled:
+When the setting “Python Environment” is “Disable completely”:
 
 ```python
 import sys

--- a/configuration/jsr223.md
+++ b/configuration/jsr223.md
@@ -823,7 +823,7 @@ logger.error("I am logged first.")
 
 ::: tab Python
 
-When the setting “Python environment” is not “Disable completely”:
+When the setting _Python environment_ is not _Disable completely_:
 
 ```python
 import sys
@@ -840,7 +840,7 @@ scope.lifecycleTracker.addDisposeHook(lambda : print("I am logged fourth. Bye!")
 print("I am logged first.")
 ```
 
-When the setting “Python Environment” is “Disable completely”:
+When the setting _Python Environment_ is _Disable completely_:
 
 ```python
 import sys


### PR DESCRIPTION
This adjusts the `scriptUnloaded()` example for Python 3, based on the settings names from https://github.com/openhab/openhab-addons/pull/20289.