### PR TITLE
Fetch external documentation contents through a Ruby pipeline

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,7 +19,8 @@ project.pbxproj
 .vscode
 
 # Built docs
+addons
 docs
-addons/integrations
 vuepress
+
 .DS_Store

--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@ project.pbxproj
 .vscode
 
 # Built docs
+.vuepress/thing-types.json
 addons
 docs
 vuepress

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "postinstall": "npm dedupe && npm prune",
     "prepare-docs": "ruby scripts/prepare-docs.rb",
+    "fetch-external-content": "ruby scripts/fetch-external-content.rb",
     "build-only": "vuepress build .",
     "build-preview": "npm run prepare-docs && npm run build-only",
     "preserve-preview": "npm run build-preview",

--- a/scripts/fetch-external-content.rb
+++ b/scripts/fetch-external-content.rb
@@ -2,14 +2,11 @@
 
 require "fileutils"
 
-# Ensure we can load files from scripts/lib
-$LOAD_PATH.unshift(File.join(File.dirname(__FILE__), "lib"))
-
-require "repo_manager"
-require "jfrog_fetcher"
-require "addon_processor"
-require "thing_types_processor"
-require "process_utils"
+require_relative "lib/repo_manager"
+require_relative "lib/jfrog_fetcher"
+require_relative "lib/addon_processor"
+require_relative "lib/thing_types_processor"
+require_relative "lib/process_utils"
 
 BASE_DIR = File.expand_path("..", File.dirname(__FILE__))
 RESOURCE_FOLDER = File.join(BASE_DIR, ".external-resources")

--- a/scripts/fetch-external-content.rb
+++ b/scripts/fetch-external-content.rb
@@ -1,0 +1,187 @@
+# frozen_string_literal: true
+
+require "fileutils"
+
+# Ensure we can load files from scripts/lib
+$LOAD_PATH.unshift(File.join(File.dirname(__FILE__), "lib"))
+
+require "repo_manager"
+require "jfrog_fetcher"
+require "addon_processor"
+require "thing_types_processor"
+
+BASE_DIR = File.expand_path("..", File.dirname(__FILE__))
+RESOURCE_FOLDER = File.join(BASE_DIR, ".external-resources")
+
+def copy_file_safe(src, dst)
+  if File.exist?(src)
+    FileUtils.mkdir_p(File.dirname(dst))
+    FileUtils.cp(src, dst)
+    puts "    ✔ Copied #{File.basename(src)} -> #{dst}"
+  else
+    warn "    ⚠️ Source file does not exist: #{src}"
+  end
+end
+
+def copy_dir_safe(src, dst)
+  if Dir.exist?(src)
+    FileUtils.mkdir_p(dst)
+    FileUtils.cp_r(File.join(src, "."), dst)
+    puts "    ✔ Copied directory #{src} -> #{dst}"
+  else
+    warn "    ⚠️ Source directory does not exist: #{src}"
+  end
+end
+
+def copy_glob_safe(pattern, dst_dir, exclude_fn = nil)
+  Dir.glob(pattern).each do |file|
+    next if File.directory?(file)
+    next if exclude_fn && exclude_fn.call(file)
+
+    relative_path = File.basename(file)
+    target_file = File.join(dst_dir, relative_path)
+
+    FileUtils.mkdir_p(File.dirname(target_file))
+    FileUtils.cp(file, target_file)
+  end
+  puts "    ✔ Copied glob #{pattern} -> #{dst_dir}"
+end
+
+def update_external_repositories
+  FileUtils.mkdir_p(RESOURCE_FOLDER)
+  readme_path = File.join(RESOURCE_FOLDER, "README.md")
+  unless File.exist?(readme_path)
+    File.write(readme_path, "# About\n\nUsed to temporarily store repository clones from related openHAB projects for 'fetch-external-docs.rb'.\n")
+  end
+
+  repos = [
+    ["openhab-distro", "openhab/openhab-distro.git", "main"],
+    ["openhab-addons", "openhab/openhab-addons.git", "main"],
+    ["openhabian", "openhab/openhabian.git", "main"],
+    ["openhab-alexa", "openhab/openhab-alexa.git", "main"],
+    ["openhab-android", "openhab/openhab-android.git", "main"],
+    ["openhab-google-assistant", "openhab/openhab-google-assistant.git", "main"],
+    ["openhab-webui", "openhab/openhab-webui.git", "main"],
+    ["openhab-addons/bundles/org.openhab.binding.zigbee", "openhab/org.openhab.binding.zigbee.git", "main"],
+    ["openhab-addons/bundles/org.openhab.binding.zwave", "openhab/org.openhab.binding.zwave.git", "main"],
+    ["openhab-garmin", "openhab/openhab-garmin.git", "main"],
+    ["openhab-sailfishos", "openhab/openhab-sailfishos.git", "main"]
+  ]
+
+  repos.each do |name, repo_path, branch|
+    RepoManager.pull_or_clone_repo(File.join(RESOURCE_FOLDER, name), repo_path, branch)
+  end
+
+  # Copy zigbee readme to where the addon processor expects it
+  zigbee_readme = File.join(RESOURCE_FOLDER, "openhab-addons/bundles/org.openhab.binding.zigbee/org.openhab.binding.zigbee/README.md")
+  zigbee_target = File.join(RESOURCE_FOLDER, "openhab-addons/bundles/org.openhab.binding.zigbee/README.md")
+  if File.exist?(zigbee_readme)
+    FileUtils.cp(zigbee_readme, zigbee_target)
+    puts "📋 ✔ Copied Zigbee README to expected location."
+  end
+end
+
+def main
+  puts "Starting fetch external content pipeline..."
+
+  # 1. Update/clone external git repos
+  update_external_repositories
+
+  # 2. Fetch feature.xml from JFrog snapshot repository
+  JfrogFetcher.fetch_features_xml(File.join(RESOURCE_FOLDER, "jfrog-files/feature.xml"))
+
+  # 3. Generate thing-types JSON
+  ThingTypesProcessor.collect_thing_types(RESOURCE_FOLDER, File.join(BASE_DIR, ".vuepress/thing-types.json"))
+
+  # 4. Process add-on markdown files
+  AddonProcessor.process_all(
+    File.join(RESOURCE_FOLDER, "openhab-distro/features/addons/src/main/feature/feature.xml"),
+    File.join(RESOURCE_FOLDER, "jfrog-files/feature.xml"),
+    File.join(RESOURCE_FOLDER, "openhab-addons/bundles"),
+    File.join(RESOURCE_FOLDER, "openhab-webui/bundles"),
+    File.join(BASE_DIR, "addons"),
+    File.join(BASE_DIR, "images")
+  )
+
+  # 5. Inline Ecosystem and Apps copying/renaming
+  puts "  Copying ecosystem & apps documentation..."
+
+  # HABPanel Config Docs
+  copy_file_safe(
+    File.join(RESOURCE_FOLDER, "openhab-webui/bundles/org.openhab.ui.habpanel/doc/habpanel.md"),
+    File.join(BASE_DIR, "docs/configuration/habpanel.md")
+  )
+  copy_dir_safe(
+    File.join(RESOURCE_FOLDER, "openhab-webui/bundles/org.openhab.ui.habpanel/doc/images"),
+    File.join(BASE_DIR, "docs/configuration/images")
+  )
+
+  # openHABian Install Docs (excluding NEWSLOG.md)
+  copy_glob_safe(
+    File.join(RESOURCE_FOLDER, "openhabian/docs/*.md"),
+    File.join(BASE_DIR, "docs/installation"),
+    lambda { |f| File.basename(f) == "NEWSLOG.md" }
+  )
+  copy_dir_safe(
+    File.join(RESOURCE_FOLDER, "openhabian/docs/images"),
+    File.join(BASE_DIR, "docs/installation/images")
+  )
+
+  # Android Docs
+  copy_file_safe(
+    File.join(RESOURCE_FOLDER, "openhab-android/docs/USAGE.md"),
+    File.join(BASE_DIR, "docs/apps/android.md")
+  )
+  copy_dir_safe(
+    File.join(RESOURCE_FOLDER, "openhab-android/docs/images"),
+    File.join(BASE_DIR, "docs/apps/images")
+  )
+
+  # Garmin Docs
+  copy_file_safe(
+    File.join(RESOURCE_FOLDER, "openhab-garmin/docs/USAGE.md"),
+    File.join(BASE_DIR, "docs/apps/garmin/readme.md")
+  )
+  copy_dir_safe(
+    File.join(RESOURCE_FOLDER, "openhab-garmin/docs/images"),
+    File.join(BASE_DIR, "docs/apps/garmin/images")
+  )
+
+  # SailfishOS Docs
+  copy_file_safe(
+    File.join(RESOURCE_FOLDER, "openhab-sailfishos/docs/USAGE.md"),
+    File.join(BASE_DIR, "docs/apps/sailfishos/readme.md")
+  )
+  copy_dir_safe(
+    File.join(RESOURCE_FOLDER, "openhab-sailfishos/docs/images"),
+    File.join(BASE_DIR, "docs/apps/sailfishos/images")
+  )
+
+  # Alexa Docs
+  copy_file_safe(
+    File.join(RESOURCE_FOLDER, "openhab-alexa/docs/USAGE.md"),
+    File.join(BASE_DIR, "docs/ecosystem/alexa/readme.md")
+  )
+  copy_dir_safe(
+    File.join(RESOURCE_FOLDER, "openhab-alexa/docs/images"),
+    File.join(BASE_DIR, "docs/ecosystem/alexa/images")
+  )
+
+  # Google Assistant Docs
+  copy_file_safe(
+    File.join(RESOURCE_FOLDER, "openhab-google-assistant/docs/USAGE.md"),
+    File.join(BASE_DIR, "docs/ecosystem/google-assistant/readme.md")
+  )
+  copy_dir_safe(
+    File.join(RESOURCE_FOLDER, "openhab-google-assistant/docs/images"),
+    File.join(BASE_DIR, "docs/ecosystem/google-assistant/images")
+  )
+
+  puts "  ✔ Copied ecosystem & apps documentation"
+
+  puts "✔ External content pipeline completed successfully!"
+end
+
+if __FILE__ == $0
+  main
+end

--- a/scripts/fetch-external-content.rb
+++ b/scripts/fetch-external-content.rb
@@ -210,6 +210,12 @@ def main
     File.join(BASE_DIR, "docs/ecosystem/google-assistant/images")
   )
 
+  # Classic Iconset
+  copy_dir_safe(
+    File.join(RESOURCE_FOLDER, "openhab-webui/bundles/org.openhab.ui.iconset.classic/src/main/resources/icons"),
+    File.join(BASE_DIR, "addons/iconsets/classic/icons")
+  )
+
   puts "  ✔ Copied ecosystem & apps documentation"
 
   puts "✔ External content pipeline completed successfully!"

--- a/scripts/fetch-external-content.rb
+++ b/scripts/fetch-external-content.rb
@@ -9,15 +9,21 @@ require "repo_manager"
 require "jfrog_fetcher"
 require "addon_processor"
 require "thing_types_processor"
+require "process_utils"
 
 BASE_DIR = File.expand_path("..", File.dirname(__FILE__))
 RESOURCE_FOLDER = File.join(BASE_DIR, ".external-resources")
 
-def copy_file_safe(src, dst)
+def copy_file_safe(src, dst, source_url = nil)
   if File.exist?(src)
     FileUtils.mkdir_p(File.dirname(dst))
-    FileUtils.cp(src, dst)
-    puts "    ✔ Copied #{File.basename(src)} -> #{dst}"
+    if File.extname(src).downcase == ".md" && source_url
+      process_markdown(File.dirname(src), File.basename(src), File.dirname(dst), source_url, File.basename(dst))
+      puts "    ✔ Processed #{File.basename(src)} -> #{dst}"
+    else
+      FileUtils.cp(src, dst)
+      puts "    ✔ Copied #{File.basename(src)} -> #{dst}"
+    end
   else
     warn "    ⚠️ Source file does not exist: #{src}"
   end
@@ -33,7 +39,7 @@ def copy_dir_safe(src, dst)
   end
 end
 
-def copy_glob_safe(pattern, dst_dir, exclude_fn = nil)
+def copy_glob_safe(pattern, dst_dir, exclude_fn = nil, source_url_fn = nil)
   Dir.glob(pattern).each do |file|
     next if File.directory?(file)
     next if exclude_fn && exclude_fn.call(file)
@@ -42,7 +48,14 @@ def copy_glob_safe(pattern, dst_dir, exclude_fn = nil)
     target_file = File.join(dst_dir, relative_path)
 
     FileUtils.mkdir_p(File.dirname(target_file))
-    FileUtils.cp(file, target_file)
+    if File.extname(file).downcase == ".md" && source_url_fn
+      source_url = source_url_fn.call(relative_path)
+      process_markdown(File.dirname(file), File.basename(file), File.dirname(target_file), source_url, File.basename(target_file))
+      puts "    ✔ Processed #{File.basename(file)} -> #{target_file}"
+    else
+      FileUtils.cp(file, target_file)
+      puts "    ✔ Copied #{File.basename(file)} -> #{target_file}"
+    end
   end
   puts "    ✔ Copied glob #{pattern} -> #{dst_dir}"
 end
@@ -103,13 +116,27 @@ def main
     File.join(BASE_DIR, "images")
   )
 
+  # Preprocess all generated addon readme files
+  puts "  Processing add-on readme files..."
+  Dir.glob(File.join(BASE_DIR, "addons/**/*.md")).each do |file|
+    next if File.basename(file) != "readme.md"
+
+    dir = File.dirname(file)
+    temp_readme = File.join(dir, "readme_raw.md")
+    FileUtils.mv(file, temp_readme)
+    process_markdown(dir, "readme_raw.md", dir, nil, "readme.md")
+    File.delete(temp_readme)
+  end
+  puts "  ✔ Processed add-on readme files"
+
   # 5. Inline Ecosystem and Apps copying/renaming
   puts "  Copying ecosystem & apps documentation..."
 
   # HABPanel Config Docs
   copy_file_safe(
     File.join(RESOURCE_FOLDER, "openhab-webui/bundles/org.openhab.ui.habpanel/doc/habpanel.md"),
-    File.join(BASE_DIR, "docs/configuration/habpanel.md")
+    File.join(BASE_DIR, "docs/configuration/habpanel.md"),
+    "https://github.com/openhab/openhab-webui/blob/main/bundles/org.openhab.ui.habpanel/doc/habpanel.md"
   )
   copy_dir_safe(
     File.join(RESOURCE_FOLDER, "openhab-webui/bundles/org.openhab.ui.habpanel/doc/images"),
@@ -120,7 +147,8 @@ def main
   copy_glob_safe(
     File.join(RESOURCE_FOLDER, "openhabian/docs/*.md"),
     File.join(BASE_DIR, "docs/installation"),
-    lambda { |f| File.basename(f) == "NEWSLOG.md" }
+    lambda { |f| File.basename(f) == "NEWSLOG.md" },
+    lambda { |fn| "https://github.com/openhab/openhabian/blob/main/docs/#{fn}" }
   )
   copy_dir_safe(
     File.join(RESOURCE_FOLDER, "openhabian/docs/images"),
@@ -130,7 +158,8 @@ def main
   # Android Docs
   copy_file_safe(
     File.join(RESOURCE_FOLDER, "openhab-android/docs/USAGE.md"),
-    File.join(BASE_DIR, "docs/apps/android.md")
+    File.join(BASE_DIR, "docs/apps/android.md"),
+    "https://github.com/openhab/openhab-android/blob/main/docs/USAGE.md"
   )
   copy_dir_safe(
     File.join(RESOURCE_FOLDER, "openhab-android/docs/images"),
@@ -140,7 +169,8 @@ def main
   # Garmin Docs
   copy_file_safe(
     File.join(RESOURCE_FOLDER, "openhab-garmin/docs/USAGE.md"),
-    File.join(BASE_DIR, "docs/apps/garmin/readme.md")
+    File.join(BASE_DIR, "docs/apps/garmin/readme.md"),
+    "https://github.com/openhab/openhab-garmin/blob/main/docs/USAGE.md"
   )
   copy_dir_safe(
     File.join(RESOURCE_FOLDER, "openhab-garmin/docs/images"),
@@ -150,7 +180,8 @@ def main
   # SailfishOS Docs
   copy_file_safe(
     File.join(RESOURCE_FOLDER, "openhab-sailfishos/docs/USAGE.md"),
-    File.join(BASE_DIR, "docs/apps/sailfishos/readme.md")
+    File.join(BASE_DIR, "docs/apps/sailfishos/readme.md"),
+    "https://github.com/openhab/openhab-sailfishos/blob/main/docs/USAGE.md"
   )
   copy_dir_safe(
     File.join(RESOURCE_FOLDER, "openhab-sailfishos/docs/images"),
@@ -160,7 +191,8 @@ def main
   # Alexa Docs
   copy_file_safe(
     File.join(RESOURCE_FOLDER, "openhab-alexa/docs/USAGE.md"),
-    File.join(BASE_DIR, "docs/ecosystem/alexa/readme.md")
+    File.join(BASE_DIR, "docs/ecosystem/alexa/readme.md"),
+    "https://github.com/openhab/openhab-alexa/blob/main/docs/USAGE.md"
   )
   copy_dir_safe(
     File.join(RESOURCE_FOLDER, "openhab-alexa/docs/images"),
@@ -170,7 +202,8 @@ def main
   # Google Assistant Docs
   copy_file_safe(
     File.join(RESOURCE_FOLDER, "openhab-google-assistant/docs/USAGE.md"),
-    File.join(BASE_DIR, "docs/ecosystem/google-assistant/readme.md")
+    File.join(BASE_DIR, "docs/ecosystem/google-assistant/readme.md"),
+    "https://github.com/openhab/openhab-google-assistant/blob/main/docs/USAGE.md"
   )
   copy_dir_safe(
     File.join(RESOURCE_FOLDER, "openhab-google-assistant/docs/images"),

--- a/scripts/lib/addon_processor.rb
+++ b/scripts/lib/addon_processor.rb
@@ -1,0 +1,193 @@
+# frozen_string_literal: true
+
+require "rexml/document"
+require "fileutils"
+
+# AddonProcessor processes external add-on repositories (openhab-addons and openhab-webui).
+#
+# It does the following:
+# 1. Calls collect_features to parse distro and downloaded snapshot features XML
+#    to build a map of installation metadata (install: auto).
+# 2. Loops through various add-on bundle directories (bindings, persistences, voices, uis, etc.).
+# 3. Strips OSGi package prefixes from bundle names (e.g. org.openhab.binding.) to get add-on IDs.
+# 4. Cleans target directories and recursively copies config, documentation, and image assets.
+# 5. Formats each add-on README: extracts the title, logo, and description; merges Karaf
+#    installation status; generates VuePress YAML frontmatter; and writes the resulting
+#    readme.md file.
+#
+# It is called by fetch-external-docs.rb to process and place add-on documentations.
+module AddonProcessor
+  def self.collect_feature_xml(features, xml_path, attrs)
+    return unless File.exist?(xml_path)
+
+    begin
+      xml_content = File.read(xml_path)
+      doc = REXML::Document.new(xml_content)
+      doc.elements.each("features/feature") do |feature|
+        name = feature.attributes["name"]
+        features[name] = attrs
+      end
+    rescue => e
+      warn "  ⚠️ Failed to parse feature XML at #{xml_path}: #{e.message}"
+      raise e
+    end
+  end
+
+  def self.collect_features(distro_features_path, snapshot_features_path)
+    features = {}
+    collect_feature_xml(features, distro_features_path, { "install" => "auto" })
+    collect_feature_xml(features, snapshot_features_path, { "install" => "auto" })
+    features
+  end
+
+  def self.process_addon_type(features, dest_addons_dir, images_dir, src_bundles_dir, type, dest_folder_name, suffix, lblremoves, pkgremoves)
+    puts "  Processing add-on type: #{type} -> #{dest_folder_name}..."
+
+    unless Dir.exist?(src_bundles_dir)
+      warn "  ⚠️ Source directory not found: #{src_bundles_dir}"
+      return
+    end
+
+    Dir.foreach(src_bundles_dir) do |addon_name|
+      next if addon_name == "." || addon_name == ".."
+
+      # Match the type in package name
+      next unless addon_name.include?(type)
+
+      addon_path = File.join(src_bundles_dir, addon_name)
+      next unless Dir.exist?(addon_path)
+
+      if addon_name.end_with?(".test")
+        puts "  Skipping test bundle: #{addon_name}"
+        next
+      end
+
+      # Determine final ID by stripping pkgremoves
+      id = addon_name
+      pkgremoves.each { |pkg| id = id.gsub(pkg, "") }
+
+      puts "    Processing addon: #{dest_folder_name}/#{id}..."
+
+      # Construct target directory
+      target_dir = File.join(dest_addons_dir, dest_folder_name, id)
+      FileUtils.rm_rf(target_dir) # start fresh
+      FileUtils.mkdir_p(target_dir)
+
+      # Copy doc/, cfg/, images/, and icons/ if they exist
+      ["doc", "cfg", "images", "icons"].each do |sub_dir|
+        source_sub = File.join(addon_path, sub_dir)
+        if Dir.exist?(source_sub)
+          FileUtils.cp_r(source_sub, target_dir)
+        end
+      end
+
+      # Look for README.md (case-insensitive)
+      readme_src = Dir.glob(File.join(addon_path, "[Rr][Ee][Aa][Dd][Mm][Ee].[Mm][Dd]")).first
+      if readme_src.nil? || !File.exist?(readme_src)
+        warn "    ⚠️ No readme.md/README.md found in #{addon_name}"
+        next
+      end
+
+      # Read and parse readme
+      readme_text = File.read(readme_src)
+
+      # Determine label from first level 1 header
+      label = nil
+      readme_text.each_line do |line|
+        if line.start_with?("#")
+          label = line.gsub("#", "").strip
+          lblremoves.each { |remove| label = label.gsub(Regexp.new(remove), "") }
+          label = label.strip
+          break
+        end
+      end
+
+      if label.nil? || label.empty?
+        warn "    ⚠️ No level 1 header found in README of #{addon_name}."
+        label = id
+      end
+
+      # Logo check in images/addons/ of the main project repo
+      logo_svg = File.exist?(File.join(images_dir, "addons", "#{id}.svg"))
+      logo_png = File.exist?(File.join(images_dir, "addons", "#{id}.png"))
+
+      # Find description (first non-empty text line after first level 1 header)
+      description = ""
+      first_headline = false
+      readme_text.each_line do |line|
+        if line.start_with?("#")
+          first_headline = true
+        elsif first_headline && !line.strip.empty?
+          description = line.strip.gsub('"', "'")
+          break
+        end
+      end
+
+      # Build frontmatter hash
+      front = {
+        "id" => id,
+        "label" => label,
+        "title" => "#{label}#{suffix}",
+        "type" => type,
+        "description" => "\"#{description}\""
+      }
+
+      if logo_svg
+        front["logo"] = "images/addons/#{id}.svg"
+      elsif logo_png
+        front["logo"] = "images/addons/#{id}.png"
+      end
+
+      # Find install type from features list
+      feature_entry = features.find do |key, val|
+        key.start_with?("openhab-#{type}-#{id}") ||
+          (type == "io" && key.start_with?("openhab-misc-#{id}")) ||
+          (type == "transform" && key.start_with?("openhab-transformation-#{id}"))
+      end
+
+      install_attrs = feature_entry ? feature_entry[1] : { "install" => "manual" }
+      front.merge!(install_attrs)
+
+      # Build frontmatter block
+      frontmatter_str = "---\n" + front.map { |k, v| "#{k}: #{v}" }.join("\n") + "\n---\n\n"
+
+      # Re-format readme content: remove first heading and replace with custom template
+      first_h1_match = readme_text.match(/^# .*/)
+      heading = first_h1_match ? first_h1_match[0] : "# #{label}"
+      text_without_heading = first_h1_match ? readme_text.sub(heading, "") : readme_text
+
+      addon_logo_tag = (logo_svg || logo_png) ? "\n\n<AddonLogo />" : ""
+
+      final_content = <<~MARKDOWN
+        #{frontmatter_str}<!-- Attention authors: Do not edit directly. Please add your changes to the appropriate source repository -->
+
+        #{heading}#{addon_logo_tag}#{text_without_heading}
+      MARKDOWN
+
+      # Write to target as lowercase readme.md
+      File.write(File.join(target_dir, "readme.md"), final_content)
+
+      puts "    ✔ Processed addon: #{dest_folder_name}/#{id}"
+    end
+
+    puts "  ✔ Processed add-on type: #{type} -> #{dest_folder_name}"
+  end
+
+  def self.process_all(distro_features_path, snapshot_features_path, addons_bundles_dir, webui_bundles_dir, dest_addons_dir, images_dir)
+    features = collect_features(distro_features_path, snapshot_features_path)
+
+    # Arguments: features, dest_addons_dir, images_dir, src_bundles_dir, type, dest_folder_name, suffix, lblremoves, pkgremoves
+    process_addon_type(features, dest_addons_dir, images_dir, addons_bundles_dir, "automation", "automation", " - Automation", [], ["org.openhab.automation."])
+    process_addon_type(features, dest_addons_dir, images_dir, addons_bundles_dir, "binding", "bindings", " - Bindings", [" Binding"], ["org.openhab.binding."])
+    process_addon_type(features, dest_addons_dir, images_dir, webui_bundles_dir, "iconset", "iconsets", " - Icon Sets", [], ["org.openhab.ui.iconset."])
+    process_addon_type(features, dest_addons_dir, images_dir, addons_bundles_dir, "io", "integrations", " - System Integrations", [" Service"], ["org.openhab.io."])
+    process_addon_type(features, dest_addons_dir, images_dir, addons_bundles_dir, "persistence", "persistences", " - Persistence Services", [/\\s*Persistence\\s*$/], ["org.openhab.persistence."])
+    process_addon_type(features, dest_addons_dir, images_dir, addons_bundles_dir, "transform", "transformations", " - Transformation Services", [" Transformation Service"], ["org.openhab.transform."])
+    process_addon_type(features, dest_addons_dir, images_dir, addons_bundles_dir, "voice", "voices", " - Voices", [], ["org.openhab.voice."])
+
+    # UI bundles from webui repo
+    # Note: Maven POM has excludes for ui-docs: iconset, org.openhab.ui.iconset.classic, cordova, src
+    # Here we only process bundles under openhab-webui/bundles containing 'org.openhab.ui.' but excluding iconset.
+    process_addon_type(features, dest_addons_dir, images_dir, webui_bundles_dir, "ui", "uis", " - UIs", [], ["org.openhab.ui."])
+  end
+end

--- a/scripts/lib/addon_processor.rb
+++ b/scripts/lib/addon_processor.rb
@@ -51,8 +51,16 @@ module AddonProcessor
     Dir.foreach(src_bundles_dir) do |addon_name|
       next if addon_name == "." || addon_name == ".."
 
-      # Match the type in package name
-      next unless addon_name.include?(type)
+      # Match the type in package name structure (org.openhab.<type>...)
+      parts = addon_name.split(".")
+      next unless parts[0] == "org" && parts[1] == "openhab"
+      if type == "iconset"
+        next unless parts[2] == "ui" && parts[3] == "iconset"
+      elsif type == "ui"
+        next unless parts[2] == "ui" && parts[3] != "iconset"
+      else
+        next unless parts[2] == type
+      end
 
       addon_path = File.join(src_bundles_dir, addon_name)
       next unless Dir.exist?(addon_path)

--- a/scripts/lib/jfrog_fetcher.rb
+++ b/scripts/lib/jfrog_fetcher.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+require "net/http"
+require "uri"
+require "fileutils"
+
+# JfrogFetcher downloads the latest snapshot features XML file from openHAB's
+# JFrog Artifactory repository.
+#
+# It resolves the metadata sequentially:
+# 1. Finds the latest SNAPSHOT version from the root maven-metadata.xml.
+# 2. Resolves the latest timestamped filename from that version's maven-metadata.xml.
+# 3. Downloads the Karaf features XML file and saves it to the specified local path.
+#
+# It is used by fetch-external-docs.rb to retrieve feature lists for determining
+# installation types (e.g., auto vs manual install) of the add-ons.
+module JfrogFetcher
+  def self.fetch_features_xml(dest_path)
+    FileUtils.mkdir_p(File.dirname(dest_path))
+
+    puts "  Fetching latest feature.xml from JFrog snapshot repository..."
+
+    begin
+      # 1. Download root metadata
+      root_metadata_url = "https://openhab.jfrog.io/openhab/libs-snapshot/org/openhab/distro/openhab-addons/maven-metadata.xml"
+      root_xml = Net::HTTP.get(URI(root_metadata_url))
+
+      latest_version = root_xml.match(/<latest>(.*?)<\/latest>/)&.captures&.first
+      raise "Could not parse latest version from metadata" unless latest_version
+
+      puts "   Latest version: #{latest_version}"
+
+      # 2. Download version metadata
+      version_metadata_url = "https://openhab.jfrog.io/openhab/libs-snapshot/org/openhab/distro/openhab-addons/#{latest_version}/maven-metadata.xml"
+      version_xml = Net::HTTP.get(URI(version_metadata_url))
+
+      timestamp = version_xml.match(/<timestamp>(.*?)<\/timestamp>/)&.captures&.first
+      build_number = version_xml.match(/<buildNumber>(.*?)<\/buildNumber>/)&.captures&.first
+
+      raise "Could not parse timestamp or buildNumber" unless timestamp && build_number
+
+      puts "   Build Timestamp: #{timestamp}"
+      puts "   Build Number: #{build_number}"
+
+      base_version = latest_version.sub("-SNAPSHOT", "")
+      latest_file_name = "openhab-addons-#{base_version}-#{timestamp}-#{build_number}-features.xml"
+      features_url = "https://openhab.jfrog.io/openhab/libs-snapshot/org/openhab/distro/openhab-addons/#{latest_version}/#{latest_file_name}"
+
+      puts "   Downloading: #{latest_file_name}"
+
+      # 3. Download the features XML file
+      features_xml = Net::HTTP.get(URI(features_url))
+
+      # 4. Save to target destination
+      File.write(dest_path, features_xml)
+      puts "  ✔ Saved features XML to #{dest_path}"
+    rescue => e
+      warn "  ⚠️ Error fetching features XML: #{e.message}"
+      raise e
+    end
+  end
+end

--- a/scripts/lib/process_utils.rb
+++ b/scripts/lib/process_utils.rb
@@ -10,7 +10,7 @@ def verbose(message)
 end
 
 # This function converts a "source" file to something looking good in VuePress
-def process_markdown(indir, file, outdir, source)
+def process_markdown(indir, file, outdir, source, outfile = nil)
   in_frontmatter = false
   frontmatter_processed = false
   has_source = false
@@ -18,7 +18,7 @@ def process_markdown(indir, file, outdir, source)
   og_description = "a vendor and technology agnostic open source automation software for your home"
 
   input_path = Pathname.new(indir) / file
-  output_path = Pathname.new(outdir) / file
+  output_path = Pathname.new(outdir) / (outfile || file)
   input_path_str = input_path.to_s
 
   unless input_path.exist?
@@ -58,6 +58,10 @@ def process_markdown(indir, file, outdir, source)
           elsif !has_source
             # Try to determine the source
             outdir_parts = outdir.split("/")
+            addons_idx = outdir_parts.index("addons")
+            if addons_idx
+              outdir_parts = outdir_parts[addons_idx..-1]
+            end
             outdir_parts[1] = "binding" if outdir_parts[1] == "bindings"
             outdir_parts[1] = "transform" if outdir_parts[1] == "transformations"
             outdir_parts[1] = "io" if outdir_parts[1] == "integrations"

--- a/scripts/lib/repo_manager.rb
+++ b/scripts/lib/repo_manager.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+require "fileutils"
+
+# RepoManager handles downloading and updating external Git repositories.
+#
+# It is used by the central orchestrator fetch-external-docs.rb script
+# to keep all related external openHAB projects (like openhab-addons,
+# openhab-webui, etc.) cloned and fetched inside a target_dir.
+#
+# All git operations are executed quietly (redirecting stdout to null)
+# and the script aborts immediately if any git command returns a non-zero exit status.
+module RepoManager
+  def self.run_git_cmd(*args)
+    success = system(*args, out: File::NULL)
+    unless success
+      warn "  ⚠️ Git command failed: #{args.join(' ')}"
+      raise "Git command failed: #{args.join(' ')}"
+    end
+  end
+
+  def self.pull_or_clone_repo(target_dir, repo_path, branch)
+    repo_url = "https://github.com/#{repo_path}"
+    name = File.basename(target_dir)
+
+    if Dir.exist?(target_dir)
+      puts "  Updating repository '#{name}'..."
+      # Fetch origin quietly
+      run_git_cmd("git", "-C", target_dir, "fetch", "-q", "origin")
+      # Checkout branch quietly
+      run_git_cmd("git", "-C", target_dir, "checkout", "-q", branch)
+      # Pull branch quietly
+      run_git_cmd("git", "-C", target_dir, "pull", "-q")
+      puts "  ✔ Updated repository '#{name}'"
+    else
+      puts "📥Cloning repository '#{name}' (branch: #{branch})..."
+      # Ensure parent directory exists
+      FileUtils.mkdir_p(File.dirname(target_dir))
+      # Clone the repository quietly
+      run_git_cmd("git", "clone", "-q", "--depth", "1", "--branch", branch, repo_url, target_dir)
+      puts "  ✔ Cloned repository '#{name}' (branch: #{branch})"
+    end
+  end
+end

--- a/scripts/lib/thing_types_processor.rb
+++ b/scripts/lib/thing_types_processor.rb
@@ -1,0 +1,72 @@
+# frozen_string_literal: true
+
+require "rexml/document"
+require "json"
+require "fileutils"
+
+# ThingTypesProcessor crawls the XML files in openhab-addons bundles to collect
+# all bridge and thing type definitions.
+#
+# It looks for files matching `**/OH-INF/thing/**/*.xml`, parses their
+# `bridge-type` and `thing-type` elements via REXML, and aggregates them.
+# The resulting collection is exported as a JSON file, which is consumed by
+# the website to provide the add-on / thing search functionality.
+#
+# It is called by fetch-external-docs.rb to write thing-types.json to the dest_path.
+module ThingTypesProcessor
+  def self.collect_thing_types(resource_folder, dest_path)
+    puts "  Collecting thing types..."
+
+    thing_types = []
+    xml_pattern = File.join(resource_folder, "openhab-addons/bundles/**/OH-INF/thing/**/*.xml")
+    xml_files = Dir.glob(xml_pattern)
+
+    xml_files.each do |file_path|
+      next unless File.file?(file_path)
+
+      begin
+        xml_content = File.read(file_path)
+        doc = REXML::Document.new(xml_content)
+        root = doc.root
+        next if root.nil?
+
+        binding_id = root.attributes["bindingId"]
+        next if binding_id.nil? || binding_id.empty?
+
+        # Find bridge-types
+        root.elements.each("bridge-type") do |bridge|
+          bridge_id = bridge.attributes["id"]
+          label_node = bridge.elements["label"]
+          label = label_node ? label_node.text : ""
+
+          thing_types << {
+            "bindingId" => binding_id,
+            "id" => "#{binding_id}:#{bridge_id}",
+            "label" => label
+          }
+        end
+
+        # Find thing-types
+        root.elements.each("thing-type") do |thing|
+          thing_id = thing.attributes["id"]
+          label_node = thing.elements["label"]
+          label = label_node ? label_node.text : ""
+
+          thing_types << {
+            "bindingId" => binding_id,
+            "id" => "#{binding_id}:#{thing_id}",
+            "label" => label
+          }
+        end
+      rescue => e
+        warn "  ⚠️ Failed to parse thing XML at #{file_path}: #{e.message}"
+        raise e
+      end
+    end
+
+    # Write output to dest_path
+    FileUtils.mkdir_p(File.dirname(dest_path))
+    File.write(dest_path, JSON.pretty_generate(thing_types))
+    puts "  ✔ #{thing_types.size} thing types written to #{dest_path}"
+  end
+end


### PR DESCRIPTION
This aims at replacing the combination of Maven plugins and Groovy scripts in the final branch at fetching and integrating external contents (e.g., openhab-addons) into the documentation.