### PR TITLE
Persistence DSL Extensions: delete some text

### DIFF
--- a/configuration/persistence.md
+++ b/configuration/persistence.md
@@ -252,8 +252,6 @@ It is usually not necessary to restore all Items since there is a good chance th
 ## Persistence Extensions in Scripts and Rules
 
 To make use of persisted states inside scripts and rules, a few useful extensions have been defined on items.
-Note that these extensions are only available to be applied to Items.
-They are not generally available for use in Scripts or Rules.
 
 Example:
 


### PR DESCRIPTION
> Note that these extensions are only available to be applied to Items.

This deleted text is implied by the preceding sentence: “To make use of persisted states inside scripts and rules, a few useful extensions have been defined on items.”

The next deleted sentence:

> They are not generally available for use in Scripts or Rules.

is in a section called “Persistence Extensions in Scripts and Rules”.  If the extensions are not generally availbale in Scritps and Rules, the documentation should state, where the extensions are generally available.

I see also no use-case, which might lead to a confusion, which confusion would not exist, if the herein deleted sentences are kept.  As next follow anyway only example, all of which have the form `<item>.method(…)`.