### PR TITLE
Add sidebar menu depth

### DIFF
--- a/.vuepress/config.ts
+++ b/.vuepress/config.ts
@@ -45,8 +45,8 @@ const config: UserConfig<DefaultThemeConfig> = {
     themeConfig: {
         logo: `/openhab-logo.svg`,
         editLinks: false,
-        activeHeaderLinks: false,
-        sidebarDepth: 0,
+        activeHeaderLinks: true,
+        sidebarDepth: 2,
         docsDir: 'docs',
         nav: [
             {


### PR DESCRIPTION
This has been split from #2728. It adds extra depth to the sidebar menu, making it much easier to navigate long pages. It does so by using heading levels to create "chapters".

Apparently, this change must be done somewhere else as well, so I'm just submitting it here as a starting point.