### PR TITLE
fetch-external-content: Fetch bundled openhab-js type definitions from GH release

### DIFF
--- a/scripts/fetch-external-content.rb
+++ b/scripts/fetch-external-content.rb
@@ -93,6 +93,27 @@ def update_external_repositories
   end
 end
 
+def fetch_openhab_js_types
+  pom_path = File.join(RESOURCE_FOLDER, "openhab-addons/bundles/org.openhab.automation.jsscripting/pom.xml")
+  unless File.exist?(pom_path)
+    warn "  ⚠️ JS Scripting POM not found at #{pom_path}"
+    return
+  end
+
+  pom_content = File.read(pom_path)
+  version_match = pom_content.match(/<ohjs.version>(.*?)<\/ohjs.version>/)
+  unless version_match
+    warn "  ⚠️ Could not find <ohjs.version> in JS Scripting POM"
+    return
+  end
+
+  ohjs_version = version_match[1].strip
+  puts "  Found openhab-js version in POM: #{ohjs_version}"
+
+  dest_path = File.join(BASE_DIR, "addons/automation/jsscripting/res/openhab.d.ts")
+  download_github_release_asset("openhab/openhab-js", ohjs_version, "openhab.d.ts", dest_path)
+end
+
 def main
   puts "Starting fetch external content pipeline..."
 
@@ -127,6 +148,9 @@ def main
     File.delete(temp_readme)
   end
   puts "  ✔ Processed add-on readme files"
+
+  # 4b. Fetch openhab.d.ts definitions based on JS Scripting POM version
+  fetch_openhab_js_types
 
   # 5. Inline Ecosystem and Apps copying/renaming
   puts "  Copying ecosystem & apps documentation..."

--- a/scripts/lib/process_utils.rb
+++ b/scripts/lib/process_utils.rb
@@ -2,6 +2,8 @@
 
 require "fileutils"
 require "pathname"
+require "net/http"
+require "uri"
 
 ADDONS_REPO_BRANCH = "main"
 
@@ -270,4 +272,34 @@ module UI
     color_code = COLORS.fetch(color_name, 37) # Default to white
     "\e[#{color_code}m#{text}\e[0m"
   end
+end
+
+def download_github_release_asset(repo, tag, asset_name, dest_path)
+  url = "https://github.com/#{repo}/releases/download/#{tag}/#{asset_name}"
+  puts "  Fetching #{asset_name} from GitHub release #{tag}..."
+
+  uri = URI(url)
+  limit = 5
+  while limit > 0
+    response = Net::HTTP.get_response(uri)
+    case response
+    when Net::HTTPSuccess
+      FileUtils.mkdir_p(File.dirname(dest_path))
+      File.write(dest_path, response.body)
+      puts "  ✔ Saved #{asset_name} to #{dest_path}"
+      return true
+    when Net::HTTPRedirection
+      location = response['location']
+      uri = URI(location)
+      limit -= 1
+    when Net::HTTPNotFound
+      warn "  ⚠️ Asset #{asset_name} not found in release #{tag} (HTTP 404)"
+      return false
+    else
+      warn "  ⚠️ HTTP Error: #{response.code} #{response.message} for #{url}"
+      return false
+    end
+  end
+  warn "  ⚠️ Too many redirects trying to download #{asset_name}"
+  false
 end


### PR DESCRIPTION
This fetches the bundled openhab-js type definitions `openhab.d.ts` from the GitHub release assets according to the ohjs version currently used in JS Scripting.
`openhab.d.ts` is then available on the website and the openhab-docs final branch. It can be used to provide improve LLM code generation.