### PR TITLE
rules-dsl: remove statement that Xtend documentation is referenced often

### DIFF
--- a/configuration/rules-dsl.md
+++ b/configuration/rules-dsl.md
@@ -54,7 +54,6 @@ Check out the editors page for more information and additional editor possibilit
 
 ::: tip Note
 The rule syntax is based on [Xbase](https://eclipse.dev/Xtext/documentation/305_xbase.html#xbase-language-ref-introduction) and as a result it is sharing many details with [Xtend](https://eclipse.dev/Xtext/xtend/documentation/), which is built on top of Xbase as well.
-As a result, we will often point to the Xtend documentation for details.
 :::
 
 A rule file is a text file with the following structure:


### PR DESCRIPTION
This removes spelling “As a result,” in two subsequent sentences.   The Xtend documentation is indeed referenced on some places in the openHAB documentation, on three places to be precise, but whether it is referenced “often” is both subjective and irrelevant.